### PR TITLE
srp-base: add chat realtime broadcast and retention purge

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1408,3 +1408,19 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Remove carwash scheduler registration and drop index `idx_vehicle_cleanliness_dirt`.
+
+## 2025-08-26 – Chat realtime & retention
+
+### Added
+* WebSocket and webhook broadcasts on `POST /v1/chat/messages`.
+* Hourly `chat-purge` scheduler removes messages older than `CHAT_RETENTION_MS`.
+* Config `CHAT_RETENTION_MS` with default 7 days.
+* `072_add_chat_messages_created_index.sql` adds `created_at` index.
+
+### Risks
+* Misconfigured retention could delete chat history too aggressively.
+* Additional broadcast traffic may impact clients if unsubscribed.
+
+### Rollback
+* Remove chat scheduler registration and broadcasts.
+* Drop index `idx_chat_messages_created_at`.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,43 +1,25 @@
 # Manifest
 
-- Added camera photo realtime events and scheduled retention purge.
-- Added vehicle HUD state API with WebSocket broadcasts and hourly cleanup.
+- Added chat message WebSocket/webhook broadcasts and retention purge.
 
 | File | Action | Note |
 |---|---|---|
-| src/config/env.js | M | Camera retention and cleanup settings |
-| src/repositories/cameraRepository.js | M | Add purge helper |
-| src/routes/camera.routes.js | M | Broadcast and dispatch events |
-| src/tasks/camera.js | A | Purge old photos |
-| src/server.js | M | Register camera purge scheduler |
-| src/migrations/069_add_camera_photos_created_index.sql | A | Index camera_photos.created_at |
-| openapi/api.yaml | M | Add camera event extensions |
-| docs/BASE_API_DOCUMENTATION.md | M | Document camera events and retention |
-| docs/events-and-rpcs.md | M | Map camera events |
-| docs/db-schema.md | M | Note camera_photos indexes |
-| docs/migrations.md | M | Log migration 069 |
-| docs/modules/camera.md | M | Describe realtime and purge |
-| docs/progress-ledger.md | M | Record camera realtime entry |
-| docs/index.md | M | Summarize camera realtime support |
-| docs/naming-map.md | M | Map np-camera → camera |
-| docs/research-log.md | M | Log camera resource attempt |
-| docs/run-docs.md | A | Consolidated run notes |
-| src/repositories/vehicleStatusRepository.js | A | Persist vehicle HUD state |
-| src/migrations/070_add_character_vehicle_status.sql | A | Vehicle HUD state table |
-| src/tasks/hud.js | A | Prune stale vehicle HUD state |
-| src/routes/hud.routes.js | M | Add vehicle state endpoints and broadcasts |
-| src/server.js | M | Register HUD state cleanup scheduler |
-| openapi/api.yaml | M | Document vehicle state schemas and paths |
-| docs/BASE_API_DOCUMENTATION.md | M | Add vehicle state endpoints |
-| docs/admin-ops.md | M | Note vehicle status table |
-| docs/db-schema.md | M | Document vehicle status schema |
-| docs/events-and-rpcs.md | M | Map vehicle state events |
-| docs/framework-compliance.md | M | Note vehicle state compliance |
-| docs/index.md | M | Summarize HUD vehicle state support |
-| docs/migrations.md | M | Log migration 070 |
-| docs/modules/hud.md | M | Document vehicle state API |
-| docs/naming-map.md | M | Map carandplayerhud → hud |
-| docs/progress-ledger.md | M | Record carandplayerhud entry |
-| docs/research-log.md | M | Log carandplayerhud research |
-| docs/run-docs.md | M | Summarize hud run |
-| docs/todo-gaps.md | M | Track pending HUD vitals work |
+| src/config/env.js | M | Add CHAT_RETENTION_MS setting |
+| src/repositories/chatRepository.js | M | Add deletion helper |
+| src/tasks/chat.js | A | Purge old messages |
+| src/routes/chat.routes.js | M | Broadcast and dispatch chat messages |
+| src/server.js | M | Register chat-purge scheduler |
+| src/migrations/072_add_chat_messages_created_index.sql | A | Index chat_messages.created_at |
+| openapi/api.yaml | M | Document chat message broadcast |
+| docs/admin-ops.md | M | Mention chat retention and scheduler |
+| docs/db-schema.md | M | Document chat_message indexes |
+| docs/events-and-rpcs.md | M | Map chat.message event |
+| docs/modules/chat.md | M | Describe realtime and purge |
+| docs/migrations.md | M | Log migration 072 |
+| docs/framework-compliance.md | M | Update chat compliance |
+| docs/progress-ledger.md | M | Record chat realtime entry |
+| docs/naming-map.md | M | Map chat → chat |
+| docs/research-log.md | M | Log chat research |
+| docs/run-docs.md | M | Consolidated run notes |
+| CHANGELOG.md | M | Chat realtime & retention entry |
+| MANIFEST.md | M | Update manifest |

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -32,7 +32,7 @@
 - Ensure the `character_hud_preferences` table exists for HUD settings.
 - Ensure the `character_vehicle_status` table exists for vehicle HUD state.
 - Ensure the `carwash_transactions` and `vehicle_cleanliness` tables exist for carwash tracking.
-- Ensure the `chat_messages` table exists for chat logging.
+- Ensure the `chat_messages` table exists for chat logging. Messages older than `CHAT_RETENTION_MS` are purged hourly by the `chat-purge` scheduler.
 - Ensure the `queue_priorities` table exists for connection queue priority management.
 - Ensure the `character_coords` table exists for saved coordinates.
 - Ensure the `interiors` table exists for apartment interior layouts.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -338,6 +338,8 @@ Rows older than `BASE_EVENT_RETENTION_MS` are purged hourly by the `base-events-
 | message | TEXT | Message content |
 | created_at | TIMESTAMP | Creation time |
 
+**Indexes**: `idx_chat_character` on `character_id`, `idx_chat_messages_created_at` on `created_at`
+
 ## queue_priorities
 
 | Column | Type | Notes |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -30,7 +30,7 @@
 | camera | Resource captures photos and uploads metadata | `GET /v1/camera/photos/{characterId}`, `POST /v1/camera/photos`, `DELETE /v1/camera/photos/{id}` → pushes `camera.photo.created`/`camera.photo.deleted` |
 | carandplayerhud | Resource broadcasts HUD updates and vehicle state changes | `GET /v1/characters/{characterId}/hud`, `PUT /v1/characters/{characterId}/hud`, `GET /v1/characters/{characterId}/vehicle-state`, `PUT /v1/characters/{characterId}/vehicle-state` → WebSocket `hud.vehicleState` |
 | carwash | `carwash:checkmoney`, `carwash:success`, `notenoughmoney` | `POST /v1/carwash`, `GET /v1/carwash/history/{characterId}`, `GET/PATCH /v1/vehicles/{plate}/dirt`; dirt changes push `vehicles.dirt.update` |
-| chat | Resource broadcasts chat messages | `POST /v1/chat/messages` logs message; history via `GET /v1/chat/messages/{characterId}` |
+| chat | Resource broadcasts chat messages | `POST /v1/chat/messages` logs and pushes `chat.message`; history via `GET /v1/chat/messages/{characterId}`; scheduler `chat-purge` removes old logs |
 | connectqueue | Resource uses exports `AddPriority` and `RemovePriority` with account identifiers | `GET/POST/DELETE /v1/connectqueue/priorities` manage backend priority records |
 | coordsaver | Resource lets players save named coordinates | `GET /v1/characters/{characterId}/coords`, `POST /v1/characters/{characterId}/coords`, `DELETE /v1/characters/{characterId}/coords/{id}` |
 | drz_interiors | Resource triggers save/load events for apartment interior templates | `GET /v1/apartments/{apartmentId}/interior`, `POST /v1/apartments/{apartmentId}/interior` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -72,7 +72,7 @@ practice is supported by citations.
 | **camera module** | Photo storage endpoints follow the established layered pattern with authentication and idempotency. |
 | **hud module** | HUD preference and vehicle state endpoints follow the established layered pattern with authentication, idempotency and WebSocket broadcasts. |
 | **carwash module** | Carwash endpoints follow the established layered pattern with authentication and idempotency; dirt ticks broadcast via WebSocket and webhooks. |
-| **chat module** | Chat message endpoints follow the established layered pattern with authentication and idempotency. |
+| **chat module** | Chat endpoints follow the layered pattern with authentication, idempotency, WebSocket/webhook broadcasts and hourly purge scheduler. |
 | **connectqueue module** | Queue priority endpoints follow the established layered pattern with authentication, idempotency and rate limiting. |
 | **cron module** | Cron job endpoints follow the established layered pattern with authentication and idempotency. |
 | **coordsaver module** | Coordinate endpoints follow the established layered pattern with authentication and idempotency. |

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -69,3 +69,4 @@
 | 069_add_camera_photos_created_index.sql | Index camera_photos created_at |
 | 070_add_character_vehicle_status.sql | Vehicle HUD state table |
 | 071_add_vehicle_cleanliness_dirt_index.sql | Index dirt_level for vehicle_cleanliness |
+| 072_add_chat_messages_created_index.sql | Index chat_messages created_at column |

--- a/backend/srp-base/docs/modules/chat.md
+++ b/backend/srp-base/docs/modules/chat.md
@@ -1,6 +1,8 @@
 # Chat Module
 
 The chat module records text messages sent in game. Each message is tied to a character and includes the channel and timestamp.
+New messages are broadcast to connected clients via WebSocket and to external sinks via the webhook dispatcher. A scheduler
+purges messages older than `CHAT_RETENTION_MS` (default 7 days).
 
 ## Feature flag
 
@@ -33,9 +35,11 @@ There is no feature flag for chat; the module is always enabled.
 ## Implementation details
 
 * **Repository:** `src/repositories/chatRepository.js` stores and retrieves messages.
-* **Migration:** `src/migrations/039_add_chat_messages.sql` creates the `chat_messages` table.
-* **Routes:** `src/routes/chat.routes.js` defines the REST API.
-* **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
+* **Migration:** `src/migrations/039_add_chat_messages.sql` creates the `chat_messages` table. Index `idx_chat_messages_created_at`
+  is added in `072_add_chat_messages_created_index.sql` for retention cleanup.
+* **Routes:** `src/routes/chat.routes.js` defines the REST API and emits `chat.message` events over WebSocket and webhooks.
+* **Task:** `src/tasks/chat.js` purges messages older than `config.chat.retentionMs`.
+* **OpenAPI:** `openapi/api.yaml` documents schemas and paths including event notes.
 
 ## Future work
 

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -22,3 +22,4 @@
 | carwash:checkmoney | POST /v1/carwash |
 | carwash:success | vehicles.dirt.update |
 | notenoughmoney | error: INSUFFICIENT_FUNDS |
+| chat | chat |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -72,3 +72,4 @@
 | 66 | camera realtime | Photo create/delete push events and retention purge | Extend | Broadcast events and purge old photos |
 | 67 | carandplayerhud | Vehicle and player HUD status sync | Extend | Added vehicle-state API with WebSocket broadcast and cleanup scheduler |
 | 68 | carwash realtime | Vehicle dirt ticks and broadcasts | Extend | Mounted routes, added scheduler, WS & webhook pushes |
+| 69 | chat realtime | In-game chat WS/webhook push and retention purge | Extend | Broadcast `chat.message` and purge old entries |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -316,3 +316,8 @@
 
 - Attempted to clone `https://github.com/h04X-2K/NoPixelServer` for carandplayerhud but checkout failed due to repository size. Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed EssentialMode, ESX, ND Core, FSN, QB-Core, vRP and vORP naming around seatbelt and vehicle status features.
+
+## Research Log – 2025-08-26 (chat)
+
+- Attempted to clone `https://github.com/h04X-2K/NoPixelServer` for chat resource but download was interrupted due to size. Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed chat/message implementations in EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP to align naming and real-time patterns.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,17 +1,19 @@
 # Run Summary – 2025-08-26
 
 ## Modules
-- Carwash module: mounted routes, WebSocket/webhook dirt updates and scheduler tick.
+- Chat module: WebSocket/webhook broadcast on message create and hourly retention purge.
 
 ## Documentation Updated
 - docs/progress-ledger.md
 - docs/events-and-rpcs.md
 - docs/migrations.md
-- docs/modules/carwash.md
-- docs/naming-map.md
-- docs/run-docs.md
+- docs/modules/chat.md
 - docs/admin-ops.md
+- docs/db-schema.md
 - docs/framework-compliance.md
+- docs/naming-map.md
+- docs/research-log.md
+- docs/run-docs.md
 
 ## Outstanding TODO/Gaps
 - Migrate existing apartment and garage consumers to new properties API

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -6215,6 +6215,8 @@ paths:
   /v1/chat/messages:
     post:
       summary: Create chat message
+      description: |
+        Creates a chat message record and pushes it to WebSocket and webhook subscribers.
       operationId: createChatMessage
       requestBody:
         required: true

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -75,6 +75,7 @@ const config = {
   dispatch: { retentionMs: parseInt(process.env.DISPATCH_ALERT_RETENTION_MS || '86400000', 10) },
   baseEvents: { retentionMs: parseInt(process.env.BASE_EVENT_RETENTION_MS || '2592000000', 10) },
   assets: { retentionMs: parseInt(process.env.ASSET_RETENTION_MS || '2592000000', 10) },
+  chat: { retentionMs: parseInt(process.env.CHAT_RETENTION_MS || '604800000', 10) },
   camera: {
     retentionMs: parseInt(process.env.CAMERA_RETENTION_MS || '2592000000', 10),
     cleanupIntervalMs: parseInt(process.env.CAMERA_CLEANUP_INTERVAL_MS || '3600000', 10),

--- a/backend/srp-base/src/migrations/072_add_chat_messages_created_index.sql
+++ b/backend/srp-base/src/migrations/072_add_chat_messages_created_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_chat_messages_created_at ON chat_messages(created_at);

--- a/backend/srp-base/src/repositories/chatRepository.js
+++ b/backend/srp-base/src/repositories/chatRepository.js
@@ -37,7 +37,18 @@ async function createMessage({ characterId, channel, message }) {
   return { id, characterId, channel, message };
 }
 
+/**
+ * Delete chat messages older than the provided cutoff date.
+ * @param {Date} cutoff
+ * @returns {Promise<number>} number of rows removed
+ */
+async function deleteOlderThan(cutoff) {
+  const [result] = await db.query('DELETE FROM chat_messages WHERE created_at < ?', [cutoff]);
+  return result.affectedRows || 0;
+}
+
 module.exports = {
   listMessagesByCharacter,
   createMessage,
+  deleteOlderThan,
 };

--- a/backend/srp-base/src/routes/chat.routes.js
+++ b/backend/srp-base/src/routes/chat.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const { listMessagesByCharacter, createMessage } = require('../repositories/chatRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -42,6 +44,8 @@ router.post('/v1/chat/messages', async (req, res) => {
   try {
     const msg = await createMessage({ characterId: idNum, channel, message });
     sendOk(res, { message: msg }, res.locals.requestId, res.locals.traceId);
+    websocket.broadcast('chat', 'message', { message: msg });
+    hooks.dispatch('chat.message', msg);
   } catch (err) {
     sendError(res, { code: 'CHAT_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
   }

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -18,6 +18,7 @@ const worldTasks = require('./tasks/world');
 const cameraTasks = require('./tasks/camera');
 const hudTasks = require('./tasks/hud');
 const carwashTasks = require('./tasks/carwash');
+const chatTasks = require('./tasks/chat');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -102,6 +103,12 @@ scheduler.register(
   () => carwashTasks.tick(wss),
   carwashTasks.INTERVAL_MS,
   { jitter: 60000, persistName: carwashTasks.JOB_NAME },
+);
+scheduler.register(
+  chatTasks.JOB_NAME,
+  () => chatTasks.purgeOld(),
+  chatTasks.INTERVAL_MS,
+  { jitter: 60000 },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/chat.js
+++ b/backend/srp-base/src/tasks/chat.js
@@ -1,0 +1,18 @@
+const config = require('../config/env');
+const ChatRepository = require('../repositories/chatRepository');
+const logger = require('../utils/logger');
+
+const JOB_NAME = 'chat-purge';
+const INTERVAL_MS = 3600000; // hourly
+
+async function purgeOld() {
+  try {
+    const cutoff = new Date(Date.now() - config.chat.retentionMs);
+    const removed = await ChatRepository.deleteOlderThan(cutoff);
+    if (removed) logger.info({ removed }, 'Pruned stale chat messages');
+  } catch (err) {
+    logger.error({ err }, 'Failed to prune chat messages');
+  }
+}
+
+module.exports = { purgeOld, JOB_NAME, INTERVAL_MS };


### PR DESCRIPTION
## Summary
- broadcast chat messages to websocket clients and webhook sinks
- purge old chat records on an hourly scheduler
- document chat retention and realtime events

## Testing
- `node --check backend/srp-base/src/config/env.js`
- `node --check backend/srp-base/src/repositories/chatRepository.js`
- `node --check backend/srp-base/src/tasks/chat.js`
- `node --check backend/srp-base/src/routes/chat.routes.js`
- `node --check backend/srp-base/src/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad357f6c20832da14200590445d39d