### PR TITLE
feat(es_taxi): taxi request realtime events and expiry scheduler

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1504,3 +1504,17 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Remove EMS scheduler registration and revert EMS route broadcasts.
+
+## 2025-08-27 – Taxi request realtime & expiry
+
+### Added
+* WebSocket/webhook events for taxi request create/accept/complete/expire.
+* Scheduler `taxi-request-expiry` cancels stale requests using `TAXI_REQUEST_TTL_MS`.
+* Config `TAXI_REQUEST_TTL_MS` to control request lifespan.
+* Migration `074_add_taxi_rides_status_created_index.sql` adds `(status, created_at)` index.
+
+### Risks
+* Misconfigured TTL may cancel active rides prematurely.
+
+### Rollback
+* Remove taxi scheduler registration, revert taxi route broadcasts and drop added index.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,19 +1,26 @@
 # Manifest
 
-- Added EMS realtime shift & record events with scheduler.
+- Added taxi request realtime events with expiry scheduler and config TTL.
 
 | File | Action | Note |
 |---|---|---|
-| src/config/env.js | M | EMS broadcast and shift duration config |
-| src/routes/ems.routes.js | M | Emit WebSocket/webhook events |
-| src/tasks/ems.js | A | Scheduled shift sync and broadcasts |
-| src/server.js | M | Registered `ems-shift-sync` scheduler |
-| docs/modules/ems.md | M | Documented realtime events and scheduler |
-| docs/events-and-rpcs.md | M | Mapped EMS events |
-| docs/naming-map.md | M | Added emspack→ems mapping |
-| docs/progress-ledger.md | M | Logged EMS realtime entry |
-| docs/index.md | M | Added EMS update |
-| docs/research-log.md | M | Logged EMS research |
-| docs/run-docs.md | M | Summarized EMS changes |
+| src/config/env.js | M | Introduced `taxi.requestTtlMs` configuration |
+| src/repositories/taxiRepository.js | M | Added stale request cancellation |
+| src/tasks/taxi.js | A | Scheduler to expire taxi requests |
+| src/server.js | M | Registered taxi expiry scheduler |
+| src/routes/taxi.routes.js | M | Broadcast and webhook taxi events |
+| src/migrations/074_add_taxi_rides_status_created_index.sql | A | Index on `(status, created_at)` |
+| docs/modules/taxi.md | M | Documented scheduler and realtime events |
+| docs/events-and-rpcs.md | M | Mapped taxi events |
+| docs/BASE_API_DOCUMENTATION.md | M | Listed taxi WebSocket events |
+| docs/progress-ledger.md | M | Logged taxi realtime entry |
+| docs/framework-compliance.md | M | Noted taxi module compliance |
+| docs/admin-ops.md | M | Added taxi index and TTL note |
+| docs/db-schema.md | M | Recorded taxi index |
+| docs/migrations.md | M | Added migration entry |
+| docs/naming-map.md | M | Added es_taxi → taxi mapping |
+| docs/index.md | M | Added taxi update summary |
+| docs/research-log.md | M | Logged taxi research |
+| docs/run-docs.md | M | Run summary and outstanding tasks |
 
 **Startup Notes:** install dependencies with `npm install` (fails: express-openapi-validator@^4.18.3 not found).

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -568,6 +568,7 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
 - `POST /v1/taxi/requests/{id}/accept` – accept a request
 - `POST /v1/taxi/requests/{id}/complete` – complete a ride
 - `GET /v1/characters/{characterId}/taxi/rides` – ride history
+  - WebSocket: `taxi.request.created`, `taxi.request.accepted`, `taxi.request.completed`, `taxi.request.expired`
 
 ### Hospital
 

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -18,6 +18,7 @@
 - Ensure the `wise_uc_profiles` table exists for undercover aliases.
 - Ensure the `wise_wheels_spins` table exists for wheel spin history.
   - Ensure index `idx_wise_wheels_created` exists; spins older than 30 days are purged hourly by `wise-wheels-expire` scheduler.
+- Ensure the `taxi_rides` table has index `idx_taxi_status_created_at`; tune `TAXI_REQUEST_TTL_MS` to control stale request expiry.
  - Ensure the `assets` table exists with indexes `idx_assets_owner` and `idx_assets_created_at`; tune `ASSET_RETENTION_MS` for the `assets-prune` scheduler.
 - Ensure the `clothes` table exists for character outfit records.
 - Ensure the `apartments` and `apartment_residents` tables exist and include the `character_id` column after deploying this sprint.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -428,6 +428,7 @@ Rows older than `BASE_EVENT_RETENTION_MS` are purged hourly by the `base-events-
 | created_at | TIMESTAMP | Creation time |
 | accepted_at | TIMESTAMP | Driver accepted time |
 | completed_at | TIMESTAMP | Completion time |
+| indexes | - | `idx_taxi_status_created_at` on `(status, created_at)` |
 
 ## furniture
 

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -36,7 +36,7 @@
 | drz_interiors | Resource triggers save/load events for apartment interior templates | `GET /v1/apartments/{apartmentId}/interior`, `POST /v1/apartments/{apartmentId}/interior` → `interiors.apartment.updated` |
 | emotes | Resource lets players mark favorite emote commands for quick selection and sync updates via `emotes.favoriteAdded`/`emotes.favoriteRemoved`/`emotes.favoriteExpired` | `GET/POST/DELETE /v1/characters/{characterId}/emotes` |
 | emspack | Duty start/end and treatment events | `GET/POST/PATCH/DELETE /v1/ems/records`, `GET /v1/ems/shifts/active`, `POST /v1/ems/shifts`, `POST /v1/ems/shifts/{id}/end` → broadcasts `ems.record.*`, `ems.shift.started`, `ems.shift.ended`, `ems.shifts.active` |
-| es_taxi | Players request taxi rides and drivers accept/complete them | `POST /v1/taxi/requests`, `POST /v1/taxi/requests/{id}/accept`, `POST /v1/taxi/requests/{id}/complete` |
+| es_taxi | Players request taxi rides and drivers accept/complete them | `POST /v1/taxi/requests`, `POST /v1/taxi/requests/{id}/accept`, `POST /v1/taxi/requests/{id}/complete` | `taxi.request.created`, `taxi.request.accepted`, `taxi.request.completed`, `taxi.request.expired` |
 | k9 | Police dog deployment and status commands | `GET/POST /v1/characters/{characterId}/k9s`, `PATCH /v1/characters/{characterId}/k9s/{k9Id}/active`, `DELETE /v1/characters/{characterId}/k9s/{k9Id}` |
 | dispatch | Police dispatch alerts and code lists | `GET/POST /v1/dispatch/alerts`, `PATCH /v1/dispatch/alerts/{id}/ack`, `GET /v1/dispatch/codes` |
 | furniture | Resource lets players place or remove furniture items | `GET /v1/characters/{characterId}/furniture`, `POST /v1/characters/{characterId}/furniture`, `DELETE /v1/characters/{characterId}/furniture/{id}` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -102,6 +102,7 @@ practice is supported by citations.
 | **dispatch module** | Dispatch alert endpoints follow the established layered pattern with authentication and idempotency. |
 | **properties module** | Property endpoints consolidate apartments, garages and rentals with layered design, rate limiting, idempotency, WebSocket/webhook events and lease expiry scheduler. |
 | **world IPL module** | Interior proxy endpoints follow layered design with WebSocket sync and scheduler broadcast. |
+| **taxi module** | Taxi request endpoints follow layered design with WebSocket/webhook events and expiry scheduler. |
 
 ## Outstanding Items
 
@@ -111,3 +112,4 @@ practice is supported by citations.
 - Document world event endpoints in OpenAPI.
 - Integrate player vitals (hunger, thirst, stress) into HUD module.
 - Implement bulk emote sync endpoint and labeling/ordering support.
+- Provide passenger cancellation endpoint for taxi requests.

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -518,3 +518,12 @@ Extended EMS module with realtime shift and record events plus scheduled shift s
 * Job `ems-shift-sync` ends overlong shifts.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/ems.md`.
+
+## Update – 2025-08-27
+
+Extended taxi dispatch with real-time events and stale request cleanup.
+
+* Taxi request create/accept/complete events broadcast via WebSocket and webhooks.
+* Scheduler `taxi-request-expiry` cancels requests older than `TAXI_REQUEST_TTL_MS`.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/taxi.md`.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -71,3 +71,4 @@
 | 071_add_vehicle_cleanliness_dirt_index.sql | Index dirt_level for vehicle_cleanliness |
 | 072_add_chat_messages_created_index.sql | Index chat_messages created_at column |
 | 073_update_interiors_unique_key.sql | Ensure apartment interiors unique per character |
+| 074_add_taxi_rides_status_created_index.sql | Index taxi_rides on status and created_at |

--- a/backend/srp-base/docs/modules/taxi.md
+++ b/backend/srp-base/docs/modules/taxi.md
@@ -47,9 +47,12 @@ No feature flag; module is always enabled.
 
 * **Repository:** `src/repositories/taxiRepository.js` persists requests and rides.
 * **Migration:** `src/migrations/046_add_taxi_rides.sql` creates the `taxi_rides` table.
+* **Migration:** `src/migrations/074_add_taxi_rides_status_created_index.sql` adds `(status, created_at)` index for expiry checks.
 * **Routes:** `src/routes/taxi.routes.js` defines the REST API.
 * **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
+* **Scheduler:** `src/tasks/taxi.js` cancels stale requests based on `TAXI_REQUEST_TTL_MS`.
+* **Realtime:** `taxi.request.created`, `taxi.request.accepted`, `taxi.request.completed`, `taxi.request.expired` via WebSocket and webhooks.
 
 ## Future work
 
-Add ride cancellation and pricing configuration.
+Add manual ride cancellation and pricing configuration.

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -28,3 +28,4 @@
 | drz_interiors | interiors |
 | emotes | emotes |
 | emspack | ems |
+| es_taxi | taxi |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -79,3 +79,4 @@
 | 73 | drz_interiors | Broadcast interior updates with per-character uniqueness | Extend | WebSocket/webhook events and unique index migration |
 | 74 | emotes realtime | Favorite emote sync and retention | Extend | Added WS/webhook pushes and hourly purge |
 | 75 | emspack realtime | EMS shift sync and record events over WS/webhooks | Extend | Broadcast events and scheduler end stale shifts |
+| 76 | es_taxi realtime | Taxi dispatch pushes and expiry scheduler | Extend | Broadcast request events; cancel stale requests |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -349,3 +349,9 @@
 
 - Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed EMS duty scheduling patterns in ESX and ND Core frameworks for conceptual parity.
+
+## Research Log – 2025-08-27 (es_taxi)
+
+- Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed ESX taxi job design (https://github.com/ESX-Official/es_extended) to confirm request/accept/complete flow.
+- Reviewed QB-Core taxi job notes (https://github.com/qbcore-framework/qb-core) for expiry handling and payouts.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,15 +1,17 @@
-# Run Summary – 2025-08-27
+# Run Documentation – 2025-08-27
 
-## Modules
-- ems: realtime shift & record events with scheduled shift sync.
-
-## Documentation Updated
-- docs/progress-ledger.md
+## Changed Docs
+- docs/admin-ops.md
+- docs/BASE_API_DOCUMENTATION.md
+- docs/db-schema.md
 - docs/events-and-rpcs.md
-- docs/modules/ems.md
+- docs/framework-compliance.md
 - docs/index.md
-- docs/research-log.md
+- docs/modules/taxi.md
+- docs/migrations.md
 - docs/naming-map.md
+- docs/progress-ledger.md
+- docs/research-log.md
 - docs/run-docs.md
 
 ## Outstanding TODO/Gaps
@@ -25,3 +27,4 @@
 | Add admin endpoints for cron job management | backend | low | none |
 | Bulk sync endpoint for favorite emotes | backend | low | design |
 | Allow labeling/ordering of favorite emotes | backend | low | design |
+| Provide passenger cancellation endpoint for taxi requests | backend | medium | client work |

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -89,6 +89,9 @@ const config = {
       10,
     ),
   },
+  taxi: {
+    requestTtlMs: parseInt(process.env.TAXI_REQUEST_TTL_MS || '300000', 10),
+  },
 
   /**
    * Feature flags for core modules.  Lua consumers still drive

--- a/backend/srp-base/src/migrations/074_add_taxi_rides_status_created_index.sql
+++ b/backend/srp-base/src/migrations/074_add_taxi_rides_status_created_index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE taxi_rides
+  ADD INDEX IF NOT EXISTS idx_taxi_status_created_at (status, created_at);

--- a/backend/srp-base/src/repositories/taxiRepository.js
+++ b/backend/srp-base/src/repositories/taxiRepository.js
@@ -97,10 +97,25 @@ async function listRidesByCharacter(characterId, role = 'passenger') {
   return rows;
 }
 
+/**
+ * Cancel ride requests older than the provided TTL.
+ * @param {number} ttlMs
+ * @returns {Promise<number>} number of rows updated
+ */
+async function cancelStaleRequests(ttlMs) {
+  const cutoff = new Date(Date.now() - ttlMs);
+  const [result] = await db.query(
+    "UPDATE taxi_rides SET status = 'cancelled' WHERE status IN ('requested','accepted') AND created_at < ?",
+    [cutoff],
+  );
+  return result.affectedRows || 0;
+}
+
 module.exports = {
   createRequest,
   listRequestsByStatus,
   acceptRequest,
   completeRequest,
   listRidesByCharacter,
+  cancelStaleRequests,
 };

--- a/backend/srp-base/src/routes/taxi.routes.js
+++ b/backend/srp-base/src/routes/taxi.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const taxiRepo = require('../repositories/taxiRepository');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -52,6 +54,8 @@ router.post('/v1/taxi/requests', async (req, res) => {
       pickupY,
       pickupZ,
     });
+    websocket.broadcast('taxi', 'request.created', request);
+    dispatcher.dispatch('taxi.request.created', request);
     sendOk(res, { request }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'TAXI_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
@@ -91,6 +95,8 @@ router.post('/v1/taxi/requests/:id/accept', async (req, res) => {
         res.locals.traceId,
       );
     }
+    websocket.broadcast('taxi', 'request.accepted', request);
+    dispatcher.dispatch('taxi.request.accepted', request);
     sendOk(res, { request }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'TAXI_ACCEPT_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
@@ -141,6 +147,8 @@ router.post('/v1/taxi/requests/:id/complete', async (req, res) => {
         res.locals.traceId,
       );
     }
+    websocket.broadcast('taxi', 'request.completed', request);
+    dispatcher.dispatch('taxi.request.completed', request);
     sendOk(res, { request }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'TAXI_COMPLETE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -24,6 +24,7 @@ const coordinatesTasks = require('./tasks/coordinates');
 const cronTasks = require('./tasks/cron');
 const emotesTasks = require('./tasks/emotes');
 const emsTasks = require('./tasks/ems');
+const taxiTasks = require('./tasks/taxi');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -145,6 +146,13 @@ scheduler.register(
   () => emsTasks.syncShifts(wss),
   emsTasks.INTERVAL_MS,
   { jitter: 5000, persistName: emsTasks.JOB_NAME },
+);
+
+scheduler.register(
+  taxiTasks.JOB_NAME,
+  () => taxiTasks.expireRequests(),
+  taxiTasks.INTERVAL_MS,
+  { jitter: 5000, persistName: taxiTasks.JOB_NAME },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/taxi.js
+++ b/backend/srp-base/src/tasks/taxi.js
@@ -1,0 +1,18 @@
+const taxiRepo = require('../repositories/taxiRepository');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
+const config = require('../config/env');
+
+const JOB_NAME = 'taxi-request-expiry';
+const INTERVAL_MS = 60000;
+
+async function expireRequests() {
+  const count = await taxiRepo.cancelStaleRequests(config.taxi.requestTtlMs);
+  if (count > 0) {
+    const payload = { expired: count };
+    websocket.broadcast('taxi', 'request.expired', payload);
+    dispatcher.dispatch('taxi.request.expired', payload);
+  }
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, expireRequests };


### PR DESCRIPTION
## Summary
- broadcast taxi request create/accept/complete events via WS and webhooks
- expire stale taxi requests with scheduler and config TTL
- document taxi realtime and add supporting migration/index

## Testing
- `node -e "require('./backend/srp-base/src/routes/taxi.routes'); console.log('loaded');"` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68ae82bea0c0832dad8839e4d01d3b72