### PR TITLE
chore: sanitize brand references

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -19,9 +19,9 @@
 
 ### Notes
 
-This sprint continues the integration of NoPixel server behaviours into
+This sprint continues the integration of original server behaviours into
 the unified `srp‑base` Node.js backend.  The broadcaster module
-implements the server-side logic of the NoPixel `np-broadcaster`
+implements the server-side logic of the original `np-broadcaster`
 resource in a RESTful manner.  The limit of concurrent broadcasters
 is configurable via the `MAX_BROADCASTERS` environment variable.
 
@@ -46,7 +46,7 @@ is configurable via the `MAX_BROADCASTERS` environment variable.
 This sprint focused on research, documentation and gap analysis
 rather than new features.  After compiling a framework compliance
 rubric and auditing the existing codebase, we resumed processing
-NoPixel resources.  The following resources were reviewed:
+original resources.  The following resources were reviewed:
 
 * **koilWeatherSync** – provides events to sync weather and time; the
   existing `/v1/world/state` endpoints already handle world state via
@@ -222,7 +222,7 @@ logic or require more comprehensive systems (e.g. EMS) to support.
 
 ### Notes (Part 7)
 
-In this sprint we examined another batch of NoPixel resources.
+In this sprint we examined another batch of original resources.
 `np-infinity` broadcasts players’ coordinates via events and does not
 require persistence【569396379702026†L0-L12】.  `np-interior`, `np-keypad`,
 `np-keys`, `np-lockpicking`, `np-lootsystem` and `np-login` contain
@@ -359,6 +359,8 @@ This sprint was a documentation‑only update.  No new endpoints, migrations or 
 
 ### Changed (2025‑08‑21)
 
+* Sanitised documentation and route comments to remove explicit references to the original server brand.
+
 * **openapi/api.yaml** – Corrected the websites API definition by moving the POST operation to the `/v1/websites` path and removing the erroneous POST under `/v1/players/{playerId}/ammo`.  Added path documentation for the ammo endpoints.
 * **progress‑ledger.md** – Added entries 80–105 recording skip, defer and create decisions for resources from `np‑securityheists` through `outlawalert`.  Notably, it records the creation of the ammo API for `np‑weapons`.
 * **index.md** – Appended a new sprint overview for 2025‑08‑21 summarising the ammo API and skip/defer decisions.
@@ -366,4 +368,4 @@ This sprint was a documentation‑only update.  No new endpoints, migrations or 
 
 ### Notes (2025‑08‑21)
 
-This sprint continued the systematic audit of NoPixel resources.  The vast majority of modules processed (from `np‑securityheists` to `outlawalert`) either contained only client scripts or relayed events without persisting state【644264532347613†L0-L9】【147099589493415†L0-L17】.  These were skipped or deferred.  The notable exception was **np‑weapons**, which keeps ammunition counts in a SQL table and updates them via events【735206341651753†L6-L44】.  To provide equivalent functionality, we created the **player ammunition API** described above.  We also fixed an OpenAPI misplacement for the websites POST endpoint.  No other endpoints or migrations were modified.  Future sprints will address remaining resources such as `pNotify`, `pPassword`, `ped`, `phone`, `police` and others.
+This sprint continued the systematic audit of original resources.  The vast majority of modules processed (from `np‑securityheists` to `outlawalert`) either contained only client scripts or relayed events without persisting state【644264532347613†L0-L9】【147099589493415†L0-L17】.  These were skipped or deferred.  The notable exception was **np‑weapons**, which keeps ammunition counts in a SQL table and updates them via events【735206341651753†L6-L44】.  To provide equivalent functionality, we created the **player ammunition API** described above.  We also fixed an OpenAPI misplacement for the websites POST endpoint.  No other endpoints or migrations were modified.  Future sprints will address remaining resources such as `pNotify`, `pPassword`, `ped`, `phone`, `police` and others.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -9,7 +9,7 @@ listed here.  Files not mentioned were left untouched.
 | `src/repositories/jobsRepository.js` | M | Added `countPlayersForJob` and `getJobByName` helpers to support the broadcaster module. |
 | `src/routes/broadcaster.routes.js` | A | New route for assigning the broadcaster job while enforcing a maximum number of concurrent broadcasters. |
 | `src/app.js` | M | Mounted the new broadcaster route. |
-| `DOCS/progress-ledger.md` | A | Progress log for processed NoPixel resources and decisions. |
+| `DOCS/progress-ledger.md` | A | Progress log for processed original resources and decisions. |
 | `DOCS/index.md` | A | Sprint overview summarising tasks and outcomes. |
 | `DOCS/modules/broadcaster.md` | A | Per‑module documentation describing the broadcaster API. |
 
@@ -122,3 +122,14 @@ Legend: **A** = Added, **M** = Modified.
 | `docs/BASE_API_DOCUMENTATION.md` | M | Added a **Weapons & Ammo** section summarising the new ammo endpoints. |
 | `MANIFEST.md` | M | Updated to include this section and list new files/changes. |
 | `CHANGELOG.md` | M | Appended notes for the 2025‑08‑21 sprint covering the ammo API and documentation updates. |
+# Documentation Sanitization – 2025-08-21
+
+| Path | Status | Notes |
+|---|---|---|
+| `CHANGELOG.md` | M | Noted removal of external brand references. |
+| `MANIFEST.md` | M | Added this section. |
+| `docs/BASE_API_DOCUMENTATION.md` | M | Replaced explicit brand mentions with neutral terminology. |
+| `docs/index.md` | M | Scrubbed brand references from sprint overviews. |
+| `docs/modules/broadcaster.md` | M | Generalised module description. |
+| `src/routes/broadcaster.routes.js` | M | Removed brand reference in comments. |
+| `src/routes/websites.routes.js` | M | Removed brand reference in comments. |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -363,7 +363,7 @@ By adhering to this documentation and the provided templates, you can build out 
 
 ## Additional Domain Services (Dispatch, Evidence, EMS, Keys, Loot)
 
-To support all features present in the original NoPixelServer resources at the framework level without introducing gameplay logic, the SunnyRP repository includes several **additional microservices** under `backend/services`: `srp-dispatch`, `srp-evidence`, `srp-ems`, `srp-keys` and `srp-loot`.  Each service mirrors the patterns used in `srp-base`—Express routing, MySQL persistence, token/HMAC authentication, idempotency and rate limiting—and maintains its own database schema and migrations.  These services act as the scaffolding for high‑level gameplay modules that will be written in Lua later.
+To support all features present in the original server resources at the framework level without introducing gameplay logic, the SunnyRP repository includes several **additional microservices** under `backend/services`: `srp-dispatch`, `srp-evidence`, `srp-ems`, `srp-keys` and `srp-loot`.  Each service mirrors the patterns used in `srp-base`—Express routing, MySQL persistence, token/HMAC authentication, idempotency and rate limiting—and maintains its own database schema and migrations.  These services act as the scaffolding for high‑level gameplay modules that will be written in Lua later.
 
 - **srp-dispatch** – Centralised storage and management of dispatch alerts (e.g. 911 calls, panic buttons).  It exposes:
   - `GET /v1/dispatch/alerts` – List recent dispatch alerts.
@@ -397,4 +397,4 @@ To support all features present in the original NoPixelServer resources at the f
   - `PATCH /v1/loot/items/:id` – Update fields on a loot item.
   - `DELETE /v1/loot/items/:id` – Remove a loot item after it is collected or expired.
 
-These services run on separate ports (3080 for dispatch, 3090 for evidence, 3100 for EMS, 3110 for keys and 3120 for loot) and require their own environment variables (database credentials, API token, HMAC secret, etc.).  By providing them now, the backend offers a **complete foundation** for every NoPixel resource.  Future Lua resources will call these APIs to create and retrieve alerts, evidence, medical records, keys or loot, but no gameplay logic exists on the backend; it merely stores and retrieves data.
+These services run on separate ports (3080 for dispatch, 3090 for evidence, 3100 for EMS, 3110 for keys and 3120 for loot) and require their own environment variables (database credentials, API token, HMAC secret, etc.).  By providing them now, the backend offers a **complete foundation** for every original resource.  Future Lua resources will call these APIs to create and retrieve alerts, evidence, medical records, keys or loot, but no gameplay logic exists on the backend; it merely stores and retrieves data.

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -1,6 +1,6 @@
 # Sprint Overview – 2025‑08‑18
 
-This sprint focused on continuing the migration of NoPixel
+This sprint focused on continuing the migration of original
 server-side behaviours into the unified `srp‑base` Node.js service.
 The goal is to provide feature parity with the original Lua
 resources while conforming to a clean, layered Node.js architecture.
@@ -8,7 +8,7 @@ resources while conforming to a clean, layered Node.js architecture.
 ### Highlights
 
 * Added a **broadcaster** module that replicates the behaviour of
-  the NoPixel `np-broadcaster` resource.  A new REST endpoint
+  the original `np-broadcaster` resource.  A new REST endpoint
   (`POST /v1/broadcast/attempt`) assigns the `broadcaster` job to
   a player while enforcing a configurable maximum number of
   broadcasters.
@@ -26,7 +26,7 @@ For a full list of processed resources and their decisions, see
 # Sprint Overview – 2025‑08‑19 (Part 2)
 
 This continuation of the 2025‑08‑19 sprint focused on processing
-additional NoPixel resources and documenting the decisions taken.
+additional original resources and documenting the decisions taken.
 Following the earlier documentation and compliance effort, we
 examined a further set of resources in the order listed by
 GitHub.  Because most of these resources either contain only
@@ -74,7 +74,7 @@ ensure the progress ledger is current.
 # Sprint Overview – 2025‑08‑19 (Part 3)
 
 In this follow‑on sprint we continued our systematic audit of the
-NoPixel resources, focusing on modules that appear after
+original resources, focusing on modules that appear after
 `np‑base` in the GitHub ordering.  Most resources examined
 contained only client scripts and therefore required no backend
 support.  However, the **np‑contracts** resource contained server
@@ -116,7 +116,7 @@ persistence or cross‑player interactions.
 
 # Sprint Overview – 2025‑08‑19 (Part 5)
 
-In this sprint we continued our methodical march through the NoPixel
+In this sprint we continued our methodical march through the original
 resources directory.  After handling driving schools and tests in the
 previous sprint, the next group of resources mostly contained
 client‑only features or simple event relays.  However, the **weed
@@ -174,7 +174,7 @@ interaction is required.
 
 # Sprint Overview – 2025‑08‑19 (Part 4)
 
-This sprint processed the next set of NoPixel resources after
+This sprint processed the next set of original resources after
 `np‑dirtymoney` in the repository ordering.  We identified two
 resources that required backend support: **np‑driftschool** and
 **np‑driving‑instructor**.  Each defines server events that
@@ -204,7 +204,7 @@ skipped the unrelated `np‑drugdeliveries` resource.
 # Sprint Overview – 2025‑08‑19 (Part 6)
 
 After completing the weed plants integration, we turned our attention to
-the next batch of NoPixel resources.  Most were client‑only or
+the next batch of original resources.  Most were client‑only or
 implemented purely cosmetic features, but two stood out: **np‑gurgle**
 and **np‑hospitalization**.  The former provides a phone app for
 purchasing personal websites, while the latter updates patient
@@ -275,7 +275,7 @@ records the skip/defer decisions and the new module.
 
 # Sprint Overview – 2025‑08‑19 (Part 7)
 
-In this sprint we reviewed the next batch of NoPixel resources after
+In this sprint we reviewed the next batch of original resources after
 `np‑hunting`.  The majority of these modules are purely client‑side
 or implement simple event relays that do not require any persistence
 or interplayer coordination.  Consequently, we **skipped** them.  The
@@ -305,7 +305,7 @@ ledger records these skip and defer decisions.  Future sprints will resume with
 
 # Sprint Overview – 2025‑08‑19 (Part 8)
 
-This sprint continued processing the next set of NoPixel resources in order,
+This sprint continued processing the next set of original resources in order,
 covering `np‑lost` through `np‑notepad`.  Most of these resources contain
 client‑only scripts or simple event relays with no persistent data, so they were
 **skipped**.  However, the **np‑notepad** resource maintains a `serverNotes`
@@ -347,7 +347,7 @@ across server restarts, filling a gap in the original Lua implementation.
 
 # Sprint Overview – 2025‑08‑20
 
-In this sprint we continued down the NoPixel `resources` directory,
+In this sprint we continued down the original `resources` directory,
 processing modules starting from the `np‑o` prefix.  We found that
 most of these resources contain only client‑side scripts or visual
 effects, and therefore require no backend support.  Two notable
@@ -396,7 +396,7 @@ and recorded the skip decisions for the remaining modules.
 
 # Sprint Overview – 2025‑08‑21
 
-This sprint processed the next set of NoPixel resources starting with `np‑voice` and extending through `outlawalert`.  Most of these modules are either client-only or implement event relays with no persistent state, so they were **skipped**.  The primary new feature introduced is a **player ammunition management API** to reflect the behaviour of the `np‑weapons` resource, which stores ammunition counts on the server.  We also corrected a path placement error in the OpenAPI specification for the websites API.
+This sprint processed the next set of original resources starting with `np‑voice` and extending through `outlawalert`.  Most of these modules are either client-only or implement event relays with no persistent state, so they were **skipped**.  The primary new feature introduced is a **player ammunition management API** to reflect the behaviour of the `np‑weapons` resource, which stores ammunition counts on the server.  We also corrected a path placement error in the OpenAPI specification for the websites API.
 
 ### Highlights
 

--- a/backend/srp-base/docs/modules/broadcaster.md
+++ b/backend/srp-base/docs/modules/broadcaster.md
@@ -1,7 +1,7 @@
 # Broadcaster Module
 
 The broadcaster module implements the server‑side logic of the
-NoPixel `np-broadcaster` resource in the unified `srp‑base`
+original `np-broadcaster` resource in the unified `srp‑base`
 backend.  In the original Lua resource, players trigger an
 `attemptBroadcast` event to become a broadcaster.  The server
 counts how many broadcasters are currently active and, if below a

--- a/backend/srp-base/src/routes/broadcaster.routes.js
+++ b/backend/srp-base/src/routes/broadcaster.routes.js
@@ -9,15 +9,7 @@ const { sendOk, sendError } = require('../utils/respond');
 const MAX_BROADCASTERS = Number.parseInt(process.env.MAX_BROADCASTERS, 10) || 5;
 
 /**
- * Routes for managing broadcaster roles.  NoPixel's broadcaster
- * resource allows players to become a broadcaster if there are fewer
- * than a set number of active broadcasters.  This endpoint
- * implements similar logic on the server-side.  It counts the
- * current assignments of the 'broadcaster' job and, if below the
- * configured limit, assigns the job to the requesting player.  The
- * assignment uses the existing jobs repository and does not toggle
- * duty; additional logic to set on-duty status can be added by
- * callers.
+ * Routes for managing broadcaster roles. The original Lua resource allowed players to become broadcasters if there were fewer than a set number of active broadcasters. This endpoint implements similar logic on the server-side. It counts the current assignments of the 'broadcaster' job and, if below the configured limit, assigns the job to the requesting player. The assignment uses the existing jobs repository and does not toggle duty; additional logic to set on-duty status can be added by callers.
  */
 const router = express.Router();
 

--- a/backend/srp-base/src/routes/websites.routes.js
+++ b/backend/srp-base/src/routes/websites.routes.js
@@ -16,7 +16,7 @@ router.use('/v1/websites', websitesLimiter);
  * Returns a list of websites.  If `ownerId` query parameter is provided,
  * only websites belonging to that character are returned.  Otherwise all
  * websites are returned.  This endpoint mirrors the `websitesList`
- * event in the NoPixel server, but exposed as an HTTP API.
+ * event in the original server, but exposed as an HTTP API.
  */
 router.get('/v1/websites', async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- scrub external brand mentions from docs and route comments
- note sanitization in changelog and manifest

## Testing
- `npx @redocly/cli lint openapi/api.yaml` *(failed: process terminated)*
- `npm test` *(missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c2129d28832d8e8700f0c0e4b648