### PR TITLE
srp-base(cron): cluster consolidation + parity + ws/webhooks + scheduler + express

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1451,3 +1451,16 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 * Remove `coordinates-purge` scheduler registration and broadcast hooks.
 * Restore previous route and repository names if needed.
+
+## 2025-08-27 – Cron execution worker
+
+### Added
+* Scheduler task `cron-executor` broadcasting `cron.execute` via WebSocket and webhooks.
+* Repository helpers for due job queries and rescheduling.
+* Documentation for cron realtime events.
+
+### Risks
+* Misconfigured cron expressions may schedule jobs too frequently.
+
+### Rollback
+* Remove cron executor registration and repository helpers.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,26 +1,22 @@
 # Manifest
 
-- Renamed coordsaver module to coordinates with WebSocket/webhook events and daily purge scheduler.
+- Added cron execution worker broadcasting `cron.execute` via WebSocket and webhooks.
 
 | File | Action | Note |
 |---|---|---|
-| src/routes/coordsaver.routes.js | R -> src/routes/coordinates.routes.js | Renamed and added broadcasts + alias paths |
-| src/repositories/coordsaverRepository.js | R -> src/repositories/coordinatesRepository.js | Added purgeOldCoords |
-| src/tasks/coordinates.js | A | Daily purge task |
-| src/app.js | M | Import renamed routes |
-| src/server.js | M | Register coordinates-purge scheduler |
-| openapi/api.yaml | M | Rename paths to /coordinates; add deprecated /coords |
-| docs/modules/coordinates.md | R | Updated module docs |
-| docs/progress-ledger.md | M | Record rename and realtime |
-| docs/index.md | M | Note coordinates update |
-| docs/framework-compliance.md | M | Update compliance table |
-| docs/BASE_API_DOCUMENTATION.md | M | Rename API map |
-| docs/events-and-rpcs.md | M | Document realtime events |
-| docs/naming-map.md | M | Map coordsaver → coordinates |
-| docs/admin-ops.md | M | Note purge scheduler |
-| docs/testing.md | M | Update manual test commands |
-| docs/research-log.md | M | Log coordinates research |
-| docs/migrations.md | M | Clarify coordinate migration |
+| src/tasks/cron.js | A | Executes due cron jobs and emits events |
+| src/repositories/cronRepository.js | M | Added due job queries and rescheduling |
+| src/server.js | M | Registered cron executor task |
+| package.json | M | Added cron-parser dependency |
+| docs/modules/cron.md | M | Document cron scheduler |
+| docs/events-and-rpcs.md | M | Added cron.execute event |
+| docs/BASE_API_DOCUMENTATION.md | M | Listed cron.execute push |
+| docs/framework-compliance.md | M | Noted cron scheduler compliance |
+| docs/index.md | M | Updated run summary |
+| docs/progress-ledger.md | M | Logged cron execution worker |
+| docs/research-log.md | M | Added cron executor research |
 | docs/run-docs.md | M | Consolidated run summary |
-| CHANGELOG.md | M | Add coordinates rename entry |
-| MANIFEST.md | M | Update manifest |
+| docs/todo-gaps.md | M | Added cron management TODO |
+| CHANGELOG.md | M | Added cron execution entry |
+
+**Startup Notes:** install dependencies with `npm install` (may require resolving express-openapi-validator version).

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -538,6 +538,7 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
 - **srp-cron** – Schedules timed server tasks.
   - `GET /v1/cron/jobs` – List registered cron jobs.
   - `POST /v1/cron/jobs` – Create or replace a cron job with `name`, `schedule`, optional `payload`, `accountId`, `characterId`, `priority` and `nextRun`.
+  - Scheduler emits WebSocket event `cron.execute` and dispatches webhooks when jobs run.
 - **srp-coordinates** – Stores character-specific saved coordinates.
   - `GET /v1/characters/{characterId}/coordinates` – List saved coordinates.
   - `POST /v1/characters/{characterId}/coordinates` – Save or update a coordinate (`name`, `x`, `y`, `z`, optional `heading`).

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -19,7 +19,7 @@
 | bob74_ipl | Resource toggles interior proxies (IPLs) for world interiors | `GET/POST/DELETE /v1/world/ipls` → pushes `world.ipl.updated`; scheduler broadcasts `world.ipl.sync` |
 | maps | No server events; world mapping assets | N/A |
 | furnished-shells | No server events; interior shell assets | N/A |
-| Cron | Resource triggers scheduled events for maintenance and gameplay loops | `GET /v1/cron/jobs`, `POST /v1/cron/jobs` |
+| Cron | Resource triggers scheduled events for maintenance and gameplay loops | `GET /v1/cron/jobs`, `POST /v1/cron/jobs`; scheduler broadcasts `cron.execute` |
 | hair-pack | No server events; cosmetic hair assets | N/A |
 | mh65c | No server events; vehicle model asset | N/A |
 | motel | No server events; building interior asset | N/A |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -74,7 +74,7 @@ practice is supported by citations.
 | **carwash module** | Carwash endpoints follow the established layered pattern with authentication and idempotency; dirt ticks broadcast via WebSocket and webhooks. |
 | **chat module** | Chat endpoints follow the layered pattern with authentication, idempotency, WebSocket/webhook broadcasts and hourly purge scheduler. |
 | **connectqueue module** | Queue priority endpoints follow the established layered pattern with authentication, idempotency and rate limiting; updates broadcast via WebSocket/webhooks and expired priorities purged by scheduler. |
-| **cron module** | Cron job endpoints follow the established layered pattern with authentication and idempotency. |
+| **cron module** | Cron job endpoints follow the layered pattern with authentication and idempotency; a scheduler now executes due jobs and pushes `cron.execute` over WebSocket/webhooks. |
 | **coordinates module** | Coordinate endpoints follow the established layered pattern with authentication, idempotency, WebSocket/webhook events and scheduled cleanup. |
 | **interiors module** | Interior endpoints follow the established layered pattern with authentication and idempotency. |
 | **emotes module** | Favorite emote endpoints follow the established layered pattern with authentication and idempotency. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -484,3 +484,9 @@ Renamed coordsaver to **coordinates** with real-time pushes and retention.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/coordinates.md`.
 Reference resources unavailable; proceeding with internal consistency only.
+
+## Update – 2025-08-27
+
+Added cron execution worker that polls due jobs and pushes `cron.execute` over WebSocket and webhooks.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/cron.md`.

--- a/backend/srp-base/docs/modules/cron.md
+++ b/backend/srp-base/docs/modules/cron.md
@@ -42,11 +42,12 @@ There is no feature flag for cron; the module is always enabled.
 
 ## Implementation details
 
-* **Repository:** `src/repositories/cronRepository.js` manages job persistence.
-* **Migration:** `src/migrations/041_add_cron_jobs.sql` creates the `cron_jobs` table.
+* **Repository:** `src/repositories/cronRepository.js` manages job persistence and rescheduling.
+* **Migration:** `src/migrations/042_add_cron_jobs.sql` creates the `cron_jobs` table.
 * **Routes:** `src/routes/cron.routes.js` exposes REST endpoints.
+* **Scheduler:** `src/tasks/cron.js` polls due jobs, broadcasts `cron.execute` over WebSocket and dispatches webhooks.
 * **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
 
 ## Future work
 
-Cron execution workers could consume this schedule to trigger server events.
+Additional job types and administrative endpoints could further expand scheduling capabilities.

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -75,3 +75,4 @@
 | 69 | chat realtime | In-game chat WS/webhook push and retention purge | Extend | Broadcast `chat.message` and purge old entries |
 | 70 | connectqueue realtime | Queue priority pushes and expiry purge | Extend | Broadcast `priority.*` events and scheduler cleanup |
 | 71 | coordsaver → coordinates | Rename with realtime events and retention | Extend | Broadcast saves/deletes, daily purge task |
+| 72 | cron | Scheduled job execution pushes | Extend | Added cron executor with WebSocket/webhook dispatch |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -138,6 +138,11 @@
 - Video: "NoPixel 4.0 Dev Update – World Timers" – https://www.youtube.com/watch?v=dQw4w9WgXcQ
 - Forum thread: "ProdigyRP 4.0 – Scheduled Events" – https://forum.example.com/prodigy-cron
 
+## Research Log – 2025-08-27 (Cron executor)
+
+- Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.
+- Reviewed `cron-parser` documentation for computing next execution times.
+
 ## Research Log – 2025-08-24 (coordsaver)
 
 - Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Proceeded with internal consistency only.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,21 +1,18 @@
-# Run Summary – 2025-08-26
+# Run Summary – 2025-08-27
 
 ## Modules
-- Coordinates: renamed from coordsaver with WebSocket/webhook events and daily purge scheduler.
+- Cron: added execution worker with WebSocket and webhook pushes.
 
 ## Documentation Updated
 - docs/progress-ledger.md
 - docs/events-and-rpcs.md
-- docs/modules/coordinates.md
-- docs/admin-ops.md
+- docs/modules/cron.md
 - docs/BASE_API_DOCUMENTATION.md
 - docs/framework-compliance.md
-- docs/naming-map.md
 - docs/index.md
-- docs/testing.md
 - docs/research-log.md
-- docs/migrations.md
 - docs/run-docs.md
+- docs/todo-gaps.md
 
 ## Outstanding TODO/Gaps
 | Item | Owner | Priority | Blockers |
@@ -27,3 +24,4 @@
 | Document world event endpoints in OpenAPI | backend | medium | spec alignment |
 | Integrate player vitals (hunger, thirst, stress) into HUD module | backend | medium | gameplay design |
 | Add admin bulk adjustment endpoints for queue priorities | backend | low | none |
+| Add admin endpoints for cron job management | backend | low | none |

--- a/backend/srp-base/docs/todo-gaps.md
+++ b/backend/srp-base/docs/todo-gaps.md
@@ -9,3 +9,4 @@
 | Document world event endpoints in OpenAPI | backend | medium | spec alignment |
 | Integrate player vitals (hunger, thirst, stress) into HUD module | backend | medium | gameplay design |
 | Add admin bulk adjustment endpoints for queue priorities | backend | low | none |
+| Add admin endpoints for cron job management | backend | low | none |

--- a/backend/srp-base/package.json
+++ b/backend/srp-base/package.json
@@ -18,7 +18,8 @@
     "pino": "^8.15.0",
     "prom-client": "^14.1.1",
     "uuid": "^9.0.1",
-    "ws": "^8.17.0"
+    "ws": "^8.17.0",
+    "cron-parser": "^4.8.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/backend/srp-base/src/repositories/cronRepository.js
+++ b/backend/srp-base/src/repositories/cronRepository.js
@@ -67,8 +67,47 @@ async function updateLastRun(name, lastRun) {
   await db.query('UPDATE cron_jobs SET last_run = ? WHERE name = ?', [lastRun, name]);
 }
 
+/**
+ * Fetch cron jobs that are due to run.
+ * Jobs are ordered by priority (desc) then next_run.
+ *
+ * @param {number} [limit=50] maximum number of jobs to return
+ * @returns {Promise<Array>} due cron jobs
+ */
+async function getDueJobs(limit = 50) {
+  const rows = await db.query(
+    'SELECT id, name, schedule, payload, account_id AS accountId, character_id AS characterId, priority, next_run AS nextRun, last_run AS lastRun, created_at AS createdAt, updated_at AS updatedAt FROM cron_jobs WHERE next_run <= NOW() ORDER BY priority DESC, next_run ASC LIMIT ?',
+    [limit],
+  );
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    schedule: row.schedule,
+    payload: row.payload ? JSON.parse(row.payload) : null,
+    accountId: row.accountId,
+    characterId: row.characterId,
+    priority: row.priority,
+    nextRun: row.nextRun,
+    lastRun: row.lastRun,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }));
+}
+
+/**
+ * Update job next_run and last_run after execution.
+ *
+ * @param {number} id cron job id
+ * @param {string} nextRun ISO datetime for next execution
+ */
+async function markRan(id, nextRun) {
+  await db.query('UPDATE cron_jobs SET last_run = NOW(), next_run = ? WHERE id = ?', [nextRun, id]);
+}
+
 module.exports = {
   getAllJobs,
   createJob,
   updateLastRun,
+  getDueJobs,
+  markRan,
 };

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -21,6 +21,7 @@ const carwashTasks = require('./tasks/carwash');
 const chatTasks = require('./tasks/chat');
 const connectqueueTasks = require('./tasks/connectqueue');
 const coordinatesTasks = require('./tasks/coordinates');
+const cronTasks = require('./tasks/cron');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -123,6 +124,12 @@ scheduler.register(
   () => coordinatesTasks.purgeOld(),
   coordinatesTasks.INTERVAL_MS,
   { jitter: 60000, persistName: coordinatesTasks.JOB_NAME },
+);
+scheduler.register(
+  cronTasks.JOB_NAME,
+  () => cronTasks.runDue(),
+  cronTasks.INTERVAL_MS,
+  { jitter: 5000, persistName: cronTasks.JOB_NAME },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/cron.js
+++ b/backend/srp-base/src/tasks/cron.js
@@ -1,0 +1,34 @@
+const parser = require('cron-parser');
+const cronRepo = require('../repositories/cronRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
+const logger = require('../utils/logger');
+
+const JOB_NAME = 'cron-executor';
+const INTERVAL_MS = 60000; // check every minute
+
+async function runDue() {
+  try {
+    const jobs = await cronRepo.getDueJobs();
+    for (const job of jobs) {
+      // Broadcast over WebSocket
+      websocket.broadcast('cron', 'execute', job);
+      // Dispatch to webhooks
+      hooks.dispatch('cron.execute', job);
+      let nextRun;
+      try {
+        const iter = parser.parseExpression(job.schedule, { currentDate: new Date(job.nextRun) });
+        nextRun = iter.next().toISOString();
+      } catch (err) {
+        logger.error({ err, job }, 'Failed to parse cron schedule');
+        // fallback: run again in one hour
+        nextRun = new Date(Date.now() + 3600000).toISOString();
+      }
+      await cronRepo.markRan(job.id, nextRun);
+    }
+  } catch (err) {
+    logger.error({ err }, 'Cron executor failed');
+  }
+}
+
+module.exports = { runDue, JOB_NAME, INTERVAL_MS };


### PR DESCRIPTION
## Summary
- add cron executor task that broadcasts `cron.execute` and dispatches webhooks
- extend cron repository for due job queries and rescheduling
- document cron scheduler and realtime events

## Testing
- `npm install` *(fails: No matching version found for express-openapi-validator@^4.18.3)*
- `node -e "require('./src/tasks/cron');"` *(fails: Cannot find module 'cron-parser')*

------
https://chatgpt.com/codex/tasks/task_e_68ae7933499c832da9438ac0620a2d7c