### PR TITLE
chore: handle uncaught exceptions

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -367,3 +367,10 @@ This sprint was a documentation‑only update.  No new endpoints, migrations or 
 ### Notes (2025‑08‑21)
 
 This sprint continued the systematic audit of NoPixel resources.  The vast majority of modules processed (from `np‑securityheists` to `outlawalert`) either contained only client scripts or relayed events without persisting state【644264532347613†L0-L9】【147099589493415†L0-L17】.  These were skipped or deferred.  The notable exception was **np‑weapons**, which keeps ammunition counts in a SQL table and updates them via events【735206341651753†L6-L44】.  To provide equivalent functionality, we created the **player ammunition API** described above.  We also fixed an OpenAPI misplacement for the websites POST endpoint.  No other endpoints or migrations were modified.  Future sprints will address remaining resources such as `pNotify`, `pPassword`, `ped`, `phone`, `police` and others.
+### Changed (2025‑08‑21 – Infrastructure)
+
+* **src/server.js** – Added global `uncaughtException` handler to log and exit on unexpected errors.
+* **docs/framework-compliance.md** – Updated compliance notes to mention global exception listeners.
+* **docs/index.md** – Added infrastructure sprint overview.
+* **docs/progress-ledger.md** – Noted inability to access reference resource repository.
+* **docs/research-log.md** – New file capturing research and access issue.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -122,3 +122,15 @@ Legend: **A** = Added, **M** = Modified.
 | `docs/BASE_API_DOCUMENTATION.md` | M | Added a **Weapons & Ammo** section summarising the new ammo endpoints. |
 | `MANIFEST.md` | M | Updated to include this section and list new files/changes. |
 | `CHANGELOG.md` | M | Appended notes for the 2025‑08‑21 sprint covering the ammo API and documentation updates. |
+
+# Additional updates for the 2025‑08‑21 infrastructure patch
+
+| Path | Status | Notes |
+|---|---|---|
+| `src/server.js` | M | Added `uncaughtException` handler to log and exit on fatal errors. |
+| `docs/framework-compliance.md` | M | Documented global exception handling in compliance rubric. |
+| `docs/index.md` | M | Added infrastructure sprint overview and noted repository access issue. |
+| `docs/progress-ledger.md` | M | Recorded resource repository access issue. |
+| `docs/research-log.md` | A | New research log noting failed repository clone and Node.js docs reference. |
+| `MANIFEST.md` | M | Updated to include infrastructure patch notes. |
+| `CHANGELOG.md` | M | Added entry for infrastructure patch. |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -32,7 +32,7 @@ practice is supported by citations.
 | **Dependency injection** | The current design uses simple factory functions and explicit imports.  While providers (e.g. for players) can be swapped via configuration, there is no dedicated DI container.  Introducing DI for repositories and external services could further improve testability. |
 | **Unit testing** | There are no test suites in this repository.  Adding unit tests for repositories and routes using a framework such as Jest is recommended. |
 | **Logging** | A structured logger is implemented in `src/utils/logger.js` using Pino.  Logs include timestamps and can be configured via environment variables.  Request IDs are attached via middleware. |
-| **Error handling** | Errors are caught in route handlers and forwarded to a global error handler in `app.js`, which logs the error and returns a standard JSON envelope. |
+| **Error handling** | Errors are caught in route handlers and forwarded to a global error handler in `app.js`, which logs the error and returns a standard JSON envelope.  The server also listens for `unhandledRejection` and `uncaughtException` events to log and exit safely. |
 | **Event‑driven design** | As an HTTP API the service does not implement an event bus, but it does persist domain events in an outbox table.  FiveM network events are handled by the Lua layer (outside this service) and forwarded via HTTP. |
 | **Clean code and modularity** | The code is modular and uses CommonJS modules.  Each domain resides in its own file.  ESLint and Prettier configuration are absent; adding them would enforce consistent style. |
 | **Environment management** | The `dotenv` library loads environment variables and the `env.js` config file ensures required variables are present. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -429,3 +429,10 @@ these decisions.  Future sprints will continue with `np‑voice`,
 `np‑votesystem`, `np‑warrants`, `np‑weapons`, `np‑webpages`,
 `np‑whitelist` and beyond, adding backend support only where
 persistent state or cross‑player interactions are required.
+
+---
+
+# Sprint Overview – 2025‑08‑21 (Infrastructure)
+
+A short hardening pass added a global `uncaughtException` handler so the server logs unexpected errors and exits cleanly. The reference resource repository was unreachable (HTTP 403), therefore no new gameplay resources were processed in this run.
+

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -124,3 +124,4 @@ server‑side logic is considered; purely client resources are skipped.
 | 105 | outlawalert | Defines an RGB colour table; no events or persistence【895876963551968†L0-L120】. | Skip — nothing to port. | — |
 
 **Legend:** *Skip* – no action taken because equivalent functionality already exists or the resource is client‑side. *Extend* – partially implemented; only missing behaviour added. *Create* – new module/endpoints created to port behaviour.
+2025‑08‑21: Reference resource repository was inaccessible (HTTP 403), so no new resources were processed this run.

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -1,0 +1,4 @@
+# Research Log – 2025-08-21
+
+- Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403.
+- Reviewed Node.js documentation on the `uncaughtException` event for guidance on safe shutdown behaviour.

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -28,3 +28,8 @@ process.on('SIGINT', shutdown);
 process.on('unhandledRejection', (reason) => {
   logger.error({ err: reason }, 'Unhandled promise rejection');
 });
+
+process.on('uncaughtException', (err) => {
+  logger.fatal({ err }, 'Uncaught exception');
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- log and exit on uncaught exceptions
- document global exception handling and note resource repo outage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run migrate` *(fails: API_TOKEN environment variable must be provided)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c2129d28832d8e8700f0c0e4b648