### PR TITLE
srp-base: connectqueue realtime priority events and expiry scheduler

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1424,3 +1424,15 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 * Remove chat scheduler registration and broadcasts.
 * Drop index `idx_chat_messages_created_at`.
+
+## 2025-08-26 – Connect queue realtime & expiry
+
+### Added
+* WebSocket and webhook events on queue priority upsert, remove and expiry.
+* Minute scheduler `connectqueue-expiry` purges expired priorities.
+
+### Risks
+* Misconfigured expiry may drop active priorities unexpectedly.
+
+### Rollback
+* Remove connectqueue scheduler registration and event broadcasts.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,25 +1,23 @@
 # Manifest
 
-- Added chat message WebSocket/webhook broadcasts and retention purge.
+- Added connect queue priority WebSocket/webhook notifications and expiry purge.
 
 | File | Action | Note |
 |---|---|---|
-| src/config/env.js | M | Add CHAT_RETENTION_MS setting |
-| src/repositories/chatRepository.js | M | Add deletion helper |
-| src/tasks/chat.js | A | Purge old messages |
-| src/routes/chat.routes.js | M | Broadcast and dispatch chat messages |
-| src/server.js | M | Register chat-purge scheduler |
-| src/migrations/072_add_chat_messages_created_index.sql | A | Index chat_messages.created_at |
-| openapi/api.yaml | M | Document chat message broadcast |
-| docs/admin-ops.md | M | Mention chat retention and scheduler |
-| docs/db-schema.md | M | Document chat_message indexes |
-| docs/events-and-rpcs.md | M | Map chat.message event |
-| docs/modules/chat.md | M | Describe realtime and purge |
-| docs/migrations.md | M | Log migration 072 |
-| docs/framework-compliance.md | M | Update chat compliance |
-| docs/progress-ledger.md | M | Record chat realtime entry |
-| docs/naming-map.md | M | Map chat → chat |
-| docs/research-log.md | M | Log chat research |
-| docs/run-docs.md | M | Consolidated run notes |
-| CHANGELOG.md | M | Chat realtime & retention entry |
+| src/repositories/connectqueueRepository.js | M | Add purgeExpired helper |
+| src/tasks/connectqueue.js | A | Purge expired priorities and broadcast |
+| src/routes/connectqueue.routes.js | M | Broadcast and dispatch priority updates |
+| src/server.js | M | Register connectqueue-expiry scheduler |
+| docs/modules/connectqueue.md | M | Document realtime and scheduler |
+| docs/events-and-rpcs.md | M | Map connectqueue priority events |
+| docs/progress-ledger.md | M | Record connectqueue realtime entry |
+| docs/admin-ops.md | M | Mention scheduler and webhooks |
+| docs/BASE_API_DOCUMENTATION.md | M | Note events and scheduler |
+| docs/framework-compliance.md | M | Update connectqueue compliance |
+| docs/index.md | M | Note connectqueue update |
+| docs/naming-map.md | M | Map connectqueue |
+| docs/run-docs.md | M | Summary of run |
+| docs/research-log.md | M | Log connectqueue research |
+| docs/todo-gaps.md | M | Add queue priority admin TODO |
+| CHANGELOG.md | M | Connect queue realtime & expiry entry |
 | MANIFEST.md | M | Update manifest |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -529,6 +529,7 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
   - `GET /v1/connectqueue/priorities` – List queue priorities optionally filtered by `accountId`.
   - `POST /v1/connectqueue/priorities` – Upsert a priority with `accountId`, `priority`, optional `reason` and `expiresAt`.
   - `DELETE /v1/connectqueue/priorities/{accountId}` – Remove priority for an account.
+  - Emits WebSocket/webhook events `priority.upserted`, `priority.removed` and `priority.expired`; `connectqueue-expiry` scheduler purges expired entries.
 - **srp-hardcap** – Manages server connection limits and active sessions.
   - `GET /v1/hardcap/status` – Current max players, reserved slots and active count.
   - `POST /v1/hardcap/config` – Update max player and reserved slot settings.

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -34,6 +34,7 @@
 - Ensure the `carwash_transactions` and `vehicle_cleanliness` tables exist for carwash tracking.
 - Ensure the `chat_messages` table exists for chat logging. Messages older than `CHAT_RETENTION_MS` are purged hourly by the `chat-purge` scheduler.
 - Ensure the `queue_priorities` table exists for connection queue priority management.
+- Monitor `connectqueue-expiry` scheduler purging expired priorities; priority updates emit `connectqueue.priority.*` webhooks.
 - Ensure the `character_coords` table exists for saved coordinates.
 - Ensure the `interiors` table exists for apartment interior layouts.
 - Ensure the `character_emotes` table exists for favorite emotes.

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -31,7 +31,7 @@
 | carandplayerhud | Resource broadcasts HUD updates and vehicle state changes | `GET /v1/characters/{characterId}/hud`, `PUT /v1/characters/{characterId}/hud`, `GET /v1/characters/{characterId}/vehicle-state`, `PUT /v1/characters/{characterId}/vehicle-state` → WebSocket `hud.vehicleState` |
 | carwash | `carwash:checkmoney`, `carwash:success`, `notenoughmoney` | `POST /v1/carwash`, `GET /v1/carwash/history/{characterId}`, `GET/PATCH /v1/vehicles/{plate}/dirt`; dirt changes push `vehicles.dirt.update` |
 | chat | Resource broadcasts chat messages | `POST /v1/chat/messages` logs and pushes `chat.message`; history via `GET /v1/chat/messages/{characterId}`; scheduler `chat-purge` removes old logs |
-| connectqueue | Resource uses exports `AddPriority` and `RemovePriority` with account identifiers | `GET/POST/DELETE /v1/connectqueue/priorities` manage backend priority records |
+| connectqueue | Resource uses exports `AddPriority` and `RemovePriority` with account identifiers and now pushes `priority.upserted`, `priority.removed` and `priority.expired` over WebSocket and webhooks | `GET/POST/DELETE /v1/connectqueue/priorities` manage backend priority records |
 | coordsaver | Resource lets players save named coordinates | `GET /v1/characters/{characterId}/coords`, `POST /v1/characters/{characterId}/coords`, `DELETE /v1/characters/{characterId}/coords/{id}` |
 | drz_interiors | Resource triggers save/load events for apartment interior templates | `GET /v1/apartments/{apartmentId}/interior`, `POST /v1/apartments/{apartmentId}/interior` |
 | emotes | Resource lets players mark favorite emote commands for quick selection | `GET/POST/DELETE /v1/characters/{characterId}/emotes` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -73,7 +73,7 @@ practice is supported by citations.
 | **hud module** | HUD preference and vehicle state endpoints follow the established layered pattern with authentication, idempotency and WebSocket broadcasts. |
 | **carwash module** | Carwash endpoints follow the established layered pattern with authentication and idempotency; dirt ticks broadcast via WebSocket and webhooks. |
 | **chat module** | Chat endpoints follow the layered pattern with authentication, idempotency, WebSocket/webhook broadcasts and hourly purge scheduler. |
-| **connectqueue module** | Queue priority endpoints follow the established layered pattern with authentication, idempotency and rate limiting. |
+| **connectqueue module** | Queue priority endpoints follow the established layered pattern with authentication, idempotency and rate limiting; updates broadcast via WebSocket/webhooks and expired priorities purged by scheduler. |
 | **cron module** | Cron job endpoints follow the established layered pattern with authentication and idempotency. |
 | **coordsaver module** | Coordinate endpoints follow the established layered pattern with authentication and idempotency. |
 | **interiors module** | Interior endpoints follow the established layered pattern with authentication and idempotency. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -470,3 +470,7 @@ Extended camera module with WebSocket and webhook pushes plus scheduled retentio
 ## Update – 2025-08-26
 
 Extended HUD module with vehicle state tracking, WebSocket broadcasts and scheduled cleanup.
+
+## Update – 2025-08-26
+
+Extended connect queue module with WebSocket/webhook priority events and scheduled expiry purge.

--- a/backend/srp-base/docs/modules/connectqueue.md
+++ b/backend/srp-base/docs/modules/connectqueue.md
@@ -37,7 +37,8 @@ There is no feature flag for connectqueue; the module is always enabled.
 
 * **Repository:** `src/repositories/connectqueueRepository.js` stores priority entries.
 * **Migration:** `src/migrations/040_add_queue_priorities.sql` creates the `queue_priorities` table.
-* **Routes:** `src/routes/connectqueue.routes.js` defines the REST API.
+* **Routes:** `src/routes/connectqueue.routes.js` defines the REST API and emits WebSocket and webhook events `priority.upserted` and `priority.removed`.
+* **Scheduler:** `src/tasks/connectqueue.js` purges expired priorities every minute and broadcasts `priority.expired` events.
 * **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
 
 ## Future work

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -23,3 +23,4 @@
 | carwash:success | vehicles.dirt.update |
 | notenoughmoney | error: INSUFFICIENT_FUNDS |
 | chat | chat |
+| connectqueue | connectqueue |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -73,3 +73,4 @@
 | 67 | carandplayerhud | Vehicle and player HUD status sync | Extend | Added vehicle-state API with WebSocket broadcast and cleanup scheduler |
 | 68 | carwash realtime | Vehicle dirt ticks and broadcasts | Extend | Mounted routes, added scheduler, WS & webhook pushes |
 | 69 | chat realtime | In-game chat WS/webhook push and retention purge | Extend | Broadcast `chat.message` and purge old entries |
+| 70 | connectqueue realtime | Queue priority pushes and expiry purge | Extend | Broadcast `priority.*` events and scheduler cleanup |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -321,3 +321,8 @@
 
 - Attempted to clone `https://github.com/h04X-2K/NoPixelServer` for chat resource but download was interrupted due to size. Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed chat/message implementations in EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP to align naming and real-time patterns.
+
+## Research Log – 2025-08-26 (connectqueue)
+
+- Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed connection queue patterns in ESX, QB-Core and ND Core for priority and expiry handling.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,18 +1,19 @@
 # Run Summary – 2025-08-26
 
 ## Modules
-- Chat module: WebSocket/webhook broadcast on message create and hourly retention purge.
+- Connect Queue: WebSocket/webhook priority events and minute-based expiry purge.
 
 ## Documentation Updated
 - docs/progress-ledger.md
 - docs/events-and-rpcs.md
-- docs/migrations.md
-- docs/modules/chat.md
+- docs/modules/connectqueue.md
 - docs/admin-ops.md
-- docs/db-schema.md
+- docs/BASE_API_DOCUMENTATION.md
 - docs/framework-compliance.md
 - docs/naming-map.md
+- docs/index.md
 - docs/research-log.md
+- docs/todo-gaps.md
 - docs/run-docs.md
 
 ## Outstanding TODO/Gaps
@@ -22,3 +23,4 @@
 - Paginate and search property listings
 - Document world event endpoints in OpenAPI
 - Integrate player vitals (hunger, thirst, stress) into HUD module
+- Add admin bulk adjustment endpoints for queue priorities

--- a/backend/srp-base/docs/todo-gaps.md
+++ b/backend/srp-base/docs/todo-gaps.md
@@ -8,3 +8,4 @@
 | Paginate and search property listings | backend | low | none |
 | Document world event endpoints in OpenAPI | backend | medium | spec alignment |
 | Integrate player vitals (hunger, thirst, stress) into HUD module | backend | medium | gameplay design |
+| Add admin bulk adjustment endpoints for queue priorities | backend | low | none |

--- a/backend/srp-base/src/repositories/connectqueueRepository.js
+++ b/backend/srp-base/src/repositories/connectqueueRepository.js
@@ -51,8 +51,23 @@ async function removePriority(accountId) {
   await db.query('DELETE FROM queue_priorities WHERE account_id = ?', [accountId]);
 }
 
+/**
+ * Purge expired queue priorities and return affected account IDs.
+ * @returns {Promise<number[]>}
+ */
+async function purgeExpired() {
+  const rows = await db.query(
+    'SELECT account_id FROM queue_priorities WHERE expires_at IS NOT NULL AND expires_at < NOW()',
+  );
+  if (rows.length) {
+    await db.query('DELETE FROM queue_priorities WHERE expires_at IS NOT NULL AND expires_at < NOW()');
+  }
+  return rows.map((r) => r.account_id);
+}
+
 module.exports = {
   listPriorities,
   upsertPriority,
   removePriority,
+  purgeExpired,
 };

--- a/backend/srp-base/src/routes/connectqueue.routes.js
+++ b/backend/srp-base/src/routes/connectqueue.routes.js
@@ -2,6 +2,8 @@ const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const { listPriorities, upsertPriority, removePriority } = require('../repositories/connectqueueRepository');
 const { createRateLimiter } = require('../middleware/rateLimit');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -64,6 +66,8 @@ router.post('/v1/connectqueue/priorities', async (req, res) => {
   }
   try {
     const priorityRow = await upsertPriority({ accountId: accountNum, priority: priorityNum, reason, expiresAt: expiresDate });
+    websocket.broadcast('connectqueue', 'priority.upserted', priorityRow);
+    dispatcher.dispatch('connectqueue.priority.upserted', priorityRow);
     sendOk(res, { priority: priorityRow }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'QUEUE_PRIORITY_UPSERT_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
@@ -85,6 +89,9 @@ router.delete('/v1/connectqueue/priorities/:accountId', async (req, res) => {
   }
   try {
     await removePriority(accountNum);
+    const payload = { accountId: accountNum };
+    websocket.broadcast('connectqueue', 'priority.removed', payload);
+    dispatcher.dispatch('connectqueue.priority.removed', payload);
     sendOk(res, { deleted: true }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'QUEUE_PRIORITY_DELETE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -19,6 +19,7 @@ const cameraTasks = require('./tasks/camera');
 const hudTasks = require('./tasks/hud');
 const carwashTasks = require('./tasks/carwash');
 const chatTasks = require('./tasks/chat');
+const connectqueueTasks = require('./tasks/connectqueue');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -109,6 +110,12 @@ scheduler.register(
   () => chatTasks.purgeOld(),
   chatTasks.INTERVAL_MS,
   { jitter: 60000 },
+);
+scheduler.register(
+  connectqueueTasks.JOB_NAME,
+  () => connectqueueTasks.purgeExpired(),
+  connectqueueTasks.INTERVAL_MS,
+  { jitter: 5000, persistName: connectqueueTasks.JOB_NAME },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/connectqueue.js
+++ b/backend/srp-base/src/tasks/connectqueue.js
@@ -1,0 +1,17 @@
+const connectqueueRepo = require('../repositories/connectqueueRepository');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
+
+const JOB_NAME = 'connectqueue-expiry';
+const INTERVAL_MS = 60_000;
+
+async function purgeExpired() {
+  const expired = await connectqueueRepo.purgeExpired();
+  expired.forEach((accountId) => {
+    const payload = { accountId };
+    websocket.broadcast('connectqueue', 'priority.expired', payload);
+    dispatcher.dispatch('connectqueue.priority.expired', payload);
+  });
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, purgeExpired };


### PR DESCRIPTION
## Summary
- broadcast connect queue priority changes via WebSocket and webhook
- purge expired queue priorities on a minute scheduler
- document connectqueue realtime events and update admin guidance

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "require('./src/routes/connectqueue.routes.js')"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68ad4f424c08832da464bb7cbadb970c