### PR TITLE
srp-base: integrate hardcap player cap tracking

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1008,3 +1008,21 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 * Remove garage routes and repository changes.
 * Drop `character_id` column from `garage_vehicles`.
+
+## 2025-08-25 – hardcap
+
+### Added
+
+* Hardcap module with `/v1/hardcap/status`, `/v1/hardcap/config` and `/v1/hardcap/sessions` endpoints.
+
+### Migrations
+
+* `050_add_hardcap.sql`
+
+### Risks
+
+* Misreported session counts could block valid connections.
+
+### Rollback
+
+* Drop `hardcap_config` and `hardcap_sessions` tables and remove hardcap routes.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -6,6 +6,7 @@
 - Added furniture placement APIs.
 - Added endpoint to retrieve the active character for multi-character support.
 - Added hospital admission APIs.
+- Added hardcap configuration and session tracking APIs.
 
 ## File Changes
 
@@ -70,6 +71,23 @@
 | `docs/BASE_API_DOCUMENTATION.md` | M | Documented hospital endpoints |
 | `docs/framework-compliance.md` | M | Noted hospital module compliance |
 | `docs/research-log.md` | M | Logged gabz_pillbox_hospital research |
+| `src/repositories/hardcapRepository.js` | A | Persistence for hardcap configuration and sessions |
+| `src/routes/hardcap.routes.js` | A | REST endpoints for hardcap operations |
+| `src/migrations/050_add_hardcap.sql` | A | Create hardcap tables |
+| `src/app.js` | M | Mounted hardcap routes |
+| `openapi/api.yaml` | M | Documented hardcap schemas and paths |
+| `docs/index.md` | M | Logged hardcap update |
+| `docs/progress-ledger.md` | M | Added hardcap entry |
+| `docs/framework-compliance.md` | M | Noted hardcap module compliance |
+| `docs/BASE_API_DOCUMENTATION.md` | M | Documented hardcap endpoints |
+| `docs/events-and-rpcs.md` | M | Mapped hardcap events |
+| `docs/db-schema.md` | M | Documented hardcap tables |
+| `docs/migrations.md` | M | Listed migration 050 |
+| `docs/admin-ops.md` | M | Added hardcap table check |
+| `docs/security.md` | M | Added hardcap security note |
+| `docs/testing.md` | M | Added hardcap curl examples |
+| `docs/modules/hardcap.md` | A | Module documentation |
+| `docs/research-log.md` | M | Logged hardcap research attempt |
 
 ## Startup Notes
 

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -502,6 +502,11 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
   - `GET /v1/connectqueue/priorities` – List queue priorities optionally filtered by `accountId`.
   - `POST /v1/connectqueue/priorities` – Upsert a priority with `accountId`, `priority`, optional `reason` and `expiresAt`.
   - `DELETE /v1/connectqueue/priorities/{accountId}` – Remove priority for an account.
+- **srp-hardcap** – Manages server connection limits and active sessions.
+  - `GET /v1/hardcap/status` – Current max players, reserved slots and active count.
+  - `POST /v1/hardcap/config` – Update max player and reserved slot settings.
+  - `POST /v1/hardcap/sessions` – Register an active session.
+  - `DELETE /v1/hardcap/sessions/{id}` – End an active session.
 - **srp-cron** – Schedules timed server tasks.
   - `GET /v1/cron/jobs` – List registered cron jobs.
   - `POST /v1/cron/jobs` – Create or replace a cron job with `name`, `schedule`, optional `payload`, `accountId`, `characterId`, `priority` and `nextRun`.

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -33,3 +33,4 @@
 - Ensure the `taxi_rides` table exists for taxi dispatch.
 - Ensure the `furniture` table exists for stored furniture placements.
 - Ensure the `hospital_admissions` table exists for patient tracking.
+- Ensure the `hardcap_config` and `hardcap_sessions` tables exist for player capacity tracking.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -382,3 +382,22 @@
 | character_id | BIGINT | Character storing the vehicle |
 | stored_at | TIMESTAMP | Storage time |
 | retrieved_at | TIMESTAMP | Retrieval time |
+
+## hardcap_config
+
+| Column | Type | Notes |
+|---|---|---|
+| id | TINYINT | Always 1 |
+| max_players | INT | Maximum allowed concurrent players |
+| reserved_slots | INT | Slots reserved for priority |
+| updated_at | TIMESTAMP | Update time |
+
+## hardcap_sessions
+
+| Column | Type | Notes |
+|---|---|---|
+| id | BIGINT AUTO_INCREMENT | Primary key |
+| account_id | BIGINT | FK to accounts.id |
+| character_id | BIGINT | FK to characters.id |
+| connected_at | TIMESTAMP | Connection time |
+| disconnected_at | TIMESTAMP | Disconnection time; null if active |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -42,3 +42,4 @@
 | gabz_pillbox_hospital | Resource handles hospital admissions and bed management | `GET /v1/hospital/admissions/active`, `POST /v1/hospital/admissions`, `POST /v1/hospital/admissions/{id}/discharge` |
 | garages | Resource emits events when vehicles are stored or retrieved from garages | `/v1/garages` CRUD, `/v1/garages/{garageId}/store`, `/v1/garages/{garageId}/retrieve`, `/v1/characters/{characterId}/garages/{garageId}/vehicles` |
 | ghmattimysql | Exports `execute`, `scalar` and `transaction` for MySQL queries | Core `db` repository offers `query`, `scalar` and `transaction` helpers with named parameters |
+| hardcap | Connection attempts and slot checks | `GET /v1/hardcap/status`, `POST /v1/hardcap/sessions`, `DELETE /v1/hardcap/sessions/{id}` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -81,3 +81,4 @@ practice is supported by citations.
 | **hospital module** | Hospital admission endpoints follow the established layered pattern with authentication and idempotency. |
 | **garages module** | Garage endpoints follow the established layered pattern with authentication, rate limiting and idempotency. |
 | **database helpers** | Core MySQL adapter now supports named parameters, scalar queries and transaction wrappers for safer, more flexible persistence. |
+| **hardcap module** | Hardcap endpoints follow the established layered pattern with authentication, rate limiting and idempotency. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -257,3 +257,11 @@ Enhanced core database utilities to align with the **ghmattimysql** resource.
 
 * Added named parameter handling, scalar queries and transaction helper functions in `src/repositories/db.js`.
 
+
+## Update – 2025-08-25
+
+Introduced server capacity tracking to support the **hardcap** resource.
+
+* Added Hardcap module with `/v1/hardcap/status`, `/v1/hardcap/config` and `/v1/hardcap/sessions` endpoints.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/hardcap.md`.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -47,3 +47,4 @@
 | 047_add_furniture.sql | Furniture table |
 | 048_add_hospital_admissions.sql | Hospital admissions table |
 | 049_add_garage_vehicle_character.sql | Add character_id to garage_vehicles |
+| 050_add_hardcap.sql | Hardcap configuration and session tables |

--- a/backend/srp-base/docs/modules/hardcap.md
+++ b/backend/srp-base/docs/modules/hardcap.md
@@ -1,0 +1,54 @@
+# Hardcap Module
+
+Manages server connection limits and active sessions.
+
+## Feature flag
+
+There is no feature flag for hardcap; the module is always enabled.
+
+## Endpoints
+
+| Method & Path | Description | Rate Limit | Auth | Idempotent | Request Body | Response |
+|---|---|---|---|---|---|---|
+| **GET `/v1/hardcap/status`** | Retrieve current max players, reserved slots and active count. | 30/min per IP | Required | Yes | None | `{ ok, data: { status: HardcapStatus }, requestId, traceId }` |
+| **POST `/v1/hardcap/config`** | Update max player and reserved slot settings. | 30/min per IP | Required | Yes | `HardcapConfigRequest` | `{ ok, data: { config: HardcapStatus }, requestId, traceId }` |
+| **POST `/v1/hardcap/sessions`** | Register an active account/character session. | 30/min per IP | Required | Yes | `HardcapSessionCreateRequest` | `{ ok, data: { session: HardcapSession }, requestId, traceId }` |
+| **DELETE `/v1/hardcap/sessions/{id}`** | End an active session. | 30/min per IP | Required | Yes | None | `{ ok, data: { deleted: boolean }, requestId, traceId }` |
+
+### Schemas
+
+* **HardcapStatus** –
+  ```yaml
+  maxPlayers: integer
+  reservedSlots: integer
+  currentPlayers: integer
+  ```
+* **HardcapConfigRequest** –
+  ```yaml
+  maxPlayers: integer
+  reservedSlots: integer
+  ```
+* **HardcapSession** –
+  ```yaml
+  id: integer
+  accountId: integer
+  characterId: integer
+  connectedAt: string (date-time)
+  disconnectedAt: string (date-time) | null
+  ```
+* **HardcapSessionCreateRequest** –
+  ```yaml
+  accountId: integer
+  characterId: integer
+  ```
+
+## Implementation details
+
+* **Repository:** `src/repositories/hardcapRepository.js` handles configuration and session persistence.
+* **Migration:** `src/migrations/050_add_hardcap.sql` creates the `hardcap_config` and `hardcap_sessions` tables.
+* **Routes:** `src/routes/hardcap.routes.js` exposes the REST API.
+* **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
+
+## Future work
+
+Consider exposing metrics for queue length and automatic capacity scaling.

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -42,3 +42,4 @@
 | 38 | gabz_pillbox_hospital | Pillbox hospital admissions and bed tracking | Create | Added patient admission API |
 | 39 | garages | Vehicle storage per character with garage definitions | Extend | Added character-scoped storage API |
 | 40 | ghmattimysql | MySQL middleware offering execute, scalar and transaction utilities | Extend | Added named parameters, scalar and transaction helpers |
+| 41 | hardcap | Enforce player slot limits and track active sessions | Create | Added config and session APIs |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -183,3 +183,9 @@
 - Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.
 - GitHub repository "vecchiotom/ghmattimysql" – middleware overview. https://github.com/vecchiotom/ghmattimysql
 - GitHub repository "imahdiy/qb-target-nopixel4.0" – notes on NoPixel 4.0 interaction style. https://github.com/imahdiy/qb-target-nopixel4.0
+
+## Research Log – 2025-08-25 (hardcap)
+
+- Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.
+- GitHub API search results for "NoPixel 4.0" – https://api.github.com/search/repositories?q=NoPixel+4.0
+- GitHub API search results for "ProdigyRP 4.0" – https://api.github.com/search/repositories?q=ProdigyRP+4.0

--- a/backend/srp-base/docs/security.md
+++ b/backend/srp-base/docs/security.md
@@ -31,3 +31,4 @@
 - Taxi routes inherit the same authentication and idempotency requirements.
 - Furniture routes inherit the same authentication and idempotency requirements.
 - Hospital routes inherit the same authentication and idempotency requirements.
+- Hardcap routes inherit the same authentication, idempotency and rate limiting requirements.

--- a/backend/srp-base/docs/testing.md
+++ b/backend/srp-base/docs/testing.md
@@ -289,3 +289,17 @@ curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: hosp1' -H 'Content-Type: a
 curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: hosp2' \
   http://localhost:3010/v1/hospital/admissions/1/discharge
 ```
+
+Manually verify the hardcap endpoints:
+
+```sh
+curl -H 'X-API-Token: <token>' http://localhost:3010/v1/hardcap/status
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: hard1' -H 'Content-Type: application/json' \
+  -d '{"maxPlayers":64,"reservedSlots":0}' \
+  http://localhost:3010/v1/hardcap/config
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: hard2' -H 'Content-Type: application/json' \
+  -d '{"accountId":1,"characterId":1}' \
+  http://localhost:3010/v1/hardcap/sessions
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: hard3' -X DELETE \
+  http://localhost:3010/v1/hardcap/sessions/1
+```

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -1475,6 +1475,51 @@ components:
         type: string
         format: date-time
         nullable: true
+  HardcapStatus:
+    type: object
+    properties:
+      maxPlayers:
+        type: integer
+      reservedSlots:
+        type: integer
+      currentPlayers:
+        type: integer
+  HardcapConfigRequest:
+    type: object
+    required:
+      - maxPlayers
+    properties:
+      maxPlayers:
+        type: integer
+      reservedSlots:
+        type: integer
+        default: 0
+  HardcapSession:
+    type: object
+    properties:
+      id:
+        type: integer
+      accountId:
+        type: integer
+      characterId:
+        type: integer
+      connectedAt:
+        type: string
+        format: date-time
+      disconnectedAt:
+        type: string
+        format: date-time
+        nullable: true
+  HardcapSessionCreateRequest:
+    type: object
+    required:
+      - accountId
+      - characterId
+    properties:
+      accountId:
+        type: integer
+      characterId:
+        type: integer
 security:
   - ApiToken: []
 paths:
@@ -5699,3 +5744,112 @@ paths:
                   traceId:
                     type: string
 
+  /v1/hardcap/status:
+    get:
+      summary: Get hardcap status
+      operationId: getHardcapStatus
+      responses:
+        '200':
+          description: Hardcap status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/HardcapStatus'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /v1/hardcap/config:
+    post:
+      summary: Update hardcap configuration
+      operationId: updateHardcapConfig
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HardcapConfigRequest'
+      responses:
+        '200':
+          description: Updated hardcap configuration
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/HardcapStatus'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /v1/hardcap/sessions:
+    post:
+      summary: Register an active session
+      operationId: createHardcapSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HardcapSessionCreateRequest'
+      responses:
+        '200':
+          description: Hardcap session created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/HardcapSession'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /v1/hardcap/sessions/{id}:
+    delete:
+      summary: End an active session
+      operationId: deleteHardcapSession
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Session ended
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      deleted:
+                        type: boolean
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'

--- a/backend/srp-base/src/app.js
+++ b/backend/srp-base/src/app.js
@@ -83,6 +83,8 @@ const phoneRoutes = require('./routes/phone.routes');
 const chatRoutes = require('./routes/chat.routes');
 // connect queue domain route
 const connectqueueRoutes = require('./routes/connectqueue.routes');
+// hardcap domain route
+const hardcapRoutes = require('./routes/hardcap.routes');
 
 // camera domain route
 const cameraRoutes = require('./routes/camera.routes');
@@ -214,6 +216,8 @@ app.use(chatRoutes);
 
 // mount connect queue routes
 app.use(connectqueueRoutes);
+// mount hardcap routes
+app.use(hardcapRoutes);
 
 // mount camera routes
 app.use(cameraRoutes);

--- a/backend/srp-base/src/migrations/050_add_hardcap.sql
+++ b/backend/srp-base/src/migrations/050_add_hardcap.sql
@@ -1,0 +1,22 @@
+-- Hardcap configuration and session tracking
+CREATE TABLE IF NOT EXISTS hardcap_config (
+  id TINYINT NOT NULL PRIMARY KEY CHECK (id = 1),
+  max_players INT NOT NULL,
+  reserved_slots INT NOT NULL DEFAULT 0,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+INSERT INTO hardcap_config (id, max_players, reserved_slots)
+SELECT 1, 64, 0 FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM hardcap_config WHERE id = 1);
+
+CREATE TABLE IF NOT EXISTS hardcap_sessions (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  account_id BIGINT NOT NULL,
+  character_id BIGINT NOT NULL,
+  connected_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  disconnected_at TIMESTAMP NULL,
+  CONSTRAINT fk_hardcap_session_account FOREIGN KEY (account_id) REFERENCES accounts(id),
+  CONSTRAINT fk_hardcap_session_character FOREIGN KEY (character_id) REFERENCES characters(id),
+  INDEX idx_hardcap_sessions_active (disconnected_at)
+);

--- a/backend/srp-base/src/repositories/hardcapRepository.js
+++ b/backend/srp-base/src/repositories/hardcapRepository.js
@@ -1,0 +1,80 @@
+const db = require('./db');
+
+/**
+ * Retrieve hardcap configuration and current player count.
+ * @returns {Promise<{maxPlayers:number,reservedSlots:number,currentPlayers:number}>}
+ */
+async function getStatus() {
+  const [cfg] = await db.query(
+    'SELECT max_players AS maxPlayers, reserved_slots AS reservedSlots FROM hardcap_config WHERE id = 1',
+  );
+  const [{ count }] = await db.query(
+    'SELECT COUNT(*) AS count FROM hardcap_sessions WHERE disconnected_at IS NULL',
+  );
+  return { maxPlayers: cfg ? cfg.maxPlayers : 0, reservedSlots: cfg ? cfg.reservedSlots : 0, currentPlayers: count };
+}
+
+/**
+ * Update hardcap configuration.
+ * @param {Object} params
+ * @param {number} params.maxPlayers
+ * @param {number} [params.reservedSlots]
+ * @returns {Promise<{maxPlayers:number,reservedSlots:number}>}
+ */
+async function updateConfig({ maxPlayers, reservedSlots = 0 }) {
+  await db.query(
+    'UPDATE hardcap_config SET max_players = ?, reserved_slots = ?, updated_at = CURRENT_TIMESTAMP WHERE id = 1',
+    [maxPlayers, reservedSlots],
+  );
+  const [row] = await db.query(
+    'SELECT max_players AS maxPlayers, reserved_slots AS reservedSlots FROM hardcap_config WHERE id = 1',
+  );
+  return row;
+}
+
+/**
+ * Add an active session for a character.
+ * Verifies the character belongs to the account.
+ * @param {Object} params
+ * @param {number} params.accountId
+ * @param {number} params.characterId
+ * @returns {Promise<{id:number,accountId:number,characterId:number,connectedAt:string,disconnectedAt:null}>}
+ */
+async function createSession({ accountId, characterId }) {
+  const [owner] = await db.query(
+    'SELECT 1 FROM characters WHERE id = ? AND account_id = ?',
+    [characterId, accountId],
+  );
+  if (!owner) {
+    throw new Error('CHARACTER_NOT_FOUND');
+  }
+  const result = await db.query(
+    'INSERT INTO hardcap_sessions (account_id, character_id) VALUES (?, ?)',
+    [accountId, characterId],
+  );
+  const [row] = await db.query(
+    'SELECT id, account_id AS accountId, character_id AS characterId, connected_at AS connectedAt, disconnected_at AS disconnectedAt FROM hardcap_sessions WHERE id = ?',
+    [result.insertId],
+  );
+  return row;
+}
+
+/**
+ * Mark a session as disconnected.
+ * @param {number} id
+ * @returns {Promise<boolean>}
+ */
+async function endSession(id) {
+  const result = await db.query(
+    'UPDATE hardcap_sessions SET disconnected_at = CURRENT_TIMESTAMP WHERE id = ? AND disconnected_at IS NULL',
+    [id],
+  );
+  return result.affectedRows > 0;
+}
+
+module.exports = {
+  getStatus,
+  updateConfig,
+  createSession,
+  endSession,
+};

--- a/backend/srp-base/src/routes/hardcap.routes.js
+++ b/backend/srp-base/src/routes/hardcap.routes.js
@@ -1,0 +1,120 @@
+const express = require('express');
+const { sendOk, sendError } = require('../utils/respond');
+const { getStatus, updateConfig, createSession, endSession } = require('../repositories/hardcapRepository');
+const { createRateLimiter } = require('../middleware/rateLimit');
+
+const router = express.Router();
+
+// Limit hardcap operations to 30 requests per minute per IP
+const hardcapLimiter = createRateLimiter({ windowMs: 60_000, max: 30 });
+router.use('/v1/hardcap', hardcapLimiter);
+
+// GET /v1/hardcap/status
+router.get('/v1/hardcap/status', async (req, res) => {
+  try {
+    const status = await getStatus();
+    sendOk(res, { status }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'HARDCAP_STATUS_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+// POST /v1/hardcap/config
+router.post('/v1/hardcap/config', async (req, res) => {
+  if (!req.headers['x-idempotency-key']) {
+    return sendError(
+      res,
+      { code: 'IDEMPOTENCY_KEY_REQUIRED', message: 'X-Idempotency-Key header is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  const { maxPlayers, reservedSlots } = req.body || {};
+  const maxNum = parseInt(maxPlayers, 10);
+  const reserveNum = reservedSlots !== undefined ? parseInt(reservedSlots, 10) : 0;
+  if (Number.isNaN(maxNum) || maxNum < 1 || Number.isNaN(reserveNum) || reserveNum < 0) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'maxPlayers must be positive and reservedSlots non-negative integers' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const cfg = await updateConfig({ maxPlayers: maxNum, reservedSlots: reserveNum });
+    sendOk(res, { config: cfg }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'HARDCAP_CONFIG_UPDATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+// POST /v1/hardcap/sessions
+router.post('/v1/hardcap/sessions', async (req, res) => {
+  if (!req.headers['x-idempotency-key']) {
+    return sendError(
+      res,
+      { code: 'IDEMPOTENCY_KEY_REQUIRED', message: 'X-Idempotency-Key header is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  const { accountId, characterId } = req.body || {};
+  const accountNum = parseInt(accountId, 10);
+  const charNum = parseInt(characterId, 10);
+  if (Number.isNaN(accountNum) || Number.isNaN(charNum)) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'accountId and characterId must be integers' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const session = await createSession({ accountId: accountNum, characterId: charNum });
+    sendOk(res, { session }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    let code = 'HARDCAP_SESSION_CREATE_FAILED';
+    let status = 500;
+    if (err.message === 'CHARACTER_NOT_FOUND') {
+      code = 'CHARACTER_NOT_FOUND';
+      status = 404;
+    }
+    sendError(res, { code, message: err.message }, status, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+// DELETE /v1/hardcap/sessions/:id
+router.delete('/v1/hardcap/sessions/:id', async (req, res) => {
+  if (!req.headers['x-idempotency-key']) {
+    return sendError(
+      res,
+      { code: 'IDEMPOTENCY_KEY_REQUIRED', message: 'X-Idempotency-Key header is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  const { id } = req.params;
+  const sessionId = parseInt(id, 10);
+  if (Number.isNaN(sessionId)) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'id must be an integer' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const deleted = await endSession(sessionId);
+    sendOk(res, { deleted }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'HARDCAP_SESSION_DELETE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add hardcap configuration and session tracking APIs
- expose hardcap routes and persistence
- document hardcap endpoints, tables, and research

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68abc0feb448832db3f1bedd29af00f1