### PR TITLE
docs: document evidence api

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -367,3 +367,17 @@ This sprint was a documentation‑only update.  No new endpoints, migrations or 
 ### Notes (2025‑08‑21)
 
 This sprint continued the systematic audit of NoPixel resources.  The vast majority of modules processed (from `np‑securityheists` to `outlawalert`) either contained only client scripts or relayed events without persisting state【644264532347613†L0-L9】【147099589493415†L0-L17】.  These were skipped or deferred.  The notable exception was **np‑weapons**, which keeps ammunition counts in a SQL table and updates them via events【735206341651753†L6-L44】.  To provide equivalent functionality, we created the **player ammunition API** described above.  We also fixed an OpenAPI misplacement for the websites POST endpoint.  No other endpoints or migrations were modified.  Future sprints will address remaining resources such as `pNotify`, `pPassword`, `ped`, `phone`, `police` and others.
+## 2025‑08‑22
+
+### Added
+
+* **docs/modules/evidence.md** – module documentation for the evidence domain.
+
+### Changed
+
+* **openapi/api.yaml** – documented evidence item endpoints and schemas.
+* **docs/progress-ledger.md**, **docs/index.md** – updated to reference evidence documentation work.
+
+### Notes
+
+Documentation-only sprint to align API specification and docs with existing evidence routes.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -122,3 +122,12 @@ Legend: **A** = Added, **M** = Modified.
 | `docs/BASE_API_DOCUMENTATION.md` | M | Added a **Weapons & Ammo** section summarising the new ammo endpoints. |
 | `MANIFEST.md` | M | Updated to include this section and list new files/changes. |
 | `CHANGELOG.md` | M | Appended notes for the 2025‑08‑21 sprint covering the ammo API and documentation updates. |
+
+# Additional updates for the 2025‑08‑22 sprint
+
+| Path | Status | Notes |
+|---|---|---|
+| `openapi/api.yaml` | M | Documented evidence item endpoints and schemas. |
+| `docs/progress-ledger.md` | M | Updated entry for evidence module to note OpenAPI coverage. |
+| `docs/index.md` | M | Added sprint overview for evidence documentation. |
+| `docs/modules/evidence.md` | A | New module documentation describing evidence API. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -429,3 +429,16 @@ these decisions.  Future sprints will continue with `np‑voice`,
 `np‑votesystem`, `np‑warrants`, `np‑weapons`, `np‑webpages`,
 `np‑whitelist` and beyond, adding backend support only where
 persistent state or cross‑player interactions are required.
+---
+# Sprint Overview – 2025‑08‑22
+
+This documentation sprint added missing OpenAPI coverage for the existing
+evidence module. The evidence routes were implemented in earlier work but
+lacked formal specification.
+
+### Highlights
+
+* **Evidence OpenAPI** – documented CRUD endpoints for evidence items and introduced `EvidenceItem` schemas.
+* **Module docs** – added `docs/modules/evidence.md` describing repository, routes and schemas.
+
+No database schema changes were required in this sprint.

--- a/backend/srp-base/docs/modules/evidence.md
+++ b/backend/srp-base/docs/modules/evidence.md
@@ -1,0 +1,50 @@
+# Evidence Module
+
+The **evidence** module persists forensic evidence such as shell casings or DNA swabs in the `evidence_items` table.
+Each item records a type, description, optional location, owner and metadata.  Evidence records can be created,
+retrieved, updated and deleted via REST endpoints.
+
+## Endpoints
+
+| Method & Path | Description | Rate Limit | Auth | Idempotent | Request Body | Response |
+|---|---|---|---|---|---|---|
+| **GET `/v1/evidence/items`** | List recent evidence items. | 60/min per IP | Required | Yes | None | `{ ok, data: { items: EvidenceItem[] }, requestId, traceId }` |
+| **GET `/v1/evidence/items/{id}`** | Fetch a specific evidence item by ID. | 60/min per IP | Required | Yes | None | `{ ok, data: { item: EvidenceItem }, requestId, traceId }` |
+| **POST `/v1/evidence/items`** | Create a new evidence item with `type` and `description`. | 30/min per IP | Required | Yes | `EvidenceItemCreateRequest` | `{ ok, data: { item: EvidenceItem }, requestId, traceId }` |
+| **PATCH `/v1/evidence/items/{id}`** | Update fields on an existing evidence item. | 30/min per IP | Required | Yes | `EvidenceItemUpdateRequest` | `{ ok, data: { item: EvidenceItem }, requestId, traceId }` |
+| **DELETE `/v1/evidence/items/{id}`** | Remove an evidence item. | 30/min per IP | Required | Yes | None | `{ ok, data: { deleted: true }, requestId, traceId }` |
+
+### Schemas
+
+* **EvidenceItem** –
+  ```yaml
+  id: integer
+  type: string
+  description: string
+  location: string (nullable)
+  owner: string (nullable)
+  metadata: object (nullable)
+  created_at: string (date-time)
+  updated_at: string (date-time)
+  ```
+* **EvidenceItemCreateRequest** –
+  ```yaml
+  type: string (required)
+  description: string (required)
+  location: string (optional)
+  owner: string (optional)
+  metadata: object (optional)
+  ```
+* **EvidenceItemUpdateRequest** – same fields as create request but all optional for partial updates.
+
+## Implementation details
+
+* **Repository:** `src/repositories/evidenceRepository.js` performs parameterised SQL queries against `evidence_items`.
+* **Migration:** Table defined in `src/migrations/002_extended_services.sql`.
+* **Routes:** `src/routes/evidence.routes.js` wires HTTP verbs to repository functions.
+* **OpenAPI:** `openapi/api.yaml` documents the schemas and paths listed above.
+
+## Future work
+
+Future sprints may extend the module with pagination, filtering and
+linkage to case or character records.

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -13,7 +13,7 @@ server‑side logic is considered; purely client resources are skipped.
 | 1 | baseevents | Handles player connecting, spawning and dropping; registers players and records spawn positions. | Already implemented in initial sprint | — |
 | 2 | coordsaver | Saves, lists and deletes coordinate presets; writes to `srp_coords` table. | Already implemented in initial sprint | — |
 | 3 | PolyZone | Registers, removes and lists named zones; maintains an in‑memory zone registry. | Already implemented in initial sprint | — |
-| 4 | np‑evidence | Receives `evidence:pooled`, `evidence:removal` and `evidence:clear` events; relays them to clients via corresponding events【457964279538678†L0-L15】. | Create — added evidence routes/events to forward these events. | See previous sprint | 
+| 4 | np‑evidence | Receives `evidence:pooled`, `evidence:removal` and `evidence:clear` events; relays them to clients via corresponding events【457964279538678†L0-L15】. | Create — added evidence routes/events; OpenAPI and docs extended. | See previous sprint |
 | 5 | np‑eblips | Receives `e-blips:updateBlips` with ped network ID, job and callsign; responds with `e-blips:addHandler` to the sender【423160286560117†L0-L8】. | Create — added blips routes/events to update client blips. | See previous sprint |
 | 6 | np‑dispatch | Central dispatch: listens for `dispatch:svNotify` events with codes 10‑13A/B and others; builds recipient lists and blip data and broadcasts `dispatch:clNotify`; defines commands (`togglealerts`) and alert events【737463347219154†L0-L29】【737463347219154†L30-L111】. | Create — added dispatch routes and logic for notifications, toggles and alert handlers. | See previous sprint |
 | 7 | np‑crimeschool | No server script; client‑side only. | Skip — nothing to port. | — |

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -315,7 +315,61 @@ components:
         z:
           type: number
           description: Z coordinate where the note is placed
-security:
+    # Evidence item record
+    EvidenceItem:
+      type: object
+      properties:
+        id:
+          type: integer
+        type:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+          nullable: true
+        owner:
+          type: string
+          nullable: true
+        metadata:
+          type: object
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    EvidenceItemCreateRequest:
+      type: object
+      properties:
+        type:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+        owner:
+          type: string
+        metadata:
+          type: object
+      required:
+        - type
+        - description
+    EvidenceItemUpdateRequest:
+      type: object
+      properties:
+        type:
+          type: string
+        description:
+          type: string
+        location:
+          type: string
+        owner:
+          type: string
+        metadata:
+          type: object
+    security:
   - ApiToken: []
 paths:
   /v1/healthz:
@@ -1042,7 +1096,206 @@ paths:
                     type: string
                   traceId:
                     type: string
-
+  # Evidence management
+  /v1/evidence/items:
+    get:
+      summary: List evidence items
+      responses:
+        '200':
+          description: List of evidence items
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/EvidenceItem'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+    post:
+      summary: Create evidence item
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvidenceItemCreateRequest'
+      responses:
+        '200':
+          description: Evidence item created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      item:
+                        $ref: '#/components/schemas/EvidenceItem'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+  /v1/evidence/items/{id}:
+    get:
+      summary: Fetch evidence item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Evidence item
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      item:
+                        $ref: '#/components/schemas/EvidenceItem'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+    patch:
+      summary: Update evidence item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EvidenceItemUpdateRequest'
+      responses:
+        '200':
+          description: Evidence item updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      item:
+                        $ref: '#/components/schemas/EvidenceItem'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+    delete:
+      summary: Delete evidence item
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Evidence item deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      deleted:
+                        type: boolean
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '404':
+          description: Not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                      message:
+                        type: string
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
   # Player ammunition management
   /v1/players/{playerId}/ammo:
     get:


### PR DESCRIPTION
## Summary
- document evidence item CRUD endpoints in OpenAPI spec
- add evidence module documentation and update progress ledger

## Testing
- `npx swagger-cli validate openapi/api.yaml` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6c0a876e0832d9c101cc6aa43ccf1