### PR TITLE
srp-base: climate override timecycle API

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1179,3 +1179,17 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 
 * Drop `world_forecast` table and remove world forecast routes.
+
+## 2025-08-25 – climate-overrides
+
+### Added
+* Timecycle override endpoints `/v1/world/timecycle` and repository helpers.
+
+### Migrations
+* `059_add_world_timecycle.sql` creates `world_timecycle` table.
+
+### Risks
+* Incorrect preset names could cause inconsistent visuals.
+
+### Rollback
+* Drop `world_timecycle` table and remove timecycle routes and repository.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -18,6 +18,7 @@
 - Renamed k9 migration to `057_add_k9_units.sql` to resolve duplication.
 - Added debug diagnostics endpoint and repository.
  - Added world state and forecast APIs.
+- Added timecycle override API for world timecycle presets.
 
 ## File Changes
 
@@ -243,6 +244,23 @@
 | `docs/framework-compliance.md` | M | Noted world module compliance |
 | `CHANGELOG.md` | M | Added world forecast entry |
 | `docs/framework-compliance.md` | M | Added debug module compliance |
+| `src/repositories/worldRepository.js` | M | Timecycle override persistence |
+| `src/routes/world.routes.js` | M | Timecycle override endpoints |
+| `src/migrations/059_add_world_timecycle.sql` | A | Create `world_timecycle` table |
+| `openapi/api.yaml` | M | Document timecycle override paths |
+| `docs/index.md` | M | Logged climate-overrides update |
+| `docs/progress-ledger.md` | M | Added climate-overrides entry |
+| `docs/framework-compliance.md` | M | Noted world timecycle compliance |
+| `docs/BASE_API_DOCUMENTATION.md` | M | Documented world timecycle endpoints |
+| `docs/events-and-rpcs.md` | M | Mapped climate-overrides resource |
+| `docs/db-schema.md` | M | Documented `world_timecycle` table |
+| `docs/migrations.md` | M | Listed migration 059 |
+| `docs/admin-ops.md` | M | Added world_timecycle table check |
+| `docs/security.md` | M | Noted world timecycle security |
+| `docs/testing.md` | M | Added timecycle curl examples |
+| `docs/modules/world.md` | M | Updated module documentation |
+| `docs/research-log.md` | M | Logged climate-overrides research |
+| `CHANGELOG.md` | M | Added climate-overrides entry |
 ## Startup Notes
 
 - Run `node src/bootstrap/migrate.js` to apply migration `046_add_taxi_rides.sql`.
@@ -254,3 +272,4 @@
 - Run `node src/bootstrap/migrate.js` to apply migration `057_add_k9_units.sql`.
 - Run `node src/bootstrap/migrate.js` to apply migration `056_add_character_jobs.sql`.
 - Run `node src/bootstrap/migrate.js` to apply migration `058_add_world_forecast.sql`.
+- Run `node src/bootstrap/migrate.js` to apply migration `059_add_world_timecycle.sql`.

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -597,3 +597,11 @@ Introduced K9 unit management for police characters.
 * `DELETE /v1/characters/{characterId}/k9s/{k9Id}` – retire a K9 unit (requires `X-Idempotency-Key`).
 
 All endpoints require standard authentication headers.
+
+## Update – 2025-08-25 (climate-overrides)
+
+Added world timecycle management endpoints.
+
+- `GET /v1/world/timecycle` – retrieve current timecycle override.
+- `POST /v1/world/timecycle` – set override with `preset` and optional `expiresAt`.
+- `DELETE /v1/world/timecycle` – clear override.

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -41,3 +41,4 @@
 - Ensure the `jobs` and `character_jobs` tables exist for job management.
 - Ensure the `k9_units` table exists after applying migration 057.
 - Ensure the `world_forecast` table exists for weather scheduling.
+- Ensure the `world_timecycle` table exists for timecycle overrides.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -491,3 +491,12 @@ Added `world_forecast` table for weather scheduling. K9 migration renamed to 057
 | id | INT AUTO_INCREMENT | Primary key |
 | forecast | JSON | Array of weather steps |
 | created_at | TIMESTAMP | Creation time |
+
+## world_timecycle
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INT AUTO_INCREMENT | Primary key |
+| preset | VARCHAR(64) | Active timecycle preset |
+| expires_at | TIMESTAMP | Optional expiration time |
+| created_at | TIMESTAMP | Creation time |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -52,3 +52,4 @@
 | broadcaster | Event to attempt joining the broadcaster job | `POST /v1/broadcast/attempt` |
 | srp-debug | Developer requests for runtime diagnostics | `GET /v1/debug/status` returns server metrics |
 | srp-weathersync | Resource broadcasts weather and time updates to clients | `GET /v1/world/state`, `POST /v1/world/state`, `GET /v1/world/forecast`, `POST /v1/world/forecast` |
+| climate-overrides | Resource applies custom timecycle XMLs | `/v1/world/timecycle` to set or clear presets |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -88,4 +88,4 @@ practice is supported by citations.
 | **k9 module** | K9 unit endpoints follow the established layered pattern with authentication and idempotency. |
 | **jobs module** | Job CRUD and assignment endpoints follow the established layered pattern with authentication and idempotency. |
 | **broadcaster module** | Broadcaster assignment uses character-scoped job logic and follows the established layered pattern. || **debug module** | Debug status endpoint follows the established layered pattern with authentication and rate limiting. |
-| **world module** | World state and forecast endpoints follow the established layered pattern with authentication and idempotency. |
+| **world module** | World state, forecast and timecycle endpoints follow the established layered pattern with authentication and idempotency. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -334,3 +334,12 @@ Introduced world weather forecast tracking to support the **srp-weathersync** re
 * Added world forecast endpoints and migration `058_add_world_forecast.sql`.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/world.md`.
+
+## Update – 2025-08-25
+
+Extended world module with timecycle override support for the **climate-overrides** resource (formerly koillove).
+
+* Added world timecycle endpoints and repository functions.
+* Migration `059_add_world_timecycle.sql` creates `world_timecycle` table.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/world.md`.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -56,3 +56,4 @@
 | 056_add_character_jobs.sql | Character job assignments table |
 | 057_add_k9_units.sql | Police K9 unit table |
 | 058_add_world_forecast.sql | Weather forecast schedule table |
+| 059_add_world_timecycle.sql | Timecycle override table |

--- a/backend/srp-base/docs/modules/world.md
+++ b/backend/srp-base/docs/modules/world.md
@@ -1,6 +1,6 @@
 # world module
 
-Provides APIs to read and update global world state and manage weather forecasts.
+Provides APIs to read and update global world state, manage weather forecasts and control timecycle overrides.
 
 ## Routes
 
@@ -8,6 +8,9 @@ Provides APIs to read and update global world state and manage weather forecasts
 - `POST /v1/world/state`
 - `GET /v1/world/forecast`
 - `POST /v1/world/forecast`
+- `GET /v1/world/timecycle`
+- `POST /v1/world/timecycle`
+- `DELETE /v1/world/timecycle`
 
 ## Repository Contracts
 
@@ -15,8 +18,11 @@ Provides APIs to read and update global world state and manage weather forecasts
 - `updateWorldState({ time, weather, density })` – append new world state.
 - `getForecast()` – fetch latest forecast schedule.
 - `updateForecast(forecast)` – store forecast array.
+- `getTimecycleOverride()` – fetch current timecycle override.
+- `setTimecycleOverride({ preset, expiresAt })` – set override preset and optional expiry.
+- `clearTimecycleOverride()` – remove active override.
 
 ## Edge Cases
 
-- Missing world state or forecast returns `null`.
+- Missing world state, forecast or timecycle override returns `null`.
 - Forecast defaults to an empty array when not provided.

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -52,3 +52,4 @@
 | 47 | jobsystem | Manage job definitions, assignments and duty status | Create | Added character-scoped jobs API |
 | 48 | srp-debug | Developer diagnostics endpoints | Create | Added server status API |
 | 49 | srp-weathersync | Global weather synchronization with forecast scheduling | Extend | Added world state documentation and forecast API |
+| 50 | climate-overrides | Timecycle overrides and weather preset controls | Extend | Added world timecycle API |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -235,3 +235,10 @@
 - Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.
 - Video: "NoPixel 4.0 Dev Stream – Dynamic Weather System" – https://www.youtube.com/watch?v=dQw4w9WgXcQ
 - Forum thread: "ProdigyRP 4.0 – Weather & Climate" – https://forum.example.com/prodigy-weather
+
+## Research Log – 2025-08-25 (climate-overrides)
+
+- GitHub API listing for `resources/koillove` – timecycle mod files. https://api.github.com/repos/h04X-2K/NoPixelServer/contents/resources/koillove
+- GitHub repository "DP-Hacking-Game" – NoPixel 4.0 hacking minigame references. https://github.com/01priyanshubisht/DP-Hacking-Game
+- GitHub repository "ImConsKrypt/SK-Hud" – ProdigyRP-inspired HUD concepts. https://github.com/ImConsKrypt/SK-Hud
+- Reference resources unavailable; proceeding with internal consistency only.

--- a/backend/srp-base/docs/security.md
+++ b/backend/srp-base/docs/security.md
@@ -40,4 +40,4 @@
 - Jobs routes inherit the same authentication and idempotency requirements.
 - Broadcaster routes inherit the same authentication and idempotency requirements.
 - Debug routes inherit the same authentication and rate limiting requirements.
-- World routes inherit the same authentication and idempotency requirements.
+- World routes (state, forecast and timecycle) inherit the same authentication and idempotency requirements.

--- a/backend/srp-base/docs/testing.md
+++ b/backend/srp-base/docs/testing.md
@@ -362,8 +362,7 @@ curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: k92' -H 'Content-Type: app
   http://localhost:3010/v1/characters/1/k9s/1/active
 curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: k93' -X DELETE \
   http://localhost:3010/v1/characters/1/k9s/1
-=======
-Manually verify the jobs endpoints:
+=Manually verify the jobs endpoints:
 
 ```sh
 curl -H 'X-API-Token: <token>' http://localhost:3010/v1/jobs
@@ -401,4 +400,14 @@ curl -H 'X-API-Token: <token>' http://localhost:3010/v1/world/forecast
 curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: 2' -H 'Content-Type: application/json' \
   -d '{"forecast":[{"weather":"RAIN","duration":30}]}' \
   http://localhost:3010/v1/world/forecast
+```
+
+Manually verify the world timecycle endpoints:
+
+```sh
+curl -H 'X-API-Token: <token>' http://localhost:3010/v1/world/timecycle
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: tc1' -H 'Content-Type: application/json' \
+  -d '{"preset":"w_xmas"}' \
+  http://localhost:3010/v1/world/timecycle
+curl -H 'X-API-Token: <token>' -X DELETE http://localhost:3010/v1/world/timecycle
 ```

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -1748,6 +1748,21 @@ components:
       createdAt:
         type: string
         format: date-time
+  TimecycleOverride:
+    type: object
+    properties:
+      id:
+        type: integer
+      preset:
+        type: string
+        nullable: true
+      expiresAt:
+        type: string
+        format: date-time
+        nullable: true
+      createdAt:
+        type: string
+        format: date-time
 security:
   - ApiToken: []
 paths:
@@ -7021,6 +7036,88 @@ paths:
       responses:
         '200':
           description: Update acknowledgement
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /v1/world/timecycle:
+    get:
+      summary: Get timecycle override
+      responses:
+        '200':
+          description: Current timecycle override
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/TimecycleOverride'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    post:
+      summary: Set timecycle override
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - preset
+              properties:
+                preset:
+                  type: string
+                expiresAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+      responses:
+        '200':
+          description: Update acknowledgement
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    delete:
+      summary: Clear timecycle override
+      responses:
+        '200':
+          description: Clear acknowledgement
           content:
             application/json:
               schema:

--- a/backend/srp-base/src/migrations/059_add_world_timecycle.sql
+++ b/backend/srp-base/src/migrations/059_add_world_timecycle.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS world_timecycle (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  preset VARCHAR(64) NOT NULL,
+  expires_at TIMESTAMP NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_world_timecycle_created_at ON world_timecycle (created_at);

--- a/backend/srp-base/src/repositories/worldRepository.js
+++ b/backend/srp-base/src/repositories/worldRepository.js
@@ -102,6 +102,40 @@ async function saveCoordinates(entry) {
   );
 }
 
+/**
+ * Retrieve the latest timecycle override. Returns null if no override
+ * has been set.
+ *
+ * @returns {Promise<object|null>}
+ */
+async function getTimecycleOverride() {
+  const rows = await db.query(
+    'SELECT id, preset, expires_at AS expiresAt, created_at AS createdAt FROM world_timecycle ORDER BY id DESC LIMIT 1',
+    [],
+  );
+  return rows[0] || null;
+}
+
+/**
+ * Set a new timecycle override.
+ *
+ * @param {{preset: string, expiresAt?: string}} override
+ */
+async function setTimecycleOverride(override) {
+  const { preset, expiresAt = null } = override;
+  await db.query(
+    'INSERT INTO world_timecycle (preset, expires_at) VALUES (?, ?)',
+    [preset, expiresAt],
+  );
+}
+
+/**
+ * Clear any active timecycle override.
+ */
+async function clearTimecycleOverride() {
+  await db.query('DELETE FROM world_timecycle');
+}
+
 module.exports = {
   getWorldState,
   updateWorldState,
@@ -109,4 +143,7 @@ module.exports = {
   updateForecast,
   recordEvent,
   saveCoordinates,
+  getTimecycleOverride,
+  setTimecycleOverride,
+  clearTimecycleOverride,
 };

--- a/backend/srp-base/src/routes/world.routes.js
+++ b/backend/srp-base/src/routes/world.routes.js
@@ -58,6 +58,38 @@ router.post('/v1/world/forecast', async (req, res, next) => {
   }
 });
 
+// Fetch the current timecycle override. Returns null if none is set.
+router.get('/v1/world/timecycle', async (req, res, next) => {
+  try {
+    const override = await worldRepo.getTimecycleOverride();
+    sendOk(res, override, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Set a timecycle override. Clients should include idempotency and
+// HMAC headers to authenticate and avoid duplicates.
+router.post('/v1/world/timecycle', async (req, res, next) => {
+  try {
+    const { preset, expiresAt } = req.body || {};
+    await worldRepo.setTimecycleOverride({ preset, expiresAt });
+    sendOk(res, { message: 'Timecycle override set' }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Clear any active timecycle override.
+router.delete('/v1/world/timecycle', async (req, res, next) => {
+  try {
+    await worldRepo.clearTimecycleOverride();
+    sendOk(res, { message: 'Timecycle override cleared' }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
 // Record a death event.  Accepts a JSON body with playerId,
 // killerId (optional), weapon (optional) and coords.  This
 // endpoint simply persists the event; consumers can subscribe to


### PR DESCRIPTION
## Summary
- extend world module with timecycle override management for climate-overrides resource
- add `/v1/world/timecycle` endpoints and `world_timecycle` table
- document new API, migration and tests

## Testing
- manual curl examples for world timecycle endpoints


------
https://chatgpt.com/codex/tasks/task_e_68acb7284724832da3d5e91f017af75e