### PR TITLE
srp-base: integrate ghmattimysql-style database helpers

### DIFF
--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -41,3 +41,4 @@
 | gabz_mrpd | Map resource for Mission Row PD building; no events | N/A |
 | gabz_pillbox_hospital | Resource handles hospital admissions and bed management | `GET /v1/hospital/admissions/active`, `POST /v1/hospital/admissions`, `POST /v1/hospital/admissions/{id}/discharge` |
 | garages | Resource emits events when vehicles are stored or retrieved from garages | `/v1/garages` CRUD, `/v1/garages/{garageId}/store`, `/v1/garages/{garageId}/retrieve`, `/v1/characters/{characterId}/garages/{garageId}/vehicles` |
+| ghmattimysql | Exports `execute`, `scalar` and `transaction` for MySQL queries | Core `db` repository offers `query`, `scalar` and `transaction` helpers with named parameters |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -80,3 +80,4 @@ practice is supported by citations.
 | **characters module** | Added endpoint to retrieve the active character, maintaining layered design and validation. |
 | **hospital module** | Hospital admission endpoints follow the established layered pattern with authentication and idempotency. |
 | **garages module** | Garage endpoints follow the established layered pattern with authentication, rate limiting and idempotency. |
+| **database helpers** | Core MySQL adapter now supports named parameters, scalar queries and transaction wrappers for safer, more flexible persistence. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -250,3 +250,10 @@ Extended parity for the **garages** resource by scoping stored vehicles to chara
 * Migration `049_add_garage_vehicle_character.sql` adds `character_id` to `garage_vehicles`.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/garages.md`.
+
+## Update – 2025-08-25
+
+Enhanced core database utilities to align with the **ghmattimysql** resource.
+
+* Added named parameter handling, scalar queries and transaction helper functions in `src/repositories/db.js`.
+

--- a/backend/srp-base/docs/modules/db.md
+++ b/backend/srp-base/docs/modules/db.md
@@ -1,0 +1,24 @@
+# Database Utility
+
+Provides low-level MySQL helpers for repositories. Supports named parameters (`@name`), scalar queries and multi-step transactions.
+
+## Functions
+
+| Function | Description |
+|---|---|
+| `query(sql, params)` | Execute a statement with positional or named parameters and return resulting rows. |
+| `scalar(sql, params)` | Return the first column of the first row or `null` when no rows match. |
+| `transaction(steps)` | Execute an array of `{ sql, params }` steps atomically. Returns `true` on commit and `false` on rollback. |
+| `getConnection()` | Acquire a dedicated connection from the pool for manual transaction control. |
+
+## Parameter formats
+
+- Arrays: `[1, 2]` map to `?` placeholders.
+- Objects: `{ id: 3 }` map to `@id` placeholders.
+
+## Implementation details
+
+- Repository file: `src/repositories/db.js`.
+- Uses `mysql2/promise` connection pool with `utf8mb4` charset.
+- Logs connection issues and transaction rollbacks via the shared logger.
+

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -41,3 +41,4 @@
 | 37 | gabz_mrpd | Mission Row PD mapping; no server logic | Skip | Asset-only |
 | 38 | gabz_pillbox_hospital | Pillbox hospital admissions and bed tracking | Create | Added patient admission API |
 | 39 | garages | Vehicle storage per character with garage definitions | Extend | Added character-scoped storage API |
+| 40 | ghmattimysql | MySQL middleware offering execute, scalar and transaction utilities | Extend | Added named parameters, scalar and transaction helpers |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -177,3 +177,9 @@
 
 - Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.
 - GitHub API search results for "NoPixel garages" – https://api.github.com/search/repositories?q=NoPixel+garages
+
+# Research Log – 2025-08-25 (ghmattimysql)
+
+- Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.
+- GitHub repository "vecchiotom/ghmattimysql" – middleware overview. https://github.com/vecchiotom/ghmattimysql
+- GitHub repository "imahdiy/qb-target-nopixel4.0" – notes on NoPixel 4.0 interaction style. https://github.com/imahdiy/qb-target-nopixel4.0

--- a/backend/srp-base/src/repositories/db.js
+++ b/backend/srp-base/src/repositories/db.js
@@ -30,9 +30,54 @@ pool.on('error', (err) => {
   logger.error({ err }, 'MySQL pool error');
 });
 
+function prepare(sql, params) {
+  if (!params || Array.isArray(params)) {
+    return { sql, values: params };
+  }
+  const values = [];
+  const formatted = sql.replace(/@([a-zA-Z0-9_]+)/g, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(params, key)) {
+      throw new Error(`Missing value for named parameter ${key}`);
+    }
+    values.push(params[key]);
+    return '?';
+  });
+  return { sql: formatted, values };
+}
+
 async function query(sql, params) {
-  const [rows] = await pool.execute(sql, params);
+  const { sql: formatted, values } = prepare(sql, params);
+  const [rows] = await pool.execute(formatted, values);
   return rows;
+}
+
+async function scalar(sql, params) {
+  const rows = await query(sql, params);
+  if (!rows.length) {
+    return null;
+  }
+  const row = rows[0];
+  const keys = Object.keys(row);
+  return keys.length ? row[keys[0]] : null;
+}
+
+async function transaction(steps) {
+  const connection = await pool.getConnection();
+  try {
+    await connection.beginTransaction();
+    for (const step of steps) {
+      const { sql: formatted, values } = prepare(step.sql, step.params);
+      await connection.execute(formatted, values);
+    }
+    await connection.commit();
+    return true;
+  } catch (err) {
+    await connection.rollback();
+    logger.error({ err }, 'transaction rollback');
+    return false;
+  } finally {
+    connection.release();
+  }
 }
 
 /**
@@ -47,5 +92,7 @@ async function getConnection() {
 module.exports = {
   pool,
   query,
+  scalar,
   getConnection,
+  transaction,
 };


### PR DESCRIPTION
## Summary
- add named parameter, scalar and transaction helpers to MySQL adapter
- document new db utilities and update resource ledger
- log research sources for ghmattimysql and NoPixel 4 style interaction

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68abbebbfa38832dbae49dad5355a893