### PR TITLE
srp-base: Wise Imports scheduler and delivery

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1244,3 +1244,18 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Drop `expires_at` column from `zones` and remove zone scheduler/broadcast logic.
+
+## 2025-03-15 – Wise Imports scheduler & delivery
+
+### Added
+* Scheduler task to promote pending import orders to `ready` with WebSocket and webhook pushes.
+* `POST /v1/wise-imports/orders/{id}/deliver` endpoint to finalize deliveries.
+
+### Migrations
+* `063_update_wise_import_orders.sql`
+
+### Risks
+* Misconfigured interval may spam readiness events.
+
+### Rollback
+* Remove wise imports scheduler registration and delivery route; drop `updated_at` column and status index from `wise_import_orders`.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,29 +1,29 @@
-# Manifest – 2025-02-14
+# Manifest
 
-## Summary
-- Added zone expiration with scheduler purge and real-time broadcasts.
+- Added ready notifier scheduler and delivery endpoint for Wise Imports.
+- Introduced `updated_at` column and status index for import orders.
+- Documented new endpoints and database changes across docs.
 
-## File Changes
-| Path | Status | Notes |
+| File | Action | Note |
 |---|---|---|
-| `src/repositories/zonesRepository.js` | M | add expiresAt and purge helper |
-| `src/routes/zones.routes.js` | M | broadcast events, idempotency checks |
-| `src/tasks/zones.js` | A | purge expired zones and broadcast |
-| `src/server.js` | M | register zone-expiry scheduler |
-| `src/migrations/062_add_zone_expiry.sql` | A | add expires_at column/index |
-| `openapi/api.yaml` | M | document expiresAt |
-| `docs/index.md` | M | log PolyZone update |
-| `docs/progress-ledger.md` | M | add PolyZone entry |
-| `docs/framework-compliance.md` | M | note zone expiration compliance |
-| `docs/BASE_API_DOCUMENTATION.md` | M | zone API updates |
-| `docs/events-and-rpcs.md` | M | map zone push events |
-| `docs/db-schema.md` | M | document expires_at column |
-| `docs/migrations.md` | M | record zone expiry migration |
-| `docs/admin-ops.md` | M | zone expiry maintenance note |
-| `docs/testing.md` | M | include expiresAt in examples |
-| `docs/modules/zones.md` | M | document expiration and pushes |
-| `docs/research-log.md` | M | log PolyZone references |
-| `docs/run-docs.md` | M | run summary |
-
-## Startup Notes
-- Apply migration `062_add_zone_expiry.sql` via `node src/bootstrap/migrate.js`.
+| src/tasks/wiseImports.js | A | Periodically marks pending orders ready |
+| src/repositories/wiseImportsRepository.js | M | Status transitions and delivery logic |
+| src/routes/wiseImports.routes.js | M | Delivery endpoint & pushes |
+| src/bootstrap/scheduler.js | M | Persist last run via cron jobs |
+| src/repositories/cronRepository.js | M | Added `updateLastRun` helper |
+| src/migrations/063_update_wise_import_orders.sql | A | Adds `updated_at` column & status index |
+| src/server.js | M | Registers Wise Imports scheduler |
+| openapi/api.yaml | M | Schemas and deliver path |
+| docs/modules/wise-imports.md | M | Documented scheduler and delivery |
+| docs/progress-ledger.md | M | Logged Wise Imports ready notifier |
+| docs/index.md | M | Run summary for Wise Imports update |
+| docs/BASE_API_DOCUMENTATION.md | M | Added deliver endpoint |
+| docs/db-schema.md | M | Documented updated_at column |
+| docs/migrations.md | M | Listed new migration |
+| docs/admin-ops.md | M | Note on status index |
+| docs/events-and-rpcs.md | M | Updated event mapping |
+| docs/framework-compliance.md | M | Outstanding work for Wise Imports |
+| docs/testing.md | M | Curl example for delivery |
+| docs/research-log.md | M | Logged reference sources |
+| docs/run-docs.md | M | Summary of this run |
+| CHANGELOG.md | M | Release notes for scheduler & delivery |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -435,6 +435,7 @@ To support all features present in the original server resources at the framewor
 - **srp-wise-imports** – Manages vehicle import orders.
   - `GET /v1/wise-imports/orders/{characterId}` – List import orders for a character.
   - `POST /v1/wise-imports/orders` – Create an order with `characterId` and `model`.
+  - `POST /v1/wise-imports/orders/{id}/deliver` – Mark a ready order as delivered.
 - **srp-import-pack** – Tracks vehicle import packages.
   - `GET /v1/import-pack/orders/character/{characterId}` – List import package orders for a character.
   - `GET /v1/import-pack/orders/{id}?characterId={characterId}` – Fetch a specific order.

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -14,6 +14,7 @@
 - Ensure `zones` table includes `expires_at`; expired zones are purged hourly by `zone-expiry-purge` scheduler.
 - Ensure the `wise_audio_tracks` table exists for character audio tracks.
 - Ensure the `wise_import_orders` table exists for vehicle import orders.
+  - Ensure `wise_import_orders` includes `updated_at` column and index `idx_wise_import_orders_status`.
 - Ensure the `wise_uc_profiles` table exists for undercover aliases.
 - Ensure the `wise_wheels_spins` table exists for wheel spin history.
 - Ensure the `assets` table exists for character asset records.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -133,7 +133,8 @@ Added `world_forecast` table for weather scheduling. K9 migration renamed to 057
 | character_id | BIGINT | Owning character |
 | model | VARCHAR(64) | Vehicle model identifier |
 | status | VARCHAR(32) | Order status |
-| created_at | BIGINT | Epoch milliseconds |
+| created_at | BIGINT | Created timestamp (ms) |
+| updated_at | BIGINT | Last status update timestamp (ms) |
 
 ## wise_uc_profiles
 

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -7,7 +7,7 @@
 | InteractSound | Resource triggers audio playback events specifying sound name and volume to target clients | `POST /v1/interact-sound/plays` logs and broadcasts; history via `GET /v1/interact-sound/plays/:characterId` |
 | PolyZone | Resource defines polygonal zones for triggers | `GET /v1/zones`, `POST /v1/zones`, `DELETE /v1/zones/:id` manage zone records; `zone.created` and `zone.deleted` pushed via WebSocket/webhooks |
 | Wise Audio | Resource manages character soundboard tracks | `GET /v1/wise-audio/tracks/:characterId`, `POST /v1/wise-audio/tracks` → pushes `wise-audio.track.created` |
-| Wise Imports | Resource manages vehicle import orders | `GET /v1/wise-imports/orders/:characterId`, `POST /v1/wise-imports/orders` → pushes `wise-imports.order.created` |
+| Wise Imports | Resource manages vehicle import orders | `GET /v1/wise-imports/orders/:characterId`, `POST /v1/wise-imports/orders`, `POST /v1/wise-imports/orders/{id}/deliver` → pushes `wise-imports.order.created`, scheduler pushes `wise-imports.order.ready`, delivery pushes `wise-imports.order.delivered` |
 | import-Pack2 | Resource manages vehicle import packages with pricing and cancellation | `GET /v1/import-pack/orders/character/{characterId}`, `GET /v1/import-pack/orders/{id}`, `POST /v1/import-pack/orders`, `POST /v1/import-pack/orders/{id}/deliver`, `POST /v1/import-pack/orders/{id}/cancel` |
 | WiseGuy-Vanilla | Base resource using account-scoped character management | `GET/POST/DELETE/POST select/GET selected /v1/accounts/{accountId}/characters` |
 | Wise-UC | Resource manages undercover aliases for characters | `GET /v1/wise-uc/profiles/:characterId`, `POST /v1/wise-uc/profiles` → pushes `wise-uc.profile.upserted` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -66,6 +66,7 @@ practice is supported by citations.
 * **Webhook endpoints:** admin CRUD added; implement secret rotation.
 * **Base API documentation:** update global API docs for new realtime components.
 * **Dispatch workflow:** implement call assignment and unit tracking.
+* **Wise Imports:** add order cancellation and ownership integration.
 | **baseevents module** | Base event logging endpoints follow the established layered pattern with authentication and idempotency. |
 | **boatshop module** | Boatshop endpoints follow the established layered pattern with authentication and idempotency. |
 | **camera module** | Photo storage endpoints follow the established layered pattern with authentication and idempotency. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -118,6 +118,15 @@ Introduced base event logging to support the **baseevents** resource.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/baseevents.md`.
 
+## Update – 2025-03-15
+
+Enhanced the Wise Imports module with scheduler-driven order readiness and delivery confirmation.
+
+* Added background task promoting pending orders to ready status with real-time pushes.
+* Added `POST /v1/wise-imports/orders/{id}/deliver` endpoint to finalize deliveries.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/wise-imports.md`.
+
 ## Update – 2025-08-24
 
 Introduced boat catalog and purchase endpoints to support the **boatshop** resource.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -60,3 +60,4 @@
 | 060_add_world_timecycle.sql | Timecycle override table |
 | 061_add_dispatch_alert_index.sql | Index dispatch_alerts created_at |
 | 062_add_zone_expiry.sql | Add expires_at to zones |
+| 063_update_wise_import_orders.sql | Add updated_at column and status index to wise_import_orders |

--- a/backend/srp-base/docs/modules/wise-imports.md
+++ b/backend/srp-base/docs/modules/wise-imports.md
@@ -12,6 +12,7 @@ There is no feature flag for this module; it is always enabled.
 |---|---|---|---|---|---|---|
 | **GET `/v1/wise-imports/orders/:characterId`** | Retrieve up to 50 import orders for the specified character. | n/a | Required | Yes | None | `200 { ok, data: { orders: WiseImportOrder[] }, requestId, traceId }` |
 | **POST `/v1/wise-imports/orders`** | Store a new vehicle import order and broadcast `wise-imports.order.created` via WebSocket and webhook. | n/a | Required | Yes (use `X-Idempotency-Key`) | `WiseImportOrderCreateRequest` | `200 { ok, data: { order: WiseImportOrder }, requestId, traceId }` |
+| **POST `/v1/wise-imports/orders/{id}/deliver`** | Mark a ready order as delivered, broadcasting `wise-imports.order.delivered`. | n/a | Required | Yes (use `X-Idempotency-Key`) | `{ characterId: string }` | `200 { ok, data: { delivered: true }, requestId, traceId }` |
 
 ### Schemas
 
@@ -22,6 +23,7 @@ There is no feature flag for this module; it is always enabled.
   model: string
   status: string
   createdAt: integer (unix ms)
+  updatedAt: integer (unix ms)
   ```
 
 * **WiseImportOrderCreateRequest** –
@@ -32,11 +34,12 @@ There is no feature flag for this module; it is always enabled.
 
 ## Implementation details
 
-* **Repository:** `src/repositories/wiseImportsRepository.js` provides `createOrder` and `listOrdersByCharacter`.
-* **Migration:** `src/migrations/027_add_wise_imports.sql` creates the `wise_import_orders` table.
+* **Repository:** `src/repositories/wiseImportsRepository.js` provides `createOrder`, `listOrdersByCharacter`, status updates and delivery.
+* **Scheduler:** `src/tasks/wiseImports.js` promotes pending orders to `ready` and pushes `wise-imports.order.ready`.
+* **Migration:** `src/migrations/027_add_wise_imports.sql` creates the `wise_import_orders` table and `063_update_wise_import_orders.sql` adds `updated_at` and status index.
 * **Routes:** `src/routes/wiseImports.routes.js` defines the HTTP endpoints, pushes WebSocket events and dispatches webhooks.
 * **OpenAPI:** `openapi/api.yaml` documents the schemas and `/v1/wise-imports/orders` paths.
 
 ## Future work
 
-Future iterations may allow updating order status or cancelling orders.
+Add order cancellation and vehicle integration once workflows finalize.

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -61,3 +61,4 @@
 | 55 | Police dispatch | Alert broadcasting and retention | Extend | WS/webhook push and hourly purge |
 | 56 | PolyZone expiry & pushes | Zone expiration and real-time broadcasts | Extend | Added expiresAt field and scheduler |
 | 57 | Wise cluster realtime | WebSocket/webhook pushes for Wise Audio/Imports/UC/Wheels | Extend | Broadcast create events |
+| 58 | Wise Imports ready notifier | Promote pending import orders to ready via scheduler and delivery endpoint | Extend | Added ready scheduler and `/v1/wise-imports/orders/{id}/deliver` |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -78,6 +78,11 @@
 # Research Log – 2025-08-24 (apartments)
 
 - Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.
+
+# Research Log – 2025-03-15 (Wise Imports ready notifier)
+
+- Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/WiseGuy-Imports` for vehicle import context.
+- Reviewed vehicle import order flows in ESX (`es_extended`) and ND (`ND_Core`) for status transition patterns.
 # Research Log – 2025-08-24 (Boatshop)
 
 - Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,18 +1,20 @@
-# Run Summary – 2025-08-25
+# Run Summary – 2025-03-15
 
 ## Modules
-- Wise cluster realtime pushes (Audio, Imports, UC, Wheels)
+- Wise Imports ready notifier and delivery endpoint
 
 ## Migrations
-- None
+- 063_update_wise_import_orders.sql
 
 ## Documentation Updated
-- progress-ledger.md
-- framework-compliance.md
-- events-and-rpcs.md
-- modules/wise-audio.md
-- modules/wise-imports.md
-- modules/wise-uc.md
-- modules/wise-wheels.md
-- research-log.md
-- naming-map.md
+- docs/index.md
+- docs/progress-ledger.md
+- docs/framework-compliance.md
+- docs/events-and-rpcs.md
+- docs/BASE_API_DOCUMENTATION.md
+- docs/db-schema.md
+- docs/migrations.md
+- docs/admin-ops.md
+- docs/testing.md
+- docs/modules/wise-imports.md
+- docs/research-log.md

--- a/backend/srp-base/docs/testing.md
+++ b/backend/srp-base/docs/testing.md
@@ -79,6 +79,9 @@ curl -H 'X-API-Token: <token>' http://localhost:3010/v1/wise-imports/orders/char
 curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: wi1' -H 'Content-Type: application/json' \
   -d '{"characterId":"char123","model":"sultan"}' \
   http://localhost:3010/v1/wise-imports/orders
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: wi2' -H 'Content-Type: application/json' \
+  -d '{"characterId":"char123"}' \
+  http://localhost:3010/v1/wise-imports/orders/1/deliver
 ```
 
 Manually verify the wise uc endpoints:

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -743,6 +743,9 @@ components:
         createdAt:
           type: integer
           format: int64
+        updatedAt:
+          type: integer
+          format: int64
     WiseImportOrderCreateRequest:
       type: object
       required:
@@ -4905,6 +4908,51 @@ paths:
           description: List of orders
           content:
             application/json:
+          schema:
+            type: object
+            properties:
+              ok:
+                type: boolean
+              data:
+                type: object
+                properties:
+                  orders:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/WiseImportOrder'
+              requestId:
+                type: string
+              traceId:
+                type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+  /v1/wise-imports/orders/{id}/deliver:
+    post:
+      summary: Mark an import order as delivered
+      description: Updates status to delivered and broadcasts `wise-imports.order.delivered`.
+      operationId: deliverWiseImportOrder
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - characterId
+              properties:
+                characterId:
+                  type: string
+      responses:
+        '200':
+          description: Order delivered
+          content:
+            application/json:
               schema:
                 type: object
                 properties:
@@ -4913,10 +4961,8 @@ paths:
                   data:
                     type: object
                     properties:
-                      orders:
-                        type: array
-                        items:
-                          $ref: '#/components/schemas/WiseImportOrder'
+                      delivered:
+                        type: boolean
                   requestId:
                     type: string
                   traceId:

--- a/backend/srp-base/src/bootstrap/scheduler.js
+++ b/backend/srp-base/src/bootstrap/scheduler.js
@@ -1,4 +1,5 @@
 const logger = require('../utils/logger');
+const cronRepo = require('../repositories/cronRepository');
 
 const tasks = [];
 
@@ -9,6 +10,9 @@ function schedule(task) {
     task.lastRun = Date.now();
     try {
       await task.fn(task);
+      if (task.persistName) {
+        await cronRepo.updateLastRun(task.persistName, new Date(task.lastRun).toISOString());
+      }
     } catch (err) {
       logger.error({ err }, `Scheduler task ${task.name} failed`);
     }
@@ -23,6 +27,7 @@ function register(name, fn, intervalMs, options = {}) {
     fn,
     intervalMs,
     jitter: options.jitter || 0,
+    persistName: options.persistName,
     lastRun: 0,
     nextRun: Date.now() + intervalMs,
   };

--- a/backend/srp-base/src/migrations/063_update_wise_import_orders.sql
+++ b/backend/srp-base/src/migrations/063_update_wise_import_orders.sql
@@ -1,0 +1,3 @@
+ALTER TABLE wise_import_orders
+  ADD COLUMN IF NOT EXISTS updated_at BIGINT NOT NULL DEFAULT 0,
+  ADD INDEX IF NOT EXISTS idx_wise_import_orders_status (status);

--- a/backend/srp-base/src/repositories/cronRepository.js
+++ b/backend/srp-base/src/repositories/cronRepository.js
@@ -63,7 +63,12 @@ async function createJob({ name, schedule, payload, accountId, characterId, prio
   };
 }
 
+async function updateLastRun(name, lastRun) {
+  await db.query('UPDATE cron_jobs SET last_run = ? WHERE name = ?', [lastRun, name]);
+}
+
 module.exports = {
   getAllJobs,
   createJob,
+  updateLastRun,
 };

--- a/backend/srp-base/src/repositories/wiseImportsRepository.js
+++ b/backend/srp-base/src/repositories/wiseImportsRepository.js
@@ -3,19 +3,52 @@ const db = require('./db');
 async function createOrder({ characterId, model }) {
   const status = 'pending';
   const createdAt = Date.now();
+  const updatedAt = createdAt;
   const result = await db.query(
-    'INSERT INTO wise_import_orders (character_id, model, status, created_at) VALUES (?, ?, ?, ?)',
-    [characterId, model, status, createdAt],
+    'INSERT INTO wise_import_orders (character_id, model, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+    [characterId, model, status, createdAt, updatedAt],
   );
-  return { id: result.insertId, characterId, model, status, createdAt };
+  return { id: result.insertId, characterId, model, status, createdAt, updatedAt };
 }
 
 async function listOrdersByCharacter(characterId, limit = 50) {
   const rows = await db.query(
-    'SELECT id, character_id AS characterId, model, status, created_at AS createdAt FROM wise_import_orders WHERE character_id = ? ORDER BY created_at DESC LIMIT ?',
+    'SELECT id, character_id AS characterId, model, status, created_at AS createdAt, updated_at AS updatedAt FROM wise_import_orders WHERE character_id = ? ORDER BY created_at DESC LIMIT ?',
     [characterId, limit],
   );
   return rows;
 }
 
-module.exports = { createOrder, listOrdersByCharacter };
+async function listPendingOlderThan(cutoff) {
+  const rows = await db.query(
+    'SELECT id, character_id AS characterId, model FROM wise_import_orders WHERE status = ? AND created_at < ?',
+    ['pending', cutoff],
+  );
+  return rows;
+}
+
+async function markReady(id) {
+  const updatedAt = Date.now();
+  const res = await db.query(
+    'UPDATE wise_import_orders SET status = ?, updated_at = ? WHERE id = ? AND status = ?',
+    ['ready', updatedAt, id, 'pending'],
+  );
+  return res.affectedRows > 0 ? updatedAt : null;
+}
+
+async function deliverOrder(id, characterId) {
+  const updatedAt = Date.now();
+  const res = await db.query(
+    'UPDATE wise_import_orders SET status = ?, updated_at = ? WHERE id = ? AND character_id = ? AND status = ?',
+    ['delivered', updatedAt, id, characterId, 'ready'],
+  );
+  return res.affectedRows > 0;
+}
+
+module.exports = {
+  createOrder,
+  listOrdersByCharacter,
+  listPendingOlderThan,
+  markReady,
+  deliverOrder,
+};

--- a/backend/srp-base/src/routes/wiseImports.routes.js
+++ b/backend/srp-base/src/routes/wiseImports.routes.js
@@ -37,4 +37,44 @@ router.post('/v1/wise-imports/orders', async (req, res) => {
   }
 });
 
+router.post('/v1/wise-imports/orders/:id/deliver', async (req, res) => {
+  if (!req.get('X-Idempotency-Key')) {
+    return sendError(
+      res,
+      { code: 'IDEMPOTENCY_KEY_REQUIRED', message: 'X-Idempotency-Key header is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  const { id } = req.params;
+  const { characterId } = req.body || {};
+  if (!characterId) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'characterId is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const delivered = await repo.deliverOrder(Number(id), characterId);
+    if (!delivered) {
+      return sendError(
+        res,
+        { code: 'NOT_FOUND', message: 'Order not ready' },
+        404,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    websocket.broadcast('wise-imports', 'order-delivered', { id: Number(id), characterId });
+    hooks.dispatch('wise-imports.order.delivered', { id: Number(id), characterId });
+    sendOk(res, { delivered: true }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'WISE_IMPORTS_DELIVER_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
 module.exports = router;

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -7,6 +7,7 @@ const casinoTasks = require('./tasks/diamondCasino');
 const interactSoundTasks = require('./tasks/interactSound');
 const dispatchTasks = require('./tasks/dispatch');
 const zoneTasks = require('./tasks/zones');
+const wiseImportsTasks = require('./tasks/wiseImports');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -26,6 +27,12 @@ scheduler.register('casino-resolver', () => casinoTasks.resolvePending(wss), 300
 scheduler.register('interact-sound-purge', () => interactSoundTasks.purgeOld(), 3600000, { jitter: 60000 });
 scheduler.register('dispatch-alert-purge', () => dispatchTasks.purgeOld(), 3600000, { jitter: 60000 });
 scheduler.register('zone-expiry-purge', () => zoneTasks.pruneExpired(), 60000, { jitter: 5000 });
+scheduler.register(
+  wiseImportsTasks.JOB_NAME,
+  () => wiseImportsTasks.notifyReady(),
+  wiseImportsTasks.INTERVAL_MS,
+  { jitter: 60000, persistName: wiseImportsTasks.JOB_NAME },
+);
 
 // Handle graceful shutdown
 function shutdown() {

--- a/backend/srp-base/src/tasks/wiseImports.js
+++ b/backend/srp-base/src/tasks/wiseImports.js
@@ -1,0 +1,33 @@
+const repo = require('../repositories/wiseImportsRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
+const cronRepo = require('../repositories/cronRepository');
+const logger = require('../utils/logger');
+
+const INTERVAL_MS = 600000; // 10 minutes
+const JOB_NAME = 'wise-imports-ready';
+
+cronRepo
+  .createJob({
+    name: JOB_NAME,
+    schedule: `interval:${INTERVAL_MS}`,
+    payload: null,
+    priority: 0,
+    nextRun: new Date(Date.now() + INTERVAL_MS).toISOString(),
+  })
+  .catch((err) => logger.error({ err }, 'Failed to ensure wise-imports cron job'));
+
+async function notifyReady() {
+  const cutoff = Date.now() - INTERVAL_MS;
+  const pending = await repo.listPendingOlderThan(cutoff);
+  for (const order of pending) {
+    const updatedAt = await repo.markReady(order.id);
+    if (updatedAt) {
+      const payload = { id: order.id, characterId: order.characterId, model: order.model, status: 'ready', updatedAt };
+      websocket.broadcast('wise-imports', 'order-ready', { order: payload });
+      hooks.dispatch('wise-imports.order.ready', payload);
+    }
+  }
+}
+
+module.exports = { notifyReady, INTERVAL_MS, JOB_NAME };


### PR DESCRIPTION
## Summary
- promote pending Wise Imports orders to ready state on a 10 minute scheduler with persisted last-run
- add POST /v1/wise-imports/orders/{id}/deliver endpoint and updated_at field
- document and expose updated schemas and admin guidance

## Testing
- `node --check backend/srp-base/src/routes/wiseImports.routes.js`
- `node --check backend/srp-base/src/tasks/wiseImports.js`

------
https://chatgpt.com/codex/tasks/task_e_68accfd18208832d853167ed2f601178