### PR TITLE
srp-base: add vehicle HUD state sync

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1379,3 +1379,19 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Remove camera scheduler registration and drop index `idx_camera_photos_created_at`.
+
+## 2025-08-26 – HUD vehicle state
+
+### Added
+* Vehicle HUD state persistence (seatbelt, harness, nitrous).
+* WebSocket broadcasts on vehicle state changes.
+* Hourly scheduler purges stale vehicle state.
+
+### Migrations
+* `070_add_character_vehicle_status.sql` creates `character_vehicle_status` table.
+
+### Risks
+* Missing DB grants could prevent state writes.
+
+### Rollback
+* Drop `character_vehicle_status` table and remove HUD scheduler registration.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,6 +1,7 @@
 # Manifest
 
 - Added camera photo realtime events and scheduled retention purge.
+- Added vehicle HUD state API with WebSocket broadcasts and hourly cleanup.
 
 | File | Action | Note |
 |---|---|---|
@@ -21,3 +22,22 @@
 | docs/naming-map.md | M | Map np-camera → camera |
 | docs/research-log.md | M | Log camera resource attempt |
 | docs/run-docs.md | A | Consolidated run notes |
+| src/repositories/vehicleStatusRepository.js | A | Persist vehicle HUD state |
+| src/migrations/070_add_character_vehicle_status.sql | A | Vehicle HUD state table |
+| src/tasks/hud.js | A | Prune stale vehicle HUD state |
+| src/routes/hud.routes.js | M | Add vehicle state endpoints and broadcasts |
+| src/server.js | M | Register HUD state cleanup scheduler |
+| openapi/api.yaml | M | Document vehicle state schemas and paths |
+| docs/BASE_API_DOCUMENTATION.md | M | Add vehicle state endpoints |
+| docs/admin-ops.md | M | Note vehicle status table |
+| docs/db-schema.md | M | Document vehicle status schema |
+| docs/events-and-rpcs.md | M | Map vehicle state events |
+| docs/framework-compliance.md | M | Note vehicle state compliance |
+| docs/index.md | M | Summarize HUD vehicle state support |
+| docs/migrations.md | M | Log migration 070 |
+| docs/modules/hud.md | M | Document vehicle state API |
+| docs/naming-map.md | M | Map carandplayerhud → hud |
+| docs/progress-ledger.md | M | Record carandplayerhud entry |
+| docs/research-log.md | M | Log carandplayerhud research |
+| docs/run-docs.md | M | Summarize hud run |
+| docs/todo-gaps.md | M | Track pending HUD vitals work |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -513,8 +513,10 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
     - `DELETE /v1/camera/photos/{id}` – Remove a photo record; broadcasts `camera.photo.deleted`.
     - Scheduler purges photos older than `CAMERA_RETENTION_MS` at `CAMERA_CLEANUP_INTERVAL_MS`.
   - **srp-hud** – Stores per-character HUD settings.
-  - `GET /v1/characters/{characterId}/hud` – Retrieve HUD preferences.
-  - `PUT /v1/characters/{characterId}/hud` – Update HUD preferences.
+- `GET /v1/characters/{characterId}/hud` – Retrieve HUD preferences.
+- `PUT /v1/characters/{characterId}/hud` – Update HUD preferences.
+- `GET /v1/characters/{characterId}/vehicle-state` – Retrieve vehicle HUD state.
+- `PUT /v1/characters/{characterId}/vehicle-state` – Update vehicle HUD state (broadcasts `hud.vehicleState`).
 - **srp-carwash** – Records vehicle washes and dirt levels.
   - `POST /v1/carwash` – Record a car wash (`characterId`, `plate`, `location`, `cost`).
   - `GET /v1/carwash/history/{characterId}` – List recent washes for a character.

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -30,6 +30,7 @@
 - Scheduler `boatshop-catalog-broadcast` pushes catalog updates; monitor logs for successful runs.
 - Ensure the `camera_photos` table exists for stored photos.
 - Ensure the `character_hud_preferences` table exists for HUD settings.
+- Ensure the `character_vehicle_status` table exists for vehicle HUD state.
 - Ensure the `carwash_transactions` and `vehicle_cleanliness` tables exist for carwash tracking.
 - Ensure the `chat_messages` table exists for chat logging.
 - Ensure the `queue_priorities` table exists for connection queue priority management.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -38,6 +38,16 @@ Added `world_forecast` table for weather scheduling. K9 migration renamed to 057
 | volume | FLOAT | Playback volume |
 | played_at | BIGINT | Epoch milliseconds |
 
+## character_vehicle_status
+
+| Column | Type | Notes |
+|---|---|---|
+| character_id | INT | PK, FK to characters.id |
+| seatbelt | TINYINT(1) | 1 if seatbelt engaged |
+| harness | TINYINT(1) | 1 if harness engaged |
+| nitrous | INT | Remaining nitrous amount |
+| updated_at | DATETIME | Last update timestamp |
+
 ## dispatch_alerts
 
 | Column | Type | Notes |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -28,7 +28,7 @@
 | baseevents | Emits player join, drop and kill events | `POST /v1/base-events` logs events and broadcasts `base-events.logged`; `GET /v1/base-events` lists history |
 | boatshop | Resource sends purchase requests for boats | `GET /v1/boatshop`, `POST /v1/boatshop/purchase` → broadcasts `boatshop.catalog` (scheduled) and `boatshop.purchase` |
 | camera | Resource captures photos and uploads metadata | `GET /v1/camera/photos/{characterId}`, `POST /v1/camera/photos`, `DELETE /v1/camera/photos/{id}` → pushes `camera.photo.created`/`camera.photo.deleted` |
-| carandplayerhud | Resource broadcasts HUD updates when preferences change | `GET /v1/characters/{characterId}/hud`, `PUT /v1/characters/{characterId}/hud` |
+| carandplayerhud | Resource broadcasts HUD updates and vehicle state changes | `GET /v1/characters/{characterId}/hud`, `PUT /v1/characters/{characterId}/hud`, `GET /v1/characters/{characterId}/vehicle-state`, `PUT /v1/characters/{characterId}/vehicle-state` → WebSocket `hud.vehicleState` |
 | carwash | Resource triggers wash events with plate and cost | `POST /v1/carwash`, `GET /v1/carwash/history/{characterId}`, `GET/PATCH /v1/vehicles/{plate}/dirt` |
 | chat | Resource broadcasts chat messages | `POST /v1/chat/messages` logs message; history via `GET /v1/chat/messages/{characterId}` |
 | connectqueue | Resource uses exports `AddPriority` and `RemovePriority` with account identifiers | `GET/POST/DELETE /v1/connectqueue/priorities` manage backend priority records |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -70,7 +70,7 @@ practice is supported by citations.
 | **baseevents module** | Base event logging endpoints follow the established layered pattern with authentication, idempotency, WebSocket broadcast and hourly purge scheduler. |
 | **boatshop module** | Boatshop endpoints follow the established layered pattern with authentication and idempotency. |
 | **camera module** | Photo storage endpoints follow the established layered pattern with authentication and idempotency. |
-| **hud module** | HUD preference endpoints follow the established layered pattern with authentication and idempotency. |
+| **hud module** | HUD preference and vehicle state endpoints follow the established layered pattern with authentication, idempotency and WebSocket broadcasts. |
 | **carwash module** | Carwash endpoints follow the established layered pattern with authentication and idempotency. |
 | **chat module** | Chat message endpoints follow the established layered pattern with authentication and idempotency. |
 | **connectqueue module** | Queue priority endpoints follow the established layered pattern with authentication, idempotency and rate limiting. |
@@ -109,3 +109,4 @@ practice is supported by citations.
 - Add unit test coverage.
 - Migrate legacy apartments and garages routes to `/v1/properties`.
 - Document world event endpoints in OpenAPI.
+- Integrate player vitals (hunger, thirst, stress) into HUD module.

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -466,3 +466,7 @@ For resource decisions see `progress-ledger.md`. Module details are documented i
 ## Update – 2025-08-26
 
 Extended camera module with WebSocket and webhook pushes plus scheduled retention cleanup.
+
+## Update – 2025-08-26
+
+Extended HUD module with vehicle state tracking, WebSocket broadcasts and scheduled cleanup.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -67,3 +67,4 @@
 | 067_add_invoices.sql | Invoices table for character billing |
 | 068_add_ipls.sql | IPL state table |
 | 069_add_camera_photos_created_index.sql | Index camera_photos created_at |
+| 070_add_character_vehicle_status.sql | Vehicle HUD state table |

--- a/backend/srp-base/docs/modules/hud.md
+++ b/backend/srp-base/docs/modules/hud.md
@@ -1,6 +1,6 @@
 # HUD Module
 
-The **hud** module stores per-character vehicle and player HUD preferences such as speed unit, fuel display and theme.
+The **hud** module stores per-character vehicle and player HUD preferences and tracks vehicle HUD state such as seatbelt, harness and nitrous levels.
 
 ## Feature flag
 
@@ -12,6 +12,8 @@ There is no feature flag for hud; the module is always enabled.
 |---|---|---|---|---|---|---|
 | **GET `/v1/characters/{characterId}/hud`** | Retrieve HUD preferences. | 60/min per IP | Required | Yes | None | `{ ok, data: HudPreferences, requestId, traceId }` |
 | **PUT `/v1/characters/{characterId}/hud`** | Update HUD preferences. | 30/min per IP | Required | Yes | `HudPreferencesInput` | `{ ok, data: HudPreferences, requestId, traceId }` |
+| **GET `/v1/characters/{characterId}/vehicle-state`** | Retrieve vehicle HUD state. | 60/min per IP | Required | Yes | None | `{ ok, data: VehicleState, requestId, traceId }` |
+| **PUT `/v1/characters/{characterId}/vehicle-state`** | Update vehicle HUD state and broadcast to WebSocket subscribers. | 30/min per IP | Required | Yes | `VehicleStateInput` | `{ ok, data: VehicleState, requestId, traceId }` |
 
 ### Schemas
 
@@ -31,9 +33,9 @@ There is no feature flag for hud; the module is always enabled.
 
 ## Implementation details
 
-* **Repository:** `src/repositories/hudRepository.js` stores and retrieves preferences.
-* **Migration:** `src/migrations/037_add_character_hud_preferences.sql` creates the table.
-* **Routes:** `src/routes/hud.routes.js` exposes the REST API.
+* **Repositories:** `src/repositories/hudRepository.js` stores preferences; `src/repositories/vehicleStatusRepository.js` tracks vehicle state.
+* **Migrations:** `src/migrations/037_add_character_hud_preferences.sql` and `src/migrations/070_add_character_vehicle_status.sql` create the tables.
+* **Routes:** `src/routes/hud.routes.js` exposes the REST API and emits `hud.vehicleState` over WebSocket on updates.
 * **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
 
 ## Future work

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -18,3 +18,4 @@
 | boatshop | boatshop |
 | bob74_ipl | ipl |
 | np-camera | camera |
+| carandplayerhud | hud |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -70,3 +70,4 @@
 | 64 | boatshop realtime | Catalog broadcasts and purchase pushes | Extend | WebSocket/webhook events and scheduler |
 | 65 | bob74_ipl | Interior proxy toggle persistence and broadcast | Create | Added IPL state API and scheduler |
 | 66 | camera realtime | Photo create/delete push events and retention purge | Extend | Broadcast events and purge old photos |
+| 67 | carandplayerhud | Vehicle and player HUD status sync | Extend | Added vehicle-state API with WebSocket broadcast and cleanup scheduler |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -311,3 +311,8 @@
 ## Research Log – 2025-08-26 (camera)
 
 - Attempted to clone reference repository `https://github.com/h04X-2K/NoPixelServer` for camera resource but download size was prohibitive. Reference resources unavailable; proceeding with internal consistency only.
+
+## Research Log – 2025-08-26 (carandplayerhud)
+
+- Attempted to clone `https://github.com/h04X-2K/NoPixelServer` for carandplayerhud but checkout failed due to repository size. Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed EssentialMode, ESX, ND Core, FSN, QB-Core, vRP and vORP naming around seatbelt and vehicle status features.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -2,6 +2,7 @@
 
 ## Modules
 - Camera module: added WebSocket and webhook pushes plus scheduled retention cleanup.
+- HUD module: added vehicle state API, WebSocket broadcast and cleanup scheduler.
 
 ## Documentation Updated
 - docs/index.md
@@ -10,8 +11,13 @@
 - docs/db-schema.md
 - docs/migrations.md
 - docs/modules/camera.md
+- docs/modules/hud.md
 - docs/naming-map.md
 - docs/run-docs.md
+- docs/admin-ops.md
+- docs/framework-compliance.md
+- docs/todo-gaps.md
+- docs/research-log.md
 
 ## Outstanding TODO/Gaps
 - Migrate existing apartment and garage consumers to new properties API
@@ -19,3 +25,4 @@
 - Dispatch property events to external webhooks
 - Paginate and search property listings
 - Document world event endpoints in OpenAPI
+- Integrate player vitals (hunger, thirst, stress) into HUD module

--- a/backend/srp-base/docs/todo-gaps.md
+++ b/backend/srp-base/docs/todo-gaps.md
@@ -7,3 +7,4 @@
 | Dispatch property events to external webhooks | backend | medium | webhook endpoint adoption |
 | Paginate and search property listings | backend | low | none |
 | Document world event endpoints in OpenAPI | backend | medium | spec alignment |
+| Integrate player vitals (hunger, thirst, stress) into HUD module | backend | medium | gameplay design |

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -1263,6 +1263,26 @@ components:
         hudTheme:
           type: string
           nullable: true
+    VehicleState:
+      type: object
+      properties:
+        characterId:
+          type: integer
+        seatbelt:
+          type: boolean
+        harness:
+          type: boolean
+        nitrous:
+          type: integer
+    VehicleStateInput:
+      type: object
+      properties:
+        seatbelt:
+          type: boolean
+        harness:
+          type: boolean
+        nitrous:
+          type: integer
     CarwashTransaction:
       type: object
       properties:
@@ -6044,6 +6064,50 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HudPreferences'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /v1/characters/{characterId}/vehicle-state:
+    get:
+      summary: Get vehicle HUD state
+      operationId: getVehicleState
+      parameters:
+        - in: path
+          name: characterId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Vehicle HUD state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VehicleState'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+    put:
+      summary: Update vehicle HUD state
+      operationId: updateVehicleState
+      parameters:
+        - in: path
+          name: characterId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VehicleStateInput'
+      responses:
+        '200':
+          description: Updated vehicle HUD state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VehicleState'
         '400':
           $ref: '#/components/responses/BadRequest'
 

--- a/backend/srp-base/src/migrations/070_add_character_vehicle_status.sql
+++ b/backend/srp-base/src/migrations/070_add_character_vehicle_status.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS character_vehicle_status (
+  character_id INT NOT NULL PRIMARY KEY,
+  seatbelt TINYINT(1) NOT NULL DEFAULT 0,
+  harness TINYINT(1) NOT NULL DEFAULT 0,
+  nitrous INT NOT NULL DEFAULT 0,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_vehicle_status_character FOREIGN KEY (character_id) REFERENCES characters(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE INDEX IF NOT EXISTS idx_character_vehicle_status_updated_at
+  ON character_vehicle_status(updated_at);

--- a/backend/srp-base/src/repositories/vehicleStatusRepository.js
+++ b/backend/srp-base/src/repositories/vehicleStatusRepository.js
@@ -1,0 +1,53 @@
+const db = require('./db');
+
+/**
+ * Retrieve vehicle HUD status for a character. Defaults to false/zero when none exist.
+ * @param {number} characterId
+ * @returns {Promise<Object>}
+ */
+async function getStatus(characterId) {
+  const rows = await db.query(
+    'SELECT character_id AS characterId, seatbelt, harness, nitrous FROM character_vehicle_status WHERE character_id = ?',
+    [characterId],
+  );
+  if (rows.length === 0) {
+    return { characterId, seatbelt: false, harness: false, nitrous: 0 };
+  }
+  const row = rows[0];
+  return {
+    characterId: row.characterId,
+    seatbelt: row.seatbelt === 1,
+    harness: row.harness === 1,
+    nitrous: row.nitrous || 0,
+  };
+}
+
+/**
+ * Upsert vehicle HUD status for a character.
+ * @param {number} characterId
+ * @param {Object} status
+ * @param {boolean} status.seatbelt
+ * @param {boolean} status.harness
+ * @param {number} status.nitrous
+ * @returns {Promise<Object>}
+ */
+async function upsertStatus(characterId, { seatbelt, harness, nitrous }) {
+  await db.query(
+    'INSERT INTO character_vehicle_status (character_id, seatbelt, harness, nitrous, updated_at) VALUES (?, ?, ?, ?, NOW()) ON DUPLICATE KEY UPDATE seatbelt = VALUES(seatbelt), harness = VALUES(harness), nitrous = VALUES(nitrous), updated_at = NOW()',
+    [characterId, seatbelt ? 1 : 0, harness ? 1 : 0, nitrous || 0],
+  );
+  return { characterId, seatbelt: !!seatbelt, harness: !!harness, nitrous: nitrous || 0 };
+}
+
+/**
+ * Remove stale vehicle HUD status entries older than the supplied TTL.
+ * @param {number} ttlMs
+ */
+async function pruneStale(ttlMs) {
+  await db.query(
+    'DELETE FROM character_vehicle_status WHERE updated_at < DATE_SUB(NOW(), INTERVAL ? SECOND)',
+    [Math.floor(ttlMs / 1000)],
+  );
+}
+
+module.exports = { getStatus, upsertStatus, pruneStale };

--- a/backend/srp-base/src/routes/hud.routes.js
+++ b/backend/srp-base/src/routes/hud.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const hudRepo = require('../repositories/hudRepository');
+const vehicleStatusRepo = require('../repositories/vehicleStatusRepository');
+const websocket = require('../realtime/websocket');
 
 const router = express.Router();
 
@@ -55,6 +57,54 @@ router.put('/v1/characters/:characterId/hud', async (req, res, next) => {
       hudTheme: hudTheme || null,
     });
     sendOk(res, prefs, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Get vehicle HUD status for a character
+router.get('/v1/characters/:characterId/vehicle-state', async (req, res, next) => {
+  try {
+    const { characterId } = req.params;
+    const id = parseInt(characterId, 10);
+    if (Number.isNaN(id)) {
+      return sendError(
+        res,
+        { code: 'VALIDATION_ERROR', message: 'characterId must be an integer' },
+        400,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    const status = await vehicleStatusRepo.getStatus(id);
+    sendOk(res, status, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Update vehicle HUD status for a character
+router.put('/v1/characters/:characterId/vehicle-state', async (req, res, next) => {
+  try {
+    const { characterId } = req.params;
+    const id = parseInt(characterId, 10);
+    if (Number.isNaN(id)) {
+      return sendError(
+        res,
+        { code: 'VALIDATION_ERROR', message: 'characterId must be an integer' },
+        400,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    const { seatbelt, harness, nitrous } = req.body || {};
+    const status = await vehicleStatusRepo.upsertStatus(id, {
+      seatbelt: !!seatbelt,
+      harness: !!harness,
+      nitrous: Number.isFinite(nitrous) ? nitrous : 0,
+    });
+    websocket.broadcast('hud', 'vehicleState', status);
+    sendOk(res, status, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);
   }

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -16,6 +16,7 @@ const baseEventTasks = require('./tasks/baseEvents');
 const boatshopTasks = require('./tasks/boatshop');
 const worldTasks = require('./tasks/world');
 const cameraTasks = require('./tasks/camera');
+const hudTasks = require('./tasks/hud');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -87,6 +88,12 @@ scheduler.register(
   cameraTasks.JOB_NAME,
   () => cameraTasks.purgeOld(),
   cameraTasks.INTERVAL_MS,
+  { jitter: 60000 },
+);
+scheduler.register(
+  hudTasks.JOB_NAME,
+  () => hudTasks.pruneOld(),
+  hudTasks.INTERVAL_MS,
   { jitter: 60000 },
 );
 

--- a/backend/srp-base/src/tasks/hud.js
+++ b/backend/srp-base/src/tasks/hud.js
@@ -1,0 +1,12 @@
+const hudRepo = require('../repositories/vehicleStatusRepository');
+const config = require('../config/env');
+
+const JOB_NAME = 'hud-status-prune';
+const INTERVAL_MS = 60 * 60 * 1000; // hourly
+
+async function pruneOld() {
+  const ttl = config.hudStatusTtlMs || 60 * 60 * 1000; // default 1h
+  await hudRepo.pruneStale(ttl);
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, pruneOld };


### PR DESCRIPTION
## Summary
- store per-character vehicle HUD state (seatbelt, harness, nitrous)
- expose vehicle-state API with WebSocket broadcasts
- schedule hourly purge of stale HUD state

## Testing
- `npm --prefix backend/srp-base run migrate` *(fails: Cannot find module 'mysql2/promise')*

------
https://chatgpt.com/codex/tasks/task_e_68ad2c4f8c08832db6c13095871a0f7e