### PR TITLE
srp-base(gabz_mrpd): add police duty roster with realtime cleanup

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1532,3 +1532,20 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Remove furniture scheduler registration and event broadcasts; unset `FURNITURE_RETENTION_MS`.
+
+## 2025-08-27 – Police duty roster
+
+### Added
+* Police roster endpoints (`GET/POST /v1/police/roster`, `PUT /v1/police/roster/{id}`, `POST /v1/police/roster/{characterId}:duty`).
+* WebSocket topic `police` and webhook event `police.duty`.
+* Scheduler task `police-duty-check` cleaning stale duty records.
+* Config `POLICE_DUTY_TIMEOUT_MS` and `POLICE_CHECK_INTERVAL_MS`.
+* Migration `075_police_officers_character.sql` renaming `player_id` to `character_id` with index.
+
+### Risks
+* Misconfigured timeouts may prematurely set officers off duty.
+
+### Rollback
+* Revert routes, repository and config changes.
+* Drop `075_police_officers_character.sql` migration.
+* Remove scheduler registration and disable duty cleanup.

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -646,3 +646,14 @@ Added dispatch alert APIs with WebSocket and webhook push.
 - `GET /v1/dispatch/codes` – list configured dispatch codes.
 
 All endpoints require standard authentication headers.
+
+## Update – 2025-08-27 (police duty roster)
+
+Added police roster endpoints with WebSocket and webhook push plus stale-duty cleanup.
+
+### Endpoints
+
+- `GET /v1/police/roster` – list police officers.
+- `POST /v1/police/roster` – assign an officer (requires `X-Idempotency-Key`).
+- `PUT /v1/police/roster/{id}` – update officer rank (requires `X-Idempotency-Key`).
+- `POST /v1/police/roster/{characterId}:duty` – set duty status (requires `X-Idempotency-Key`).

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -52,6 +52,7 @@
 - Ensure the `jailbreak_attempts` table exists for jailbreak tracking.
 - Ensure the `jobs` and `character_jobs` tables exist for job management.
 - Ensure the `k9_units` table exists after applying migration 057.
+- Ensure the `police_officers` table has `character_id` column and index after migration 075.
 - Ensure the `world_forecast` table exists for weather scheduling.
 - Configure webhook sinks via environment variables. Discord sink is scaffolded but disabled unless `WEBHOOK_DISCORD_ENABLED=1` and `WEBHOOK_DISCORD_URL` are set.
 - Carwash dirt updates are dispatched via webhook; register sinks if external systems require notifications.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -597,3 +597,14 @@ Retention of sound play logs is controlled by `INTERACT_SOUND_RETENTION_MS`; old
 | name | VARCHAR(100) | Unique IPL name |
 | enabled | TINYINT(1) | 1 when active |
 | updated_at | TIMESTAMP | Last update timestamp |
+
+## police_officers
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INT AUTO_INCREMENT | Primary key |
+| character_id | INT | FK to characters.id |
+| rank | VARCHAR(50) | Officer rank |
+| on_duty | TINYINT(1) | 1 when on duty |
+| created_at | TIMESTAMP | Creation time |
+| updated_at | TIMESTAMP | Last update |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -40,7 +40,7 @@
 | k9 | Police dog deployment and status commands | `GET/POST /v1/characters/{characterId}/k9s`, `PATCH /v1/characters/{characterId}/k9s/{k9Id}/active`, `DELETE /v1/characters/{characterId}/k9s/{k9Id}` |
 | dispatch | Police dispatch alerts and code lists | `GET/POST /v1/dispatch/alerts`, `PATCH /v1/dispatch/alerts/{id}/ack`, `GET /v1/dispatch/codes` |
 | furniture | Resource lets players place or remove furniture items | `GET /v1/characters/{characterId}/furniture`, `POST /v1/characters/{characterId}/furniture`, `DELETE /v1/characters/{characterId}/furniture/{id}` (WS/webhook: `furniture.placed`, `furniture.removed`) |
-| gabz_mrpd | Map resource for Mission Row PD building; no events | N/A |
+| gabz_mrpd | Mission Row PD duty roster with push updates | `/v1/police/roster`, `/v1/police/roster/{characterId}:duty` → `police.duty` |
 | gabz_pillbox_hospital | Resource handles hospital admissions and bed management | `GET /v1/hospital/admissions/active`, `POST /v1/hospital/admissions`, `POST /v1/hospital/admissions/{id}/discharge` |
 | garages | Resource emits events when vehicles are stored or retrieved from garages | `/v1/garages` CRUD, `/v1/garages/{garageId}/store`, `/v1/garages/{garageId}/retrieve`, `/v1/characters/{characterId}/garages/{garageId}/vehicles` |
 | ghmattimysql | Exports `execute`, `scalar` and `transaction` for MySQL queries | Core `db` repository offers `query`, `scalar` and `transaction` helpers with named parameters |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -103,6 +103,7 @@ practice is supported by citations.
 | **properties module** | Property endpoints consolidate apartments, garages and rentals with layered design, rate limiting, idempotency, WebSocket/webhook events and lease expiry scheduler. |
 | **world IPL module** | Interior proxy endpoints follow layered design with WebSocket sync and scheduler broadcast. |
 | **taxi module** | Taxi request endpoints follow layered design with WebSocket/webhook events and expiry scheduler. |
+| **police module** | Duty roster endpoints follow layered design with authentication, idempotency, WebSocket/webhook pushes and stale-duty scheduler. |
 
 ## Outstanding Items
 
@@ -113,3 +114,4 @@ practice is supported by citations.
 - Integrate player vitals (hunger, thirst, stress) into HUD module.
 - Implement bulk emote sync endpoint and labeling/ordering support.
 - Provide passenger cancellation endpoint for taxi requests.
+- Implement call-sign management for police officers.

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -536,3 +536,9 @@ Extended taxi dispatch with real-time events and stale request cleanup.
 * Scheduler `taxi-request-expiry` cancels requests older than `TAXI_REQUEST_TTL_MS`.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/taxi.md`.
+
+## Update – 2025-08-27
+
+Introduced police duty roster management to support the **gabz_mrpd** cluster with WebSocket and webhook pushes plus stale-duty cleanup.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/police.md`.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -72,3 +72,4 @@
 | 072_add_chat_messages_created_index.sql | Index chat_messages created_at column |
 | 073_update_interiors_unique_key.sql | Ensure apartment interiors unique per character |
 | 074_add_taxi_rides_status_created_index.sql | Index taxi_rides on status and created_at |
+| 075_police_officers_character.sql | Rename police_officers player_id to character_id and add index |

--- a/backend/srp-base/docs/modules/police.md
+++ b/backend/srp-base/docs/modules/police.md
@@ -1,0 +1,21 @@
+# police module
+
+## Purpose
+Manages Mission Row PD duty roster with WebSocket and webhook notifications.
+
+## Routes
+- `GET /v1/police/roster` – list officers
+- `POST /v1/police/roster` – assign officer
+- `PUT /v1/police/roster/{id}` – update officer rank
+- `POST /v1/police/roster/{characterId}:duty` – set duty status
+
+## Repository Contracts
+- `listOfficers()`
+- `assignOfficer(characterId, rank, onDuty)`
+- `updateOfficer(id, rank)`
+- `setDuty(characterId, onDuty)`
+- `setOffDutyOlderThan(cutoff)`
+
+## Edge Cases
+- `onDuty` field is required when toggling duty.
+- `police-duty-check` scheduler resets officers who have not updated within `POLICE_DUTY_TIMEOUT_MS`.

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -30,3 +30,6 @@
 | emspack | ems |
 | es_taxi | taxi |
 | np-furniture | furniture |
+| gabz_mrpd | police |
+| police_officers | police roster |
+| player_id | character_id |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -81,3 +81,4 @@
 | 75 | emspack realtime | EMS shift sync and record events over WS/webhooks | Extend | Broadcast events and scheduler end stale shifts |
 | 76 | es_taxi realtime | Taxi dispatch pushes and expiry scheduler | Extend | Broadcast request events; cancel stale requests |
 | 77 | furniture realtime | Furniture place/remove pushes and retention purge | Extend | Broadcast events and daily purge |
+| 78 | gabz_mrpd | Mission Row PD duty roster with realtime pushes and stale-duty scheduler | Create | Added roster API, WS/webhook events and cleanup task |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -360,3 +360,9 @@
 
 - Attempted to clone reference repository `https://github.com/h04X-2K/NoPixelServer` for furniture but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed furniture/property placement patterns in ESX and QB-Core to inform retention and event naming.
+
+## Research Log – 2025-08-27 (gabz_mrpd)
+
+- Attempted to clone `https://github.com/h04X-2K/NoPixelServer` for gabz_mrpd but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP for police duty and job grade patterns (names/flows only).
+- Reviewed public NoPixel 4.0 summaries for economy reset and policing overhauls.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -13,6 +13,25 @@
 - docs/testing.md
 - docs/run-docs.md
 
+## Run – 2025-08-27
+
+### Docs Touched
+- docs/index.md
+- docs/progress-ledger.md
+- docs/framework-compliance.md
+- docs/BASE_API_DOCUMENTATION.md
+- docs/events-and-rpcs.md
+- docs/db-schema.md
+- docs/migrations.md
+- docs/admin-ops.md
+- docs/security.md
+- docs/testing.md
+- docs/modules/police.md
+- docs/research-log.md
+- docs/naming-map.md
+- docs/todo-gaps.md
+- docs/run-docs.md
+
 ## Outstanding TODO/Gaps
 | Item | Owner | Priority | Blockers |
 |---|---|---|---|
@@ -26,3 +45,4 @@
 | Add admin endpoints for cron job management | backend | low | none |
 | Bulk sync endpoint for favorite emotes | backend | low | design |
 | Allow labeling/ordering of favorite emotes | backend | low | design |
+| Implement call-sign management for police officers | backend | medium | design |

--- a/backend/srp-base/docs/security.md
+++ b/backend/srp-base/docs/security.md
@@ -39,6 +39,7 @@
 - Jailbreak routes inherit the same authentication and idempotency requirements.
 - K9 routes inherit the same authentication and idempotency requirements.
 - Jobs routes inherit the same authentication and idempotency requirements.
+- Police routes inherit the same authentication and idempotency requirements.
 - WebSocket connections require a `token` query parameter matching the `X-API-Token` and drop clients missing heartbeats.
 - Webhook dispatcher signs payloads with HMAC and retries failed deliveries.
 - Broadcaster routes inherit the same authentication and idempotency requirements.

--- a/backend/srp-base/docs/testing.md
+++ b/backend/srp-base/docs/testing.md
@@ -440,3 +440,15 @@ curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: tc1' -H 'Content-Type: app
   http://localhost:3010/v1/world/timecycle
 curl -H 'X-API-Token: <token>' -X DELETE http://localhost:3010/v1/world/timecycle
 ```
+
+Verify police roster endpoints:
+
+```sh
+curl -H 'X-API-Token: <token>' http://localhost:3010/v1/police/roster
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: pd1' -H 'Content-Type: application/json' \
+  -d '{"characterId":1,"rank":"officer","onDuty":true}' \
+  http://localhost:3010/v1/police/roster
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: pd2' -H 'Content-Type: application/json' \
+  -d '{"onDuty":false}' \
+  http://localhost:3010/v1/police/roster/1:duty
+```

--- a/backend/srp-base/docs/todo-gaps.md
+++ b/backend/srp-base/docs/todo-gaps.md
@@ -10,5 +10,6 @@
 | Integrate player vitals (hunger, thirst, stress) into HUD module | backend | medium | gameplay design |
 | Add admin bulk adjustment endpoints for queue priorities | backend | low | none |
 | Add admin endpoints for cron job management | backend | low | none |
-| Bulk sync endpoint for favorite emotes | backend | low | design | 
+| Bulk sync endpoint for favorite emotes | backend | low | design |
 | Allow labeling/ordering of favorite emotes | backend | low | design |
+| Implement call-sign management for police officers | backend | medium | design |

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -1991,6 +1991,23 @@ components:
         type: string
       description:
         type: string
+  PoliceOfficer:
+    type: object
+    properties:
+      id:
+        type: integer
+      characterId:
+        type: integer
+      rank:
+        type: string
+      onDuty:
+        type: boolean
+      createdAt:
+        type: string
+        format: date-time
+      updatedAt:
+        type: string
+        format: date-time
 security:
   - ApiToken: []
 paths:
@@ -8126,6 +8143,152 @@ paths:
                     type: string
         '404':
           description: Not found
+  /v1/police/roster:
+    get:
+      summary: List police officers
+      security:
+        - ApiToken: []
+      responses:
+        '200':
+          description: Officers listed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      officers:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/PoliceOfficer'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+    post:
+      summary: Assign police officer
+      security:
+        - ApiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - characterId
+              properties:
+                characterId:
+                  type: integer
+                rank:
+                  type: string
+                onDuty:
+                  type: boolean
+      responses:
+        '200':
+          description: Officer created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      officer:
+                        $ref: '#/components/schemas/PoliceOfficer'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+  /v1/police/roster/{id}:
+    put:
+      summary: Update officer rank
+      security:
+        - ApiToken: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - rank
+              properties:
+                rank:
+                  type: string
+      responses:
+        '200':
+          description: Officer updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      officer:
+                        $ref: '#/components/schemas/PoliceOfficer'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+  /v1/police/roster/{characterId}:duty:
+    post:
+      summary: Set duty status
+      security:
+        - ApiToken: []
+      parameters:
+        - in: path
+          name: characterId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - onDuty
+              properties:
+                onDuty:
+                  type: boolean
+      responses:
+        '200':
+          description: Duty updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      officer:
+                        $ref: '#/components/schemas/PoliceOfficer'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
     patch:
       summary: Update property
       parameters:

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -94,6 +94,11 @@ const config = {
     requestTtlMs: parseInt(process.env.TAXI_REQUEST_TTL_MS || '300000', 10),
   },
 
+  police: {
+    dutyTimeoutMs: parseInt(process.env.POLICE_DUTY_TIMEOUT_MS || '3600000', 10),
+    checkIntervalMs: parseInt(process.env.POLICE_CHECK_INTERVAL_MS || '300000', 10),
+  },
+
   /**
    * Feature flags for core modules.  Lua consumers still drive
    * behaviour via /v1/config/live, but these flags provide a safe

--- a/backend/srp-base/src/migrations/075_police_officers_character.sql
+++ b/backend/srp-base/src/migrations/075_police_officers_character.sql
@@ -1,0 +1,12 @@
+-- Rename player_id to character_id on police_officers for multi-character readiness
+SET @col := (
+  SELECT COLUMN_NAME FROM information_schema.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'police_officers' AND COLUMN_NAME = 'player_id'
+);
+SET @sql := IF(@col = 'player_id', 'ALTER TABLE police_officers RENAME COLUMN player_id TO character_id;', 'SELECT 1');
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- Ensure index for character lookup
+CREATE INDEX IF NOT EXISTS idx_police_officers_character_id ON police_officers(character_id);

--- a/backend/srp-base/src/repositories/policeRepository.js
+++ b/backend/srp-base/src/repositories/policeRepository.js
@@ -10,49 +10,65 @@ async function listOfficers() {
 }
 
 /**
- * Assign a player as a police officer.
- * @param {number} playerId - Player ID
+ * Assign a character as a police officer.
+ * @param {number} characterId - Character ID
  * @param {string} rank - Officer rank
  * @param {number} onDuty - Whether the officer is on duty (1 or 0)
  * @returns {Promise<Object>} created officer record
  */
-async function assignOfficer(playerId, rank = 'officer', onDuty = 0) {
+async function assignOfficer(characterId, rank = 'officer', onDuty = 0) {
   const [result] = await db.query(
-    'INSERT INTO police_officers (player_id, rank, on_duty) VALUES (?, ?, ?)',
-    [playerId, rank, onDuty],
+    'INSERT INTO police_officers (character_id, rank, on_duty) VALUES (?, ?, ?)',
+    [characterId, rank, onDuty],
   );
-  return { id: result.insertId, playerId, rank, onDuty };
+  return { id: result.insertId, characterId, rank, onDuty };
 }
 
 /**
- * Update a police officer's rank or duty status.
+ * Update a police officer's rank.
  * @param {number} id - Officer record ID
- * @param {Object} data - Fields to update
- * @returns {Promise<Object>} updated officer record
+ * @param {string} rank - New rank
  */
-async function updateOfficer(id, data) {
-  const fields = [];
-  const values = [];
-  if (data.rank) {
-    fields.push('rank = ?');
-    values.push(data.rank);
-  }
-  if (data.onDuty !== undefined) {
-    fields.push('on_duty = ?');
-    values.push(data.onDuty);
-  }
-  if (fields.length === 0) {
-    const [rows] = await db.query('SELECT * FROM police_officers WHERE id = ?', [id]);
-    return rows[0];
-  }
-  values.push(id);
-  await db.query(`UPDATE police_officers SET ${fields.join(', ')} WHERE id = ?`, values);
+async function updateOfficer(id, rank) {
+  await db.query('UPDATE police_officers SET rank = ? WHERE id = ?', [rank, id]);
   const [rows] = await db.query('SELECT * FROM police_officers WHERE id = ?', [id]);
   return rows[0];
+}
+
+/**
+ * Set on-duty status for a character.
+ * @param {number} characterId
+ * @param {number} onDuty (1 or 0)
+ */
+async function setDuty(characterId, onDuty) {
+  await db.query(
+    'UPDATE police_officers SET on_duty = ?, updated_at = CURRENT_TIMESTAMP WHERE character_id = ?',
+    [onDuty, characterId],
+  );
+  const [rows] = await db.query('SELECT * FROM police_officers WHERE character_id = ?', [characterId]);
+  return rows[0];
+}
+
+/**
+ * Set officers off duty if their updated_at is older than cutoff.
+ * Returns affected officers.
+ */
+async function setOffDutyOlderThan(cutoff) {
+  const [rows] = await db.query(
+    'SELECT id, character_id FROM police_officers WHERE on_duty = 1 AND updated_at < ?',
+    [cutoff],
+  );
+  if (rows.length) {
+    const ids = rows.map((r) => r.id);
+    await db.query(`UPDATE police_officers SET on_duty = 0 WHERE id IN (${ids.map(() => '?').join(',')})`, ids);
+  }
+  return rows;
 }
 
 module.exports = {
   listOfficers,
   assignOfficer,
   updateOfficer,
+  setDuty,
+  setOffDutyOlderThan,
 };

--- a/backend/srp-base/src/routes/police.routes.js
+++ b/backend/srp-base/src/routes/police.routes.js
@@ -4,12 +4,15 @@ const {
   listOfficers,
   assignOfficer,
   updateOfficer,
+  setDuty,
 } = require('../repositories/policeRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 
 const router = express.Router();
 
 // List all police officers
-router.get('/v1/police/officers', async (req, res) => {
+router.get('/v1/police/roster', async (req, res) => {
   try {
     const officers = await listOfficers();
     sendOk(res, { officers }, res.locals.requestId, res.locals.traceId);
@@ -19,31 +22,90 @@ router.get('/v1/police/officers', async (req, res) => {
 });
 
 // Assign a new officer
-router.post('/v1/police/officers', async (req, res) => {
-  const { playerId, rank, onDuty } = req.body;
-  if (!playerId) {
-    return sendError(res, { code: 'VALIDATION_ERROR', message: 'playerId is required' }, 400, res.locals.requestId, res.locals.traceId);
+router.post('/v1/police/roster', async (req, res) => {
+  const { characterId, rank, onDuty } = req.body;
+  if (!characterId) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'characterId is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
   }
   try {
-    const officer = await assignOfficer(playerId, rank || 'officer', onDuty ? 1 : 0);
-    sendOk(res, { officer }, res.locals.requestId, res.locals.traceId);
+    const officer = await assignOfficer(characterId, rank || 'officer', onDuty ? 1 : 0);
+    const mapped = {
+      id: officer.id,
+      characterId: officer.characterId,
+      rank: officer.rank,
+      onDuty: officer.onDuty,
+    };
+    websocket.broadcast('police', 'duty', { characterId: mapped.characterId, onDuty: mapped.onDuty });
+    hooks.dispatch('police.duty', { characterId: mapped.characterId, onDuty: mapped.onDuty });
+    sendOk(res, { officer: mapped }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'OFFICER_ASSIGN_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
   }
 });
 
-// Update officer rank or duty status
-router.put('/v1/police/officers/:id', async (req, res) => {
+// Update officer rank
+router.put('/v1/police/roster/:id', async (req, res) => {
   const { id } = req.params;
-  const { rank, onDuty } = req.body;
-  if (rank === undefined && onDuty === undefined) {
-    return sendError(res, { code: 'VALIDATION_ERROR', message: 'rank or onDuty required' }, 400, res.locals.requestId, res.locals.traceId);
+  const { rank } = req.body;
+  if (!rank) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'rank required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
   }
   try {
-    const officer = await updateOfficer(id, { rank, onDuty });
-    sendOk(res, { officer }, res.locals.requestId, res.locals.traceId);
+    const officer = await updateOfficer(id, rank);
+    const mapped = {
+      id: officer.id,
+      characterId: officer.character_id,
+      rank: officer.rank,
+      onDuty: officer.on_duty,
+      createdAt: officer.created_at,
+      updatedAt: officer.updated_at,
+    };
+    sendOk(res, { officer: mapped }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'OFFICER_UPDATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+// Toggle duty status
+router.post('/v1/police/roster/:characterId:duty', async (req, res) => {
+  const { characterId } = req.params;
+  const { onDuty } = req.body;
+  if (onDuty === undefined) {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'onDuty required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const officer = await setDuty(characterId, onDuty ? 1 : 0);
+    const mapped = {
+      id: officer.id,
+      characterId: officer.character_id,
+      rank: officer.rank,
+      onDuty: officer.on_duty,
+      createdAt: officer.created_at,
+      updatedAt: officer.updated_at,
+    };
+    websocket.broadcast('police', 'duty', { characterId: mapped.characterId, onDuty: mapped.onDuty });
+    hooks.dispatch('police.duty', { characterId: mapped.characterId, onDuty: mapped.onDuty });
+    sendOk(res, { officer: mapped }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'OFFICER_DUTY_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
   }
 });
 

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -26,6 +26,7 @@ const emotesTasks = require('./tasks/emotes');
 const emsTasks = require('./tasks/ems');
 const taxiTasks = require('./tasks/taxi');
 const furnitureTasks = require('./tasks/furniture');
+const policeTasks = require('./tasks/police');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -161,6 +162,13 @@ scheduler.register(
   () => furnitureTasks.purgeOld(),
   furnitureTasks.INTERVAL_MS,
   { jitter: 60000, persistName: furnitureTasks.JOB_NAME },
+);
+
+scheduler.register(
+  policeTasks.JOB_NAME,
+  () => policeTasks.clearStale(),
+  policeTasks.INTERVAL_MS,
+  { jitter: 5000, persistName: policeTasks.JOB_NAME },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/police.js
+++ b/backend/srp-base/src/tasks/police.js
@@ -1,0 +1,19 @@
+const repo = require('../repositories/policeRepository');
+const config = require('../config/env');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
+
+const JOB_NAME = 'police-duty-check';
+const INTERVAL_MS = config.police.checkIntervalMs || 300000;
+
+async function clearStale() {
+  const cutoff = new Date(Date.now() - config.police.dutyTimeoutMs);
+  const offDuty = await repo.setOffDutyOlderThan(cutoff);
+  offDuty.forEach((o) => {
+    const payload = { characterId: o.character_id, onDuty: 0 };
+    websocket.broadcast('police', 'duty', payload);
+    hooks.dispatch('police.duty', payload);
+  });
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, clearStale };


### PR DESCRIPTION
## Summary
- add police roster endpoints with character-scoped duty toggling
- broadcast police duty over websockets and webhooks
- expire stale duty entries via scheduler

## Testing
- `node --check backend/srp-base/src/config/env.js`
- `node --check backend/srp-base/src/repositories/policeRepository.js`
- `node --check backend/srp-base/src/routes/police.routes.js`
- `node --check backend/srp-base/src/tasks/police.js`
- `node --check backend/srp-base/src/server.js`
- `python3 - <<'PY'\nimport yaml\nyaml.safe_load(open('backend/srp-base/openapi/api.yaml'))\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68ae88ea9664832dbcdcc068b9f76faf