### PR TITLE
srp-base: realtime pushes for Wise cluster

### DIFF
--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -6,12 +6,12 @@
 | PolicePack | Resource emits events for evidence custody updates and character selections | Custody via `GET/POST /v1/evidence/items/{id}/custody`; selection via `POST /v1/accounts/{accountId}/characters/{characterId}:select` |
 | InteractSound | Resource triggers audio playback events specifying sound name and volume to target clients | `POST /v1/interact-sound/plays` logs and broadcasts; history via `GET /v1/interact-sound/plays/:characterId` |
 | PolyZone | Resource defines polygonal zones for triggers | `GET /v1/zones`, `POST /v1/zones`, `DELETE /v1/zones/:id` manage zone records; `zone.created` and `zone.deleted` pushed via WebSocket/webhooks |
-| Wise Audio | Resource manages character soundboard tracks | `GET /v1/wise-audio/tracks/:characterId`, `POST /v1/wise-audio/tracks` |
-| Wise Imports | Resource manages vehicle import orders | `GET /v1/wise-imports/orders/:characterId`, `POST /v1/wise-imports/orders` |
+| Wise Audio | Resource manages character soundboard tracks | `GET /v1/wise-audio/tracks/:characterId`, `POST /v1/wise-audio/tracks` → pushes `wise-audio.track.created` |
+| Wise Imports | Resource manages vehicle import orders | `GET /v1/wise-imports/orders/:characterId`, `POST /v1/wise-imports/orders` → pushes `wise-imports.order.created` |
 | import-Pack2 | Resource manages vehicle import packages with pricing and cancellation | `GET /v1/import-pack/orders/character/{characterId}`, `GET /v1/import-pack/orders/{id}`, `POST /v1/import-pack/orders`, `POST /v1/import-pack/orders/{id}/deliver`, `POST /v1/import-pack/orders/{id}/cancel` |
 | WiseGuy-Vanilla | Base resource using account-scoped character management | `GET/POST/DELETE/POST select/GET selected /v1/accounts/{accountId}/characters` |
-| Wise-UC | Resource manages undercover aliases for characters | `GET /v1/wise-uc/profiles/:characterId`, `POST /v1/wise-uc/profiles` |
-| WiseGuy-Wheels | Resource records wheel spin outcomes per character | `GET /v1/wise-wheels/spins/:characterId`, `POST /v1/wise-wheels/spins` |
+| Wise-UC | Resource manages undercover aliases for characters | `GET /v1/wise-uc/profiles/:characterId`, `POST /v1/wise-uc/profiles` → pushes `wise-uc.profile.upserted` |
+| WiseGuy-Wheels | Resource records wheel spin outcomes per character | `GET /v1/wise-wheels/spins/:characterId`, `POST /v1/wise-wheels/spins` → pushes `wise-wheels.spin.created` |
 | assets | Resource stores media or item assets linked to characters | `GET /v1/assets`, `GET /v1/assets/{id}`, `POST /v1/assets`, `DELETE /v1/assets/{id}` |
 | assets_clothes | Resource saves and retrieves character outfits | `GET /v1/clothes`, `POST /v1/clothes`, `DELETE /v1/clothes/{id}` |
 | apartments | Resource triggers events when characters claim or vacate apartments | `GET /v1/apartments` with optional `characterId` filter and resident assignment endpoints |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -46,6 +46,7 @@ practice is supported by citations.
 | **Wise Imports module** | Import order endpoints follow the established layered pattern with authentication and idempotency. |
 | **Wise UC module** | Undercover profile endpoints follow the established layered pattern with authentication and idempotency. |
 | **Wise Wheels module** | Wheel spin endpoints follow the established layered pattern with authentication and idempotency. |
+| **Wise cluster realtime** | Wise Audio/Imports/UC/Wheels broadcast create events over WebSockets and webhooks, reducing client polling. |
 | **assets module** | Asset endpoints follow the established layered pattern with authentication, rate limiting and idempotency. |
 | **clothes module** | Clothing endpoints follow the established layered pattern with authentication, rate limiting and idempotency. |
 | **economy module** | Banking endpoints follow the established layered pattern with authentication and idempotency. |

--- a/backend/srp-base/docs/modules/wise-audio.md
+++ b/backend/srp-base/docs/modules/wise-audio.md
@@ -11,7 +11,7 @@ There is no feature flag for this module; it is always enabled.
 | Method & Path | Description | Rate Limit | Auth | Idempotent | Request Body | Response |
 |---|---|---|---|---|---|---|
 | **GET `/v1/wise-audio/tracks/:characterId`** | Retrieve up to 50 audio tracks for the specified character. | n/a | Required | Yes | None | `200 { ok, data: { tracks: WiseAudioTrack[] }, requestId, traceId }` |
-| **POST `/v1/wise-audio/tracks`** | Store a new audio track. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseAudioTrackCreateRequest` | `200 { ok, data: { track: WiseAudioTrack }, requestId, traceId }` |
+| **POST `/v1/wise-audio/tracks`** | Store a new audio track and broadcast `wise-audio.track.created` via WebSocket and webhook. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseAudioTrackCreateRequest` | `200 { ok, data: { track: WiseAudioTrack }, requestId, traceId }` |
 
 ### Schemas
 
@@ -35,7 +35,7 @@ There is no feature flag for this module; it is always enabled.
 
 * **Repository:** `src/repositories/wiseAudioRepository.js` provides `createTrack` and `listTracksByCharacter`.
 * **Migration:** `src/migrations/026_add_wise_audio.sql` creates the `wise_audio_tracks` table.
-* **Routes:** `src/routes/wiseAudio.routes.js` defines the HTTP endpoints and validation.
+* **Routes:** `src/routes/wiseAudio.routes.js` defines the HTTP endpoints, pushes WebSocket events and dispatches webhooks.
 * **OpenAPI:** `openapi/api.yaml` documents the schemas and `/v1/wise-audio/tracks` paths.
 
 ## Future work

--- a/backend/srp-base/docs/modules/wise-imports.md
+++ b/backend/srp-base/docs/modules/wise-imports.md
@@ -11,7 +11,7 @@ There is no feature flag for this module; it is always enabled.
 | Method & Path | Description | Rate Limit | Auth | Idempotent | Request Body | Response |
 |---|---|---|---|---|---|---|
 | **GET `/v1/wise-imports/orders/:characterId`** | Retrieve up to 50 import orders for the specified character. | n/a | Required | Yes | None | `200 { ok, data: { orders: WiseImportOrder[] }, requestId, traceId }` |
-| **POST `/v1/wise-imports/orders`** | Store a new vehicle import order. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseImportOrderCreateRequest` | `200 { ok, data: { order: WiseImportOrder }, requestId, traceId }` |
+| **POST `/v1/wise-imports/orders`** | Store a new vehicle import order and broadcast `wise-imports.order.created` via WebSocket and webhook. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseImportOrderCreateRequest` | `200 { ok, data: { order: WiseImportOrder }, requestId, traceId }` |
 
 ### Schemas
 
@@ -34,7 +34,7 @@ There is no feature flag for this module; it is always enabled.
 
 * **Repository:** `src/repositories/wiseImportsRepository.js` provides `createOrder` and `listOrdersByCharacter`.
 * **Migration:** `src/migrations/027_add_wise_imports.sql` creates the `wise_import_orders` table.
-* **Routes:** `src/routes/wiseImports.routes.js` defines the HTTP endpoints and validation.
+* **Routes:** `src/routes/wiseImports.routes.js` defines the HTTP endpoints, pushes WebSocket events and dispatches webhooks.
 * **OpenAPI:** `openapi/api.yaml` documents the schemas and `/v1/wise-imports/orders` paths.
 
 ## Future work

--- a/backend/srp-base/docs/modules/wise-uc.md
+++ b/backend/srp-base/docs/modules/wise-uc.md
@@ -11,7 +11,7 @@ There is no feature flag for this module; it is always enabled.
 | Method & Path | Description | Rate Limit | Auth | Idempotent | Request Body | Response |
 |---|---|---|---|---|---|---|
 | **GET `/v1/wise-uc/profiles/:characterId`** | Retrieve undercover profile for the specified character. | n/a | Required | Yes | None | `200 { ok, data: { profile: WiseUCProfile }, requestId, traceId }` |
-| **POST `/v1/wise-uc/profiles`** | Create or update an undercover profile. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseUCProfileCreateRequest` | `200 { ok, data: { profile: WiseUCProfile }, requestId, traceId }` |
+| **POST `/v1/wise-uc/profiles`** | Create or update an undercover profile and broadcast `wise-uc.profile.upserted` via WebSocket and webhook. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseUCProfileCreateRequest` | `200 { ok, data: { profile: WiseUCProfile }, requestId, traceId }` |
 
 ### Schemas
 
@@ -35,7 +35,7 @@ There is no feature flag for this module; it is always enabled.
 
 * **Repository:** `src/repositories/wiseUCRepository.js` provides `upsertProfile` and `getProfileByCharacter`.
 * **Migration:** `src/migrations/028_add_wise_uc.sql` creates the `wise_uc_profiles` table.
-* **Routes:** `src/routes/wiseUC.routes.js` defines the HTTP endpoints and validation.
+* **Routes:** `src/routes/wiseUC.routes.js` defines the HTTP endpoints, pushes WebSocket events and dispatches webhooks.
 * **OpenAPI:** `openapi/api.yaml` documents the schemas and `/v1/wise-uc/profiles` paths.
 
 ## Future work

--- a/backend/srp-base/docs/modules/wise-wheels.md
+++ b/backend/srp-base/docs/modules/wise-wheels.md
@@ -11,7 +11,7 @@ There is no feature flag for this module; it is always enabled.
 | Method & Path | Description | Rate Limit | Auth | Idempotent | Request Body | Response |
 |---|---|---|---|---|---|---|
 | **GET `/v1/wise-wheels/spins/:characterId`** | Retrieve up to 50 wheel spins for the specified character. | n/a | Required | Yes | None | `200 { ok, data: { spins: WiseWheelsSpin[] }, requestId, traceId }` |
-| **POST `/v1/wise-wheels/spins`** | Record a wheel spin result. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseWheelsSpinCreateRequest` | `200 { ok, data: { spin: WiseWheelsSpin }, requestId, traceId }` |
+| **POST `/v1/wise-wheels/spins`** | Record a wheel spin result and broadcast `wise-wheels.spin.created` via WebSocket and webhook. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseWheelsSpinCreateRequest` | `200 { ok, data: { spin: WiseWheelsSpin }, requestId, traceId }` |
 
 ### Schemas
 
@@ -33,7 +33,7 @@ There is no feature flag for this module; it is always enabled.
 
 * **Repository:** `src/repositories/wiseWheelsRepository.js` provides `createSpin` and `listSpinsByCharacter`.
 * **Migration:** `src/migrations/029_add_wise_wheels.sql` creates the `wise_wheels_spins` table.
-* **Routes:** `src/routes/wiseWheels.routes.js` defines the HTTP endpoints and validation.
+* **Routes:** `src/routes/wiseWheels.routes.js` defines the HTTP endpoints, pushes WebSocket events and dispatches webhooks.
 * **OpenAPI:** `openapi/api.yaml` documents the schemas and `/v1/wise-wheels/spins` paths.
 
 ## Future work

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -1,0 +1,8 @@
+# Naming Map
+
+| Source Name | SRP Name |
+|---|---|
+| WiseGuy-Audio | wise-audio |
+| WiseGuy-Imports | wise-imports |
+| Wise-UC | wise-uc |
+| WiseGuy-Wheels | wise-wheels |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -60,3 +60,4 @@
 | 54 | InteractSound cluster | Sound play logging with WS/webhooks and retention scheduler | Extend | Broadcast plays and purge stale records |
 | 55 | Police dispatch | Alert broadcasting and retention | Extend | WS/webhook push and hourly purge |
 | 56 | PolyZone expiry & pushes | Zone expiration and real-time broadcasts | Extend | Added expiresAt field and scheduler |
+| 57 | Wise cluster realtime | WebSocket/webhook pushes for Wise Audio/Imports/UC/Wheels | Extend | Broadcast create events |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -259,3 +259,8 @@
 
 - Cloned `https://github.com/h04X-2K/NoPixelServer` and reviewed `resources/PolyZone` for zone definition patterns.
 - Reviewed ND Core and ESX zone handling to align naming and expiration flows.
+
+## Research Log – 2025-08-25 (Wise cluster realtime)
+
+- Reviewed `ws` WebSocket library documentation for broadcast patterns: https://github.com/websockets/ws
+- Reference resources unavailable; proceeding with internal consistency only.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,20 +1,18 @@
-# Run Summary – 2025-02-14
+# Run Summary – 2025-08-25
 
 ## Modules
-- Zones expiration + real-time pushes
+- Wise cluster realtime pushes (Audio, Imports, UC, Wheels)
 
 ## Migrations
-- 062_add_zone_expiry.sql
+- None
 
 ## Documentation Updated
-- index.md
 - progress-ledger.md
 - framework-compliance.md
-- BASE_API_DOCUMENTATION.md
 - events-and-rpcs.md
-- db-schema.md
-- migrations.md
-- admin-ops.md
-- testing.md
-- modules/zones.md
+- modules/wise-audio.md
+- modules/wise-imports.md
+- modules/wise-uc.md
+- modules/wise-wheels.md
 - research-log.md
+- naming-map.md

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -4796,6 +4796,7 @@ paths:
   /v1/wise-audio/tracks:
     post:
       summary: Create an audio track
+      description: Stores a track and broadcasts `wise-audio.track.created` via WebSocket and webhooks.
       operationId: createWiseAudioTrack
       requestBody:
         required: true
@@ -4860,6 +4861,7 @@ paths:
   /v1/wise-imports/orders:
     post:
       summary: Create an import order
+      description: Stores an order and broadcasts `wise-imports.order.created` via WebSocket and webhooks.
       operationId: createWiseImportOrder
       requestBody:
         required: true
@@ -5119,6 +5121,7 @@ paths:
   /v1/wise-uc/profiles:
     post:
       summary: Create or update an undercover profile
+      description: Upserts a profile and broadcasts `wise-uc.profile.upserted` via WebSocket and webhooks.
       operationId: upsertWiseUCProfile
       requestBody:
         required: true
@@ -5183,6 +5186,7 @@ paths:
   /v1/wise-wheels/spins:
     post:
       summary: Record a wheel spin result
+      description: Stores a spin result and broadcasts `wise-wheels.spin.created` via WebSocket and webhooks.
       operationId: createWiseWheelsSpin
       requestBody:
         required: true

--- a/backend/srp-base/package.json
+++ b/backend/srp-base/package.json
@@ -15,7 +15,8 @@
     "mysql2": "^3.5.2",
     "pino": "^8.15.0",
     "prom-client": "^14.1.1",
-    "uuid": "^9.0.1"
+    "uuid": "^9.0.1",
+    "ws": "^8.17.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/backend/srp-base/src/routes/wiseAudio.routes.js
+++ b/backend/srp-base/src/routes/wiseAudio.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const repo = require('../repositories/wiseAudioRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -27,6 +29,8 @@ router.post('/v1/wise-audio/tracks', async (req, res) => {
   }
   try {
     const track = await repo.createTrack({ characterId, label, url });
+    websocket.broadcast('wise-audio', 'track-created', { track });
+    hooks.dispatch('wise-audio.track.created', track);
     sendOk(res, { track }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'WISE_AUDIO_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);

--- a/backend/srp-base/src/routes/wiseImports.routes.js
+++ b/backend/srp-base/src/routes/wiseImports.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const repo = require('../repositories/wiseImportsRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -27,6 +29,8 @@ router.post('/v1/wise-imports/orders', async (req, res) => {
   }
   try {
     const order = await repo.createOrder({ characterId, model });
+    websocket.broadcast('wise-imports', 'order-created', { order });
+    hooks.dispatch('wise-imports.order.created', order);
     sendOk(res, { order }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'WISE_IMPORTS_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);

--- a/backend/srp-base/src/routes/wiseUC.routes.js
+++ b/backend/srp-base/src/routes/wiseUC.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const repo = require('../repositories/wiseUCRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -51,6 +53,8 @@ router.post('/v1/wise-uc/profiles', async (req, res) => {
   }
   try {
     const profile = await repo.upsertProfile({ characterId, alias, active });
+    websocket.broadcast('wise-uc', 'profile-upserted', { profile });
+    hooks.dispatch('wise-uc.profile.upserted', profile);
     sendOk(res, { profile }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(

--- a/backend/srp-base/src/routes/wiseWheels.routes.js
+++ b/backend/srp-base/src/routes/wiseWheels.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const repo = require('../repositories/wiseWheelsRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -33,6 +35,8 @@ router.post('/v1/wise-wheels/spins', async (req, res) => {
   }
   try {
     const spin = await repo.createSpin({ characterId, prize });
+    websocket.broadcast('wise-wheels', 'spin-created', { spin });
+    hooks.dispatch('wise-wheels.spin.created', spin);
     sendOk(res, { spin }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(


### PR DESCRIPTION
## Summary
- broadcast and webhook Wise Audio track creation
- push Wise Imports orders, Wise UC profiles, and Wise Wheels spins
- document naming map and update API spec for Wise cluster

## Testing
- `API_TOKEN=1 node -e "require('./src/routes/wiseAudio.routes')"`
- `API_TOKEN=1 node -e "require('./src/routes/wiseImports.routes')"`


------
https://chatgpt.com/codex/tasks/task_e_68acccaf9b74832d9de0978680a8ab49