### PR TITLE
srp-base(camera): realtime photo events and retention purge

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1364,3 +1364,18 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Drop `ipl_states` table and remove IPL scheduler registration.
+
+## 2025-08-26 – Camera realtime
+
+### Added
+* WebSocket and webhook events for camera photo creation and deletion.
+* Scheduler purges photos older than `CAMERA_RETENTION_MS`.
+
+### Migrations
+* `069_add_camera_photos_created_index.sql` adds index on `camera_photos.created_at`.
+
+### Risks
+* Misconfigured retention may delete photos prematurely.
+
+### Rollback
+* Remove camera scheduler registration and drop index `idx_camera_photos_created_at`.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,25 +1,23 @@
 # Manifest
 
-- Added world IPL state management with WebSocket broadcasts and scheduler sync.
+- Added camera photo realtime events and scheduled retention purge.
 
 | File | Action | Note |
 |---|---|---|
-| src/repositories/iplRepository.js | A | Persist interior proxy states |
-| src/routes/world.routes.js | M | Expose IPL endpoints and broadcasts |
-| src/tasks/world.js | A | Scheduler to broadcast IPL state |
-| src/server.js | M | Register world IPL scheduler |
-| src/migrations/068_add_ipls.sql | A | Create `ipl_states` table |
-| openapi/api.yaml | M | Document IPL schemas and endpoints |
-| docs/BASE_API_DOCUMENTATION.md | M | Describe IPL APIs |
-| docs/events-and-rpcs.md | M | Map bob74_ipl events |
-| docs/db-schema.md | M | Add `ipl_states` table |
-| docs/migrations.md | M | Log migration 068 |
-| docs/admin-ops.md | M | Note `ipl_states` table requirement |
-| docs/modules/world.md | M | Document IPL routes and repository |
-| docs/index.md | M | Summarize bob74_ipl support |
-| docs/progress-ledger.md | M | Record bob74_ipl decision |
-| docs/framework-compliance.md | M | Add world IPL module evaluation |
-| docs/naming-map.md | M | Map bob74_ipl → ipl |
-| docs/research-log.md | M | Log bob74_ipl research |
-| docs/todo-gaps.md | M | Note OpenAPI world events gap |
-| docs/run-docs.md | M | Consolidated run notes |
+| src/config/env.js | M | Camera retention and cleanup settings |
+| src/repositories/cameraRepository.js | M | Add purge helper |
+| src/routes/camera.routes.js | M | Broadcast and dispatch events |
+| src/tasks/camera.js | A | Purge old photos |
+| src/server.js | M | Register camera purge scheduler |
+| src/migrations/069_add_camera_photos_created_index.sql | A | Index camera_photos.created_at |
+| openapi/api.yaml | M | Add camera event extensions |
+| docs/BASE_API_DOCUMENTATION.md | M | Document camera events and retention |
+| docs/events-and-rpcs.md | M | Map camera events |
+| docs/db-schema.md | M | Note camera_photos indexes |
+| docs/migrations.md | M | Log migration 069 |
+| docs/modules/camera.md | M | Describe realtime and purge |
+| docs/progress-ledger.md | M | Record camera realtime entry |
+| docs/index.md | M | Summarize camera realtime support |
+| docs/naming-map.md | M | Map np-camera → camera |
+| docs/research-log.md | M | Log camera resource attempt |
+| docs/run-docs.md | A | Consolidated run notes |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -507,11 +507,12 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
   - `GET /v1/boatshop` – List boats available for purchase.
   - `POST /v1/boatshop/purchase` – Purchase a boat with `characterId`, `boatId`, `plate` and optional `properties`.
   - Scheduler broadcasts `boatshop.catalog` every 5 minutes; purchases emit `boatshop.purchase` over WebSocket and webhooks.
-- **srp-camera** – Stores character photos.
-  - `GET /v1/camera/photos/{characterId}` – List photos for a character.
-  - `POST /v1/camera/photos` – Save a photo with `characterId`, `imageUrl` and optional `description`.
-  - `DELETE /v1/camera/photos/{id}` – Remove a photo record.
-- **srp-hud** – Stores per-character HUD settings.
+  - **srp-camera** – Stores character photos and broadcasts changes.
+    - `GET /v1/camera/photos/{characterId}` – List photos for a character.
+    - `POST /v1/camera/photos` – Save a photo with `characterId`, `imageUrl` and optional `description`; broadcasts `camera.photo.created` over WebSocket and webhooks.
+    - `DELETE /v1/camera/photos/{id}` – Remove a photo record; broadcasts `camera.photo.deleted`.
+    - Scheduler purges photos older than `CAMERA_RETENTION_MS` at `CAMERA_CLEANUP_INTERVAL_MS`.
+  - **srp-hud** – Stores per-character HUD settings.
   - `GET /v1/characters/{characterId}/hud` – Retrieve HUD preferences.
   - `PUT /v1/characters/{characterId}/hud` – Update HUD preferences.
 - **srp-carwash** – Records vehicle washes and dirt levels.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -84,6 +84,7 @@ Added `world_forecast` table for weather scheduling. K9 migration renamed to 057
 | heading | FLOAT | Orientation |
 | created_at | TIMESTAMP | Creation time |
 | updated_at | TIMESTAMP | Update time |
+| indexes | - | `idx_camera_photos_character_id` on `character_id`, `idx_camera_photos_created_at` on `created_at` |
 ## evidence_chain
 
 | Column | Type | Notes |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -27,7 +27,7 @@
 | yuzler | No server events; clothing assets | N/A |
 | baseevents | Emits player join, drop and kill events | `POST /v1/base-events` logs events and broadcasts `base-events.logged`; `GET /v1/base-events` lists history |
 | boatshop | Resource sends purchase requests for boats | `GET /v1/boatshop`, `POST /v1/boatshop/purchase` → broadcasts `boatshop.catalog` (scheduled) and `boatshop.purchase` |
-| camera | Resource captures photos and uploads metadata | `GET /v1/camera/photos/{characterId}`, `POST /v1/camera/photos`, `DELETE /v1/camera/photos/{id}` |
+| camera | Resource captures photos and uploads metadata | `GET /v1/camera/photos/{characterId}`, `POST /v1/camera/photos`, `DELETE /v1/camera/photos/{id}` → pushes `camera.photo.created`/`camera.photo.deleted` |
 | carandplayerhud | Resource broadcasts HUD updates when preferences change | `GET /v1/characters/{characterId}/hud`, `PUT /v1/characters/{characterId}/hud` |
 | carwash | Resource triggers wash events with plate and cost | `POST /v1/carwash`, `GET /v1/carwash/history/{characterId}`, `GET/PATCH /v1/vehicles/{plate}/dirt` |
 | chat | Resource broadcasts chat messages | `POST /v1/chat/messages` logs message; history via `GET /v1/chat/messages/{characterId}` |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -462,3 +462,7 @@ Introduced interior proxy state management to support the **bob74_ipl** resource
 * Added world IPL endpoints `/v1/world/ipls` and `/v1/world/ipls/{name}` with WebSocket broadcasts and scheduled sync.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/world.md`.
+
+## Update – 2025-08-26
+
+Extended camera module with WebSocket and webhook pushes plus scheduled retention cleanup.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -66,3 +66,4 @@
 | 066_add_properties.sql | Unified properties table for housing and rentals |
 | 067_add_invoices.sql | Invoices table for character billing |
 | 068_add_ipls.sql | IPL state table |
+| 069_add_camera_photos_created_index.sql | Index camera_photos created_at |

--- a/backend/srp-base/docs/modules/camera.md
+++ b/backend/srp-base/docs/modules/camera.md
@@ -16,6 +16,15 @@ There is no feature flag for camera; the module is always enabled.
 | **POST `/v1/camera/photos`** | Create a new photo. Requires `characterId` and `imageUrl`. | 30/min per IP | Required | Yes | `CameraPhotoCreateRequest` | `{ ok, data: { photo: CameraPhoto }, requestId, traceId }` |
 | **DELETE `/v1/camera/photos/{id}`** | Delete a photo by ID. | 30/min per IP | Required | Yes | None | `{ ok, data: {}, requestId, traceId }` |
 
+### Real-time events
+
+| Channel | Event | Payload |
+|---|---|---|
+| `camera` | `photo.created` | `{ photo }` |
+| `camera` | `photo.deleted` | `{ id }` |
+
+Both events are also dispatched through the webhook dispatcher using event types `camera.photo.created` and `camera.photo.deleted`.
+
 ### Schemas
 
 * **CameraPhoto** –
@@ -41,7 +50,10 @@ There is no feature flag for camera; the module is always enabled.
 * **Migration:** `src/migrations/036_add_camera_photos.sql` creates the
   `camera_photos` table with foreign key to characters.
 * **Routes:** `src/routes/camera.routes.js` defines the REST API.
+  Photo creation and deletion broadcast over WebSocket and webhook dispatcher.
 * **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
+* **Scheduler:** `src/tasks/camera.js` purges photos older than `CAMERA_RETENTION_MS` at `CAMERA_CLEANUP_INTERVAL_MS`.
+* **Config:** Set `CAMERA_RETENTION_MS` and `CAMERA_CLEANUP_INTERVAL_MS` in environment variables to adjust retention and purge interval.
 
 ## Future work
 

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -17,3 +17,4 @@
 | np-base | base-events |
 | boatshop | boatshop |
 | bob74_ipl | ipl |
+| np-camera | camera |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -69,3 +69,4 @@
 | 63 | baseevents | Base event logging with realtime and retention | Extend | Broadcast log events and purge stale records |
 | 64 | boatshop realtime | Catalog broadcasts and purchase pushes | Extend | WebSocket/webhook events and scheduler |
 | 65 | bob74_ipl | Interior proxy toggle persistence and broadcast | Create | Added IPL state API and scheduler |
+| 66 | camera realtime | Photo create/delete push events and retention purge | Extend | Broadcast events and purge old photos |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -307,3 +307,7 @@
 
 - Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed EssentialMode, ESX, ND_Core, FSN, QB-Core, vRP and vORP frameworks for world interior toggle patterns (names/flows only).
+
+## Research Log – 2025-08-26 (camera)
+
+- Attempted to clone reference repository `https://github.com/h04X-2K/NoPixelServer` for camera resource but download size was prohibitive. Reference resources unavailable; proceeding with internal consistency only.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,21 +1,16 @@
-# Run Summary – 2025-08-25
+# Run Summary – 2025-08-26
 
 ## Modules
-- World module: added IPL state management with WebSocket broadcasts and scheduler sync.
+- Camera module: added WebSocket and webhook pushes plus scheduled retention cleanup.
 
 ## Documentation Updated
 - docs/index.md
 - docs/progress-ledger.md
-- docs/framework-compliance.md
-- docs/BASE_API_DOCUMENTATION.md
 - docs/events-and-rpcs.md
 - docs/db-schema.md
 - docs/migrations.md
-- docs/admin-ops.md
-- docs/modules/world.md
-- docs/research-log.md
+- docs/modules/camera.md
 - docs/naming-map.md
-- docs/todo-gaps.md
 - docs/run-docs.md
 
 ## Outstanding TODO/Gaps

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -5968,6 +5968,8 @@ paths:
     post:
       summary: Create a photo
       operationId: createCameraPhoto
+      x-websocket-event: camera.photo.created
+      x-webhook-event: camera.photo.created
       requestBody:
         required: true
         content:
@@ -5999,6 +6001,8 @@ paths:
     delete:
       summary: Delete a photo
       operationId: deleteCameraPhoto
+      x-websocket-event: camera.photo.deleted
+      x-webhook-event: camera.photo.deleted
       parameters:
         - in: path
           name: id

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -75,6 +75,10 @@ const config = {
   dispatch: { retentionMs: parseInt(process.env.DISPATCH_ALERT_RETENTION_MS || '86400000', 10) },
   baseEvents: { retentionMs: parseInt(process.env.BASE_EVENT_RETENTION_MS || '2592000000', 10) },
   assets: { retentionMs: parseInt(process.env.ASSET_RETENTION_MS || '2592000000', 10) },
+  camera: {
+    retentionMs: parseInt(process.env.CAMERA_RETENTION_MS || '2592000000', 10),
+    cleanupIntervalMs: parseInt(process.env.CAMERA_CLEANUP_INTERVAL_MS || '3600000', 10),
+  },
   invoiceRetentionMs: parseInt(process.env.INVOICE_RETENTION_MS || '2592000000', 10),
 
   /**

--- a/backend/srp-base/src/migrations/069_add_camera_photos_created_index.sql
+++ b/backend/srp-base/src/migrations/069_add_camera_photos_created_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_camera_photos_created_at
+  ON camera_photos (created_at);

--- a/backend/srp-base/src/repositories/cameraRepository.js
+++ b/backend/srp-base/src/repositories/cameraRepository.js
@@ -51,8 +51,23 @@ async function deletePhoto(id) {
   await db.query('DELETE FROM camera_photos WHERE id = ?', [id]);
 }
 
+/**
+ * Delete photos older than the given retention in days.
+ * @param {number} maxAgeMs
+ * @returns {Promise<number>} number of rows deleted
+ */
+async function deletePhotosOlderThan(maxAgeMs) {
+  const seconds = Math.floor(maxAgeMs / 1000);
+  const [res] = await db.query(
+    'DELETE FROM camera_photos WHERE created_at < (NOW() - INTERVAL ? SECOND)',
+    [seconds],
+  );
+  return res.affectedRows || 0;
+}
+
 module.exports = {
   listPhotosByCharacter,
   createPhoto,
   deletePhoto,
+  deletePhotosOlderThan,
 };

--- a/backend/srp-base/src/routes/camera.routes.js
+++ b/backend/srp-base/src/routes/camera.routes.js
@@ -5,6 +5,8 @@ const {
   createPhoto,
   deletePhoto,
 } = require('../repositories/cameraRepository');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -44,6 +46,8 @@ router.post('/v1/camera/photos', async (req, res) => {
   }
   try {
     const photo = await createPhoto({ characterId: idNum, imageUrl, description });
+    websocket.broadcast('camera', 'photo.created', { photo });
+    dispatcher.dispatch('camera.photo.created', photo);
     sendOk(res, { photo }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'CAMERA_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
@@ -65,6 +69,8 @@ router.delete('/v1/camera/photos/:id', async (req, res) => {
   }
   try {
     await deletePhoto(idNum);
+    websocket.broadcast('camera', 'photo.deleted', { id: idNum });
+    dispatcher.dispatch('camera.photo.deleted', { id: idNum });
     sendOk(res, {}, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'CAMERA_DELETE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -15,6 +15,7 @@ const economyTasks = require('./tasks/economy');
 const baseEventTasks = require('./tasks/baseEvents');
 const boatshopTasks = require('./tasks/boatshop');
 const worldTasks = require('./tasks/world');
+const cameraTasks = require('./tasks/camera');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -81,6 +82,12 @@ scheduler.register(
   () => worldTasks.broadcastIpls(wss),
   worldTasks.INTERVAL_MS,
   { jitter: 5000, persistName: worldTasks.JOB_NAME },
+);
+scheduler.register(
+  cameraTasks.JOB_NAME,
+  () => cameraTasks.purgeOld(),
+  cameraTasks.INTERVAL_MS,
+  { jitter: 60000 },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/camera.js
+++ b/backend/srp-base/src/tasks/camera.js
@@ -1,0 +1,11 @@
+const cameraRepo = require('../repositories/cameraRepository');
+const config = require('../config/env');
+
+const JOB_NAME = 'camera-photo-purge';
+const INTERVAL_MS = config.camera.cleanupIntervalMs;
+
+async function purgeOld() {
+  await cameraRepo.deletePhotosOlderThan(config.camera.retentionMs);
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, purgeOld };


### PR DESCRIPTION
## Summary
- broadcast camera photo create/delete over WebSocket and webhooks
- purge old photos on a jittered schedule
- document camera retention settings

## Testing
- `node -e "require('fs').readFileSync('./backend/srp-base/openapi/api.yaml'); console.log('openapi ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68ad2562073c832db3f1e7c830f17d48