### PR TITLE
feat: restore contracts API

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -367,3 +367,10 @@ This sprint was a documentation‑only update.  No new endpoints, migrations or 
 ### Notes (2025‑08‑21)
 
 This sprint continued the systematic audit of NoPixel resources.  The vast majority of modules processed (from `np‑securityheists` to `outlawalert`) either contained only client scripts or relayed events without persisting state【644264532347613†L0-L9】【147099589493415†L0-L17】.  These were skipped or deferred.  The notable exception was **np‑weapons**, which keeps ammunition counts in a SQL table and updates them via events【735206341651753†L6-L44】.  To provide equivalent functionality, we created the **player ammunition API** described above.  We also fixed an OpenAPI misplacement for the websites POST endpoint.  No other endpoints or migrations were modified.  Future sprints will address remaining resources such as `pNotify`, `pPassword`, `ped`, `phone`, `police` and others.
+### Restored (2025‑08‑21)
+
+* **Contracts API** – Reintroduced routes, repository and migration so players can create, accept or decline contracts with automatic fund transfers.
+
+### Notes (2025‑08‑21 – Contracts)
+
+Documentation referenced contract endpoints but implementation was absent. This update provides the missing code and schema to make those endpoints functional.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -122,3 +122,16 @@ Legend: **A** = Added, **M** = Modified.
 | `docs/BASE_API_DOCUMENTATION.md` | M | Added a **Weapons & Ammo** section summarising the new ammo endpoints. |
 | `MANIFEST.md` | M | Updated to include this section and list new files/changes. |
 | `CHANGELOG.md` | M | Appended notes for the 2025‑08‑21 sprint covering the ammo API and documentation updates. |
+
+
+# Additional updates for the 2025‑08‑21 sprint (contracts restore)
+
+| Path | Status | Notes |
+|---|---|---|
+| `src/repositories/contractsRepository.js` | A | Repository for contract CRUD operations and status updates. |
+| `src/routes/contracts.routes.js` | A | Routes for listing, creating, accepting and declining contracts. |
+| `src/migrations/018_add_contracts.sql` | A | Migration adding the `contracts` table with sender/receiver, amount and status flags. |
+| `docs/modules/contracts.md` | A | Module documentation for the contracts API. |
+| `docs/index.md` | M | Added overview for contracts restore. |
+| `CHANGELOG.md` | M | Recorded restoration of the contracts module. |
+| `MANIFEST.md` | M | Logged this update. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -429,3 +429,9 @@ these decisions.  Future sprints will continue with `np‑voice`,
 `np‑votesystem`, `np‑warrants`, `np‑weapons`, `np‑webpages`,
 `np‑whitelist` and beyond, adding backend support only where
 persistent state or cross‑player interactions are required.
+# Sprint Overview – 2025‑08‑21 (Contracts module restore)
+
+A brief maintenance sprint restored the contracts domain that was
+referenced in documentation but missing from the codebase. The update
+adds a repository, routes and a database migration so contracts can be
+created, accepted or declined via the API.

--- a/backend/srp-base/docs/modules/contracts.md
+++ b/backend/srp-base/docs/modules/contracts.md
@@ -1,0 +1,57 @@
+# Contracts Module
+
+## Purpose
+
+The contracts module enables players to form simple agreements that
+involve a payment. Each contract records a sender, receiver, amount
+(in whole cents) and optional information text. Contracts remain in a
+pending state until the receiver accepts or declines them. When
+accepted, funds are transferred from the receiver to the sender using
+the existing economy helpers.
+
+## Endpoints
+
+### `GET /v1/contracts?playerId=cid`
+Lists contracts where the given player is either the sender or the
+receiver. The response contains an array of contract objects with
+fields matching the database schema.
+
+### `POST /v1/contracts`
+Creates a new contract. Required body fields: `senderId`, `receiverId`
+and `amount`. Optional field `info` stores descriptive text. The
+response returns the identifier of the newly created contract.
+
+### `POST /v1/contracts/{id}/accept`
+Accepts a contract on behalf of the receiver. Body must include
+`playerId` to verify the actor. On success the service transfers the
+amount and marks the contract as paid and accepted.
+
+### `POST /v1/contracts/{id}/decline`
+Declines a pending contract. No body is required. The contract is
+marked as resolved without moving any funds.
+
+## Repository
+
+`contractsRepository.js` exposes helper functions:
+
+- **listContractsForPlayer(playerId)** – fetches contracts involving a
+  particular player.
+- **createContract({ senderId, receiverId, amount, info })** – inserts a
+  new contract row and returns its id.
+- **getContract(id)** – retrieves a single contract by id.
+- **markAccepted(id)** – sets `paid` to 1 and `accepted` to 1.
+- **markDeclined(id)** – sets `accepted` to 0 for unresolved contracts.
+
+## Database Migration
+
+`018_add_contracts.sql` creates the `contracts` table with the columns
+used by the repository. Indices on `sender_id` and `receiver_id` allow
+fast lookups for either party.
+
+## Notes
+
+* Amounts are stored as integers representing cents. Clients should
+  multiply dollar values accordingly.
+* All endpoints require standard authentication and idempotency
+  headers.
+* Once a contract is accepted or declined it cannot be changed again.

--- a/backend/srp-base/src/migrations/018_add_contracts.sql
+++ b/backend/srp-base/src/migrations/018_add_contracts.sql
@@ -1,0 +1,21 @@
+-- Migration 018_add_contracts.sql
+--
+-- Create a contracts table to store agreements between players.
+-- Each contract records the sender, receiver, amount in cents,
+-- optional info text, whether payment has been made and whether the
+-- contract was accepted.  Indices on sender and receiver allow quick
+-- lookups for either party.
+
+CREATE TABLE IF NOT EXISTS contracts (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  sender_id VARCHAR(64) NOT NULL,
+  receiver_id VARCHAR(64) NOT NULL,
+  amount BIGINT NOT NULL,
+  info TEXT DEFAULT NULL,
+  paid TINYINT(1) NOT NULL DEFAULT 0,
+  accepted TINYINT(1) DEFAULT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_contracts_sender (sender_id),
+  INDEX idx_contracts_receiver (receiver_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/srp-base/src/repositories/contractsRepository.js
+++ b/backend/srp-base/src/repositories/contractsRepository.js
@@ -1,0 +1,51 @@
+const db = require('./db');
+
+async function listContractsForPlayer(playerId) {
+  const rows = await db.query(
+    'SELECT id, sender_id, receiver_id, amount, info, paid, accepted, created_at, updated_at FROM contracts WHERE sender_id = ? OR receiver_id = ? ORDER BY id DESC',
+    [playerId, playerId],
+  );
+  return rows.map((row) => ({
+    id: row.id,
+    sender_id: row.sender_id,
+    receiver_id: row.receiver_id,
+    amount: row.amount,
+    info: row.info,
+    paid: !!row.paid,
+    accepted: row.accepted === null ? null : !!row.accepted,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  }));
+}
+
+async function createContract({ senderId, receiverId, amount, info }) {
+  const result = await db.query(
+    'INSERT INTO contracts (sender_id, receiver_id, amount, info) VALUES (?, ?, ?, ?)',
+    [senderId, receiverId, amount, info],
+  );
+  return { id: result.insertId };
+}
+
+async function getContract(id) {
+  const rows = await db.query(
+    'SELECT id, sender_id, receiver_id, amount, info, paid, accepted FROM contracts WHERE id = ?',
+    [id],
+  );
+  return rows[0] || null;
+}
+
+async function markAccepted(id) {
+  await db.query('UPDATE contracts SET paid = 1, accepted = 1, updated_at = CURRENT_TIMESTAMP WHERE id = ?', [id]);
+}
+
+async function markDeclined(id) {
+  await db.query('UPDATE contracts SET accepted = 0, updated_at = CURRENT_TIMESTAMP WHERE id = ?', [id]);
+}
+
+module.exports = {
+  listContractsForPlayer,
+  createContract,
+  getContract,
+  markAccepted,
+  markDeclined,
+};

--- a/backend/srp-base/src/routes/contracts.routes.js
+++ b/backend/srp-base/src/routes/contracts.routes.js
@@ -1,0 +1,149 @@
+const express = require('express');
+const { sendOk, sendError } = require('../utils/respond');
+const {
+  listContractsForPlayer,
+  createContract,
+  getContract,
+  markAccepted,
+  markDeclined,
+} = require('../repositories/contractsRepository');
+const { createTransaction } = require('../repositories/economyRepository');
+
+const router = express.Router();
+
+router.get('/v1/contracts', async (req, res) => {
+  const { playerId } = req.query;
+  if (!playerId) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'playerId is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const contracts = await listContractsForPlayer(playerId);
+    sendOk(res, { contracts }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'CONTRACT_LIST_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+router.post('/v1/contracts', async (req, res) => {
+  const { senderId, receiverId, amount, info } = req.body || {};
+  if (!senderId || !receiverId || amount === undefined) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'senderId, receiverId and amount are required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  const amt = Number(amount);
+  if (!Number.isFinite(amt) || amt <= 0) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'amount must be a positive number' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const { id } = await createContract({ senderId, receiverId, amount: amt, info: info || null });
+    sendOk(res, { id }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'CONTRACT_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+router.post('/v1/contracts/:id/accept', async (req, res) => {
+  const contractId = parseInt(req.params.id, 10);
+  const { playerId } = req.body || {};
+  if (Number.isNaN(contractId) || !playerId) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'valid id and playerId are required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const contract = await getContract(contractId);
+    if (!contract) {
+      return sendError(
+        res,
+        { code: 'NOT_FOUND', message: 'Contract not found' },
+        404,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    if (contract.receiver_id !== playerId) {
+      return sendError(
+        res,
+        { code: 'FORBIDDEN', message: 'Player is not the receiver' },
+        403,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    if (contract.accepted !== null) {
+      return sendError(
+        res,
+        { code: 'CONTRACT_RESOLVED', message: 'Contract already resolved' },
+        409,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    await createTransaction({ fromPlayerId: playerId, toPlayerId: contract.sender_id, amount: contract.amount, reason: 'contract' });
+    await markAccepted(contractId);
+    sendOk(res, { id: contractId }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'CONTRACT_ACCEPT_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+router.post('/v1/contracts/:id/decline', async (req, res) => {
+  const contractId = parseInt(req.params.id, 10);
+  if (Number.isNaN(contractId)) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'valid id is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const contract = await getContract(contractId);
+    if (!contract) {
+      return sendError(
+        res,
+        { code: 'NOT_FOUND', message: 'Contract not found' },
+        404,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    if (contract.accepted !== null) {
+      return sendError(
+        res,
+        { code: 'CONTRACT_RESOLVED', message: 'Contract already resolved' },
+        409,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    await markDeclined(contractId);
+    sendOk(res, { id: contractId }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'CONTRACT_DECLINE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add contract repository and migration
- expose routes to create, list, accept and decline contracts
- document contracts domain

## Testing
- `npx @redocly/cli lint openapi/api.yaml` *(fails: 403 Forbidden)*
- `npm run migrate` *(fails: API_TOKEN environment variable must be provided)*
- `API_TOKEN=test DB_HOST=localhost DB_PORT=3306 DB_NAME=test DB_USER=root DB_PASS=pass npm run migrate` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c0a876e0832d9c101cc6aa43ccf1