### PR TITLE
srp-base(furniture): realtime events and retention purge

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1518,3 +1518,17 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Remove taxi scheduler registration, revert taxi route broadcasts and drop added index.
+
+## 2025-08-27 – Furniture realtime & retention
+
+### Added
+* WebSocket/webhook events `furniture.placed` and `furniture.removed`.
+* Scheduler task `furniture-purge` removing records older than `FURNITURE_RETENTION_MS`.
+* Config `FURNITURE_RETENTION_MS` with 180-day default.
+
+### Risks
+* Misconfigured retention may delete active furniture.
+* Clients must handle push events to remain synced.
+
+### Rollback
+* Remove furniture scheduler registration and event broadcasts; unset `FURNITURE_RETENTION_MS`.

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -550,7 +550,9 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
 - **srp-furniture** – Stores custom furniture placements per character.
   - `GET /v1/characters/{characterId}/furniture` – List furniture items for a character.
   - `POST /v1/characters/{characterId}/furniture` – Place a furniture item with `item`, `x`, `y`, `z` and optional `heading`.
-- `DELETE /v1/characters/{characterId}/furniture/{id}` – Remove a furniture item.
+  - `DELETE /v1/characters/{characterId}/furniture/{id}` – Remove a furniture item.
+  - Realtime events: `furniture.placed`, `furniture.removed` (WebSocket & webhook).
+  - Daily purge of entries older than `FURNITURE_RETENTION_MS` via scheduler.
 ### Jobs
 
 - `GET /v1/jobs` – list defined jobs

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -43,6 +43,7 @@
 - Ensure the `ems_records` and `ems_shift_logs` tables exist for EMS operations.
 - Ensure the `taxi_rides` table exists for taxi dispatch.
 - Ensure the `furniture` table exists for stored furniture placements.
+  - Set `FURNITURE_RETENTION_MS` if different retention is required; `furniture-purge` task runs daily.
 - Ensure the `hospital_admissions` table exists for patient tracking.
 - Ensure the `hardcap_config` and `hardcap_sessions` tables exist for player capacity tracking.
 - Ensure the `heli_flights` table exists for helicopter flight logs.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -442,7 +442,7 @@ Rows older than `BASE_EVENT_RETENTION_MS` are purged hourly by the `base-events-
 | z | DOUBLE | Z coordinate |
 | heading | DOUBLE | Optional heading |
 | created_at | TIMESTAMP | Creation time |
-| updated_at | TIMESTAMP | Update time |
+| updated_at | TIMESTAMP | Update time (purged after `FURNITURE_RETENTION_MS`) |
 
 ## hospital_admissions
 

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -39,7 +39,7 @@
 | es_taxi | Players request taxi rides and drivers accept/complete them | `POST /v1/taxi/requests`, `POST /v1/taxi/requests/{id}/accept`, `POST /v1/taxi/requests/{id}/complete` | `taxi.request.created`, `taxi.request.accepted`, `taxi.request.completed`, `taxi.request.expired` |
 | k9 | Police dog deployment and status commands | `GET/POST /v1/characters/{characterId}/k9s`, `PATCH /v1/characters/{characterId}/k9s/{k9Id}/active`, `DELETE /v1/characters/{characterId}/k9s/{k9Id}` |
 | dispatch | Police dispatch alerts and code lists | `GET/POST /v1/dispatch/alerts`, `PATCH /v1/dispatch/alerts/{id}/ack`, `GET /v1/dispatch/codes` |
-| furniture | Resource lets players place or remove furniture items | `GET /v1/characters/{characterId}/furniture`, `POST /v1/characters/{characterId}/furniture`, `DELETE /v1/characters/{characterId}/furniture/{id}` |
+| furniture | Resource lets players place or remove furniture items | `GET /v1/characters/{characterId}/furniture`, `POST /v1/characters/{characterId}/furniture`, `DELETE /v1/characters/{characterId}/furniture/{id}` (WS/webhook: `furniture.placed`, `furniture.removed`) |
 | gabz_mrpd | Map resource for Mission Row PD building; no events | N/A |
 | gabz_pillbox_hospital | Resource handles hospital admissions and bed management | `GET /v1/hospital/admissions/active`, `POST /v1/hospital/admissions`, `POST /v1/hospital/admissions/{id}/discharge` |
 | garages | Resource emits events when vehicles are stored or retrieved from garages | `/v1/garages` CRUD, `/v1/garages/{garageId}/store`, `/v1/garages/{garageId}/retrieve`, `/v1/characters/{characterId}/garages/{garageId}/vehicles` |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -268,6 +268,15 @@ Introduced taxi dispatch backend to support the **es_taxi** resource.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/taxi.md`.
 
+## Update – 2025-08-27
+
+Extended furniture module with realtime push and retention cleanup.
+
+* Furniture placement/removal events broadcast via WebSockets and webhooks.
+* Daily job `furniture-purge` removes stale entries beyond `FURNITURE_RETENTION_MS`.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/furniture.md`.
+
 ## Update – 2025-08-25
 
 Introduced furniture placement storage to support the **furniture** resource.

--- a/backend/srp-base/docs/modules/furniture.md
+++ b/backend/srp-base/docs/modules/furniture.md
@@ -43,6 +43,14 @@ There is no feature flag for furniture; the module is always enabled.
 * **Migration:** `src/migrations/047_add_furniture.sql` creates the `furniture` table.
 * **Routes:** `src/routes/furniture.routes.js` defines the HTTP endpoints.
 * **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
+* **Realtime:** `furniture.placed` and `furniture.removed` broadcast over WebSocket and webhook dispatcher.
+* **Scheduler:** `src/tasks/furniture.js` purges furniture older than `FURNITURE_RETENTION_MS` daily.
+
+## Configuration
+
+| Key | Default | Notes |
+|---|---|---|
+| `FURNITURE_RETENTION_MS` | `15552000000` | Milliseconds to retain furniture before purge (180 days). |
 
 ## Future work
 

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -29,3 +29,4 @@
 | emotes | emotes |
 | emspack | ems |
 | es_taxi | taxi |
+| np-furniture | furniture |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -80,3 +80,4 @@
 | 74 | emotes realtime | Favorite emote sync and retention | Extend | Added WS/webhook pushes and hourly purge |
 | 75 | emspack realtime | EMS shift sync and record events over WS/webhooks | Extend | Broadcast events and scheduler end stale shifts |
 | 76 | es_taxi realtime | Taxi dispatch pushes and expiry scheduler | Extend | Broadcast request events; cancel stale requests |
+| 77 | furniture realtime | Furniture place/remove pushes and retention purge | Extend | Broadcast events and daily purge |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -355,3 +355,8 @@
 - Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed ESX taxi job design (https://github.com/ESX-Official/es_extended) to confirm request/accept/complete flow.
 - Reviewed QB-Core taxi job notes (https://github.com/qbcore-framework/qb-core) for expiry handling and payouts.
+
+## Research Log – 2025-08-27 (furniture)
+
+- Attempted to clone reference repository `https://github.com/h04X-2K/NoPixelServer` for furniture but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed furniture/property placement patterns in ESX and QB-Core to inform retention and event naming.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -5,13 +5,12 @@
 - docs/BASE_API_DOCUMENTATION.md
 - docs/db-schema.md
 - docs/events-and-rpcs.md
-- docs/framework-compliance.md
 - docs/index.md
-- docs/modules/taxi.md
-- docs/migrations.md
+- docs/modules/furniture.md
 - docs/naming-map.md
 - docs/progress-ledger.md
 - docs/research-log.md
+- docs/testing.md
 - docs/run-docs.md
 
 ## Outstanding TODO/Gaps
@@ -27,4 +26,3 @@
 | Add admin endpoints for cron job management | backend | low | none |
 | Bulk sync endpoint for favorite emotes | backend | low | design |
 | Allow labeling/ordering of favorite emotes | backend | low | design |
-| Provide passenger cancellation endpoint for taxi requests | backend | medium | client work |

--- a/backend/srp-base/docs/testing.md
+++ b/backend/srp-base/docs/testing.md
@@ -306,6 +306,8 @@ curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: furn2' -X DELETE \
   http://localhost:3010/v1/characters/1/furniture/1
 ```
 
+Connect a WebSocket client to `ws://localhost:3010/ws?token=<token>` and confirm `furniture.placed` and `furniture.removed` events fire for the create/delete calls above.
+
 Manually verify the hospital admission endpoints:
 
 ```sh

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -3226,6 +3226,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
     post:
       summary: Place a furniture item for a character
+      x-websocket-event: furniture.placed
+      x-webhook-event: furniture.placed
       parameters:
         - in: path
           name: characterId
@@ -3263,6 +3265,8 @@ paths:
   /v1/characters/{characterId}/furniture/{id}:
     delete:
       summary: Delete a furniture item
+      x-websocket-event: furniture.removed
+      x-webhook-event: furniture.removed
       parameters:
         - in: path
           name: characterId

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -80,6 +80,7 @@ const config = {
     retentionMs: parseInt(process.env.CAMERA_RETENTION_MS || '2592000000', 10),
     cleanupIntervalMs: parseInt(process.env.CAMERA_CLEANUP_INTERVAL_MS || '3600000', 10),
   },
+  furniture: { retentionMs: parseInt(process.env.FURNITURE_RETENTION_MS || '15552000000', 10) },
   invoiceRetentionMs: parseInt(process.env.INVOICE_RETENTION_MS || '2592000000', 10),
   emotes: { retentionMs: parseInt(process.env.EMOTE_RETENTION_MS || '15552000000', 10) },
   ems: {

--- a/backend/srp-base/src/repositories/furnitureRepository.js
+++ b/backend/srp-base/src/repositories/furnitureRepository.js
@@ -55,8 +55,20 @@ async function deleteFurniture(characterId, id) {
   await db.query('DELETE FROM furniture WHERE id = ? AND character_id = ?', [id, characterId]);
 }
 
+/**
+ * Delete furniture entries older than the provided cutoff timestamp.
+ *
+ * @param {Date} cutoff
+ * @returns {Promise<number>} number of rows removed
+ */
+async function deleteOlderThan(cutoff) {
+  const result = await db.query('DELETE FROM furniture WHERE updated_at < ?', [cutoff]);
+  return result.affectedRows || 0;
+}
+
 module.exports = {
   listFurniture,
   createFurniture,
   deleteFurniture,
+  deleteOlderThan,
 };

--- a/backend/srp-base/src/routes/furniture.routes.js
+++ b/backend/srp-base/src/routes/furniture.routes.js
@@ -5,6 +5,8 @@ const {
   createFurniture,
   deleteFurniture,
 } = require('../repositories/furnitureRepository');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -64,6 +66,8 @@ router.post('/v1/characters/:characterId/furniture', async (req, res) => {
   try {
     const furniture = await createFurniture({ characterId: charId, item, x, y, z, heading });
     sendOk(res, { furniture }, res.locals.requestId, res.locals.traceId);
+    websocket.broadcast('furniture', 'furniture.placed', { characterId: charId, furniture });
+    dispatcher.dispatch('furniture.placed', { characterId: charId, furniture });
   } catch (err) {
     sendError(res, { code: 'FURNITURE_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
   }
@@ -86,6 +90,8 @@ router.delete('/v1/characters/:characterId/furniture/:id', async (req, res) => {
   try {
     await deleteFurniture(charId, furnId);
     sendOk(res, {}, res.locals.requestId, res.locals.traceId);
+    websocket.broadcast('furniture', 'furniture.removed', { characterId: charId, id: furnId });
+    dispatcher.dispatch('furniture.removed', { characterId: charId, id: furnId });
   } catch (err) {
     sendError(res, { code: 'FURNITURE_DELETE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
   }

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -25,6 +25,7 @@ const cronTasks = require('./tasks/cron');
 const emotesTasks = require('./tasks/emotes');
 const emsTasks = require('./tasks/ems');
 const taxiTasks = require('./tasks/taxi');
+const furnitureTasks = require('./tasks/furniture');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -153,6 +154,13 @@ scheduler.register(
   () => taxiTasks.expireRequests(),
   taxiTasks.INTERVAL_MS,
   { jitter: 5000, persistName: taxiTasks.JOB_NAME },
+);
+
+scheduler.register(
+  furnitureTasks.JOB_NAME,
+  () => furnitureTasks.purgeOld(),
+  furnitureTasks.INTERVAL_MS,
+  { jitter: 60000, persistName: furnitureTasks.JOB_NAME },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/furniture.js
+++ b/backend/srp-base/src/tasks/furniture.js
@@ -1,0 +1,18 @@
+const config = require('../config/env');
+const FurnitureRepository = require('../repositories/furnitureRepository');
+const logger = require('../utils/logger');
+
+const JOB_NAME = 'furniture-purge';
+const INTERVAL_MS = 86400000; // daily
+
+async function purgeOld() {
+  try {
+    const cutoff = new Date(Date.now() - config.furniture.retentionMs);
+    const removed = await FurnitureRepository.deleteOlderThan(cutoff);
+    if (removed) logger.info({ removed }, 'Pruned stale furniture records');
+  } catch (err) {
+    logger.error({ err }, 'Failed to prune furniture records');
+  }
+}
+
+module.exports = { purgeOld, JOB_NAME, INTERVAL_MS };


### PR DESCRIPTION
## Summary
- broadcast furniture place/remove events over WebSockets and webhooks
- schedule daily purge of stale furniture with configurable retention
- document furniture realtime and retention settings

## Testing
- `node -e "require('./backend/srp-base/src/routes/furniture.routes');"` *(fails: Cannot find module 'express')*
- `npm install` *(fails: No matching version found for express-openapi-validator@^4.18.3)*

------
https://chatgpt.com/codex/tasks/task_e_68ae86aa1be4832da97d0f985ab9162d