### PR TITLE
feat(garages): realtime vehicle storage events with purge scheduler

### DIFF
--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,41 +1,36 @@
 # Manifest
 
 - Added hospital admission realtime events with cleanup scheduler.
-
 - Added taxi request realtime events with expiry scheduler and config TTL.
+- Added garage vehicle store/retrieve events with retention scheduler.
 
 | File | Action | Note |
 |---|---|---|
-| src/config/env.js | M | Added hospital broadcast settings and `taxi.requestTtlMs` configuration |
+| src/config/env.js | M | Added hospital broadcast settings, `taxi.requestTtlMs` and `garages.retentionMs` configuration |
 | src/repositories/taxiRepository.js | M | Added stale request cancellation |
 | src/tasks/taxi.js | A | Scheduler to expire taxi requests |
-| src/server.js | M | Registered taxi expiry scheduler and hospital sync |
+| src/server.js | M | Registered taxi expiry scheduler, hospital sync and garage purge |
 | src/routes/taxi.routes.js | M | Broadcast and webhook taxi events |
 | src/migrations/074_add_taxi_rides_status_created_index.sql | A | Index on `(status, created_at)` |
 | docs/modules/taxi.md | M | Documented scheduler and realtime events |
-| docs/events-and-rpcs.md | M | Mapped taxi events |
-| docs/BASE_API_DOCUMENTATION.md | M | Listed taxi WebSocket events |
-| docs/progress-ledger.md | M | Logged taxi realtime entry |
-| docs/framework-compliance.md | M | Noted taxi module compliance |
-| docs/admin-ops.md | M | Added taxi index and TTL note |
-| docs/db-schema.md | M | Recorded taxi index |
-| docs/migrations.md | M | Added migration entry |
+| docs/events-and-rpcs.md | M | Mapped taxi, hospital and garage events |
+| docs/BASE_API_DOCUMENTATION.md | M | Listed taxi, hospital and garage WebSocket events |
+| docs/progress-ledger.md | M | Logged taxi, hospital and garage realtime entries |
+| docs/framework-compliance.md | M | Noted taxi module compliance, hospital and garage realtime purge |
+| docs/admin-ops.md | M | Added taxi index/TTL, hospital env tuning and garage retention/index note |
+| docs/db-schema.md | M | Recorded taxi, hospital and garage indexes |
+| docs/migrations.md | M | Added migration entries |
 | docs/naming-map.md | M | Added es_taxi → taxi mapping |
-| docs/index.md | M | Added taxi update summary |
-| docs/research-log.md | M | Logged taxi research |
+| docs/index.md | M | Added taxi, hospital and garage update summaries |
+| docs/research-log.md | M | Logged taxi, hospital and garage research |
 | docs/run-docs.md | M | Run summary and outstanding tasks |
 | src/routes/hospital.routes.js | M | Broadcast admission events |
 | src/tasks/hospital.js | A | Scheduler to sync and auto-discharge admissions |
 | openapi/api.yaml | M | Added 404 response for discharge |
 | docs/modules/hospital.md | M | Documented realtime and scheduler |
-| docs/events-and-rpcs.md | M | Mapped hospital events |
-| docs/BASE_API_DOCUMENTATION.md | M | Listed hospital WebSocket events |
-| docs/db-schema.md | M | Noted hospital admission indexes |
-| docs/admin-ops.md | M | Added hospital env tuning |
-| docs/index.md | M | Added hospital update summary |
-| docs/progress-ledger.md | M | Logged hospital realtime entry |
-| docs/framework-compliance.md | M | Noted hospital module compliance |
-| docs/naming-map.md | M | Mapped gabz_pillbox_hospital → hospital |
-| docs/research-log.md | M | Logged hospital research |
+| src/routes/garages.routes.js | M | Broadcast store/retrieve events and dispatch webhooks |
+| src/repositories/garagesRepository.js | M | Added purge helper for retrieved vehicles |
+| src/tasks/garages.js | A | Scheduler to purge retrieved vehicles |
+| src/migrations/076_add_garage_vehicle_retrieved_index.sql | A | Index on `retrieved_at` |
 
 **Startup Notes:** install dependencies with `npm install` (fails: express-openapi-validator@^4.18.3 not found).

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -588,6 +588,7 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
 - `POST /v1/garages/{garageId}/store` – store a vehicle for a character
 - `POST /v1/garages/{garageId}/retrieve` – retrieve a stored vehicle
 - `GET /v1/characters/{characterId}/garages/{garageId}/vehicles` – list character vehicles in a garage
+  - WebSocket: `garage.vehicleStored`, `garage.vehicleRetrieved` on topic `vehicles`
 
 ### Heli
 

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -19,6 +19,7 @@
 - Ensure the `wise_wheels_spins` table exists for wheel spin history.
   - Ensure index `idx_wise_wheels_created` exists; spins older than 30 days are purged hourly by `wise-wheels-expire` scheduler.
 - Ensure the `taxi_rides` table has index `idx_taxi_status_created_at`; tune `TAXI_REQUEST_TTL_MS` to control stale request expiry.
+- Ensure the `garage_vehicles` table has index `idx_garage_vehicles_retrieved`; tune `GARAGE_VEHICLE_RETENTION_MS` for purge retention.
  - Ensure the `assets` table exists with indexes `idx_assets_owner` and `idx_assets_created_at`; tune `ASSET_RETENTION_MS` for the `assets-prune` scheduler.
 - Ensure the `clothes` table exists for character outfit records.
 - Ensure the `apartments` and `apartment_residents` tables exist and include the `character_id` column after deploying this sprint.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -479,6 +479,7 @@ Indexes: `idx_hospital_admissions_character` (character_id), `idx_hospital_admis
 | character_id | BIGINT | Character storing the vehicle |
 | stored_at | TIMESTAMP | Storage time |
 | retrieved_at | TIMESTAMP | Retrieval time |
+| indexes | - | `idx_garage_vehicles_character` on `character_id`, `idx_garage_vehicles_retrieved` on `retrieved_at` |
 
 ## hardcap_config
 

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -42,7 +42,7 @@
 | furniture | Resource lets players place or remove furniture items | `GET /v1/characters/{characterId}/furniture`, `POST /v1/characters/{characterId}/furniture`, `DELETE /v1/characters/{characterId}/furniture/{id}` (WS/webhook: `furniture.placed`, `furniture.removed`) |
 | gabz_mrpd | Mission Row PD duty roster with push updates | `/v1/police/roster`, `/v1/police/roster/{characterId}:duty` → `police.duty` |
 | gabz_pillbox_hospital | Resource handles hospital admissions and bed management | `GET /v1/hospital/admissions/active`, `POST /v1/hospital/admissions`, `POST /v1/hospital/admissions/{id}/discharge` – WS `hospital.*`, webhook mirrors |
-| garages | Resource emits events when vehicles are stored or retrieved from garages | `/v1/garages` CRUD, `/v1/garages/{garageId}/store`, `/v1/garages/{garageId}/retrieve`, `/v1/characters/{characterId}/garages/{garageId}/vehicles` |
+| garages | Store and retrieve vehicle events | `/v1/garages` CRUD, `/v1/garages/{garageId}/store`, `/v1/garages/{garageId}/retrieve`, `/v1/characters/{characterId}/garages/{garageId}/vehicles` → pushes `garage.vehicleStored`/`garage.vehicleRetrieved` |
 | ghmattimysql | Exports `execute`, `scalar` and `transaction` for MySQL queries | Core `db` repository offers `query`, `scalar` and `transaction` helpers with named parameters |
 | hardcap | Connection attempts and slot checks | `GET /v1/hardcap/status`, `POST /v1/hardcap/sessions`, `DELETE /v1/hardcap/sessions/{id}` |
 | heli | Resource logs helicopter flight start and end events | `POST /v1/heli/flights`, `POST /v1/heli/flights/{id}/end`, `GET /v1/characters/{characterId}/heli/flights` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -83,7 +83,7 @@ practice is supported by citations.
 | **furniture module** | Furniture endpoints follow the established layered pattern with authentication and idempotency. |
 | **characters module** | Added endpoint to retrieve the active character, maintaining layered design and validation. |
 | **hospital module** | Hospital admission endpoints follow the layered pattern with auth/idempotency, broadcast WS/webhook events and a scheduler auto-discharges stale admissions. |
-| **garages module** | Garage endpoints follow the established layered pattern with authentication, rate limiting and idempotency. |
+| **garages module** | Garage endpoints follow the layered pattern with authentication, rate limiting and idempotency; store/retrieve actions emit WebSocket/webhook events and hourly purge removes old records. |
 | **database helpers** | Core MySQL adapter now supports named parameters, scalar queries and transaction wrappers for safer, more flexible persistence. |
 | **hardcap module** | Hardcap endpoints follow the established layered pattern with authentication, rate limiting and idempotency. |
 | **heli module** | Heli flight endpoints follow the established layered pattern with authentication and idempotency. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -551,3 +551,12 @@ Extended Pillbox hospital admissions with real-time push and scheduled cleanup.
 * Scheduler `hospital-admissions-sync` auto-discharges long stays and broadcasts `hospital.admissions.active`.
 
 For resource decisions see `progress-ledger.md`. Module details are documented in `modules/hospital.md`.
+
+## Update – 2025-08-27
+
+Extended parity for the **garages** resource with realtime push and retention cleanup.
+
+* Vehicle store/retrieve operations broadcast `garage.vehicleStored` and `garage.vehicleRetrieved` over WebSocket and webhooks.
+* Hourly `garage-vehicle-purge` scheduler removes records with `retrieved_at` older than `GARAGE_VEHICLE_RETENTION_MS`.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/garages.md`.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -73,3 +73,4 @@
 | 073_update_interiors_unique_key.sql | Ensure apartment interiors unique per character |
 | 074_add_taxi_rides_status_created_index.sql | Index taxi_rides on status and created_at |
 | 075_police_officers_character.sql | Rename police_officers player_id to character_id and add index |
+| 076_add_garage_vehicle_retrieved_index.sql | Index garage_vehicles retrieved_at column |

--- a/backend/srp-base/docs/modules/garages.md
+++ b/backend/srp-base/docs/modules/garages.md
@@ -21,8 +21,19 @@ Provides CRUD for garages and per-character vehicle storage.
 - `storeVehicle(garageId, vehicleId, characterId)` records storage
 - `retrieveVehicle(garageId, vehicleId, characterId)` marks retrieval
 - `listGarageVehicles(garageId, characterId)` lists stored vehicles for a character
+- `deleteRetrievedBefore(cutoff)` purges retrieved records older than `cutoff`
 
 ## Edge Cases
 
 - Storing the same vehicle multiple times creates separate records
 - Retrieval is idempotent; repeated calls on the same record succeed
+
+## Realtime
+
+- WebSocket topic `vehicles` emits `garage.vehicleStored` and `garage.vehicleRetrieved`
+- Webhook dispatcher mirrors the above events
+
+## Scheduler
+
+- Hourly `garage-vehicle-purge` removes entries with `retrieved_at` older than `GARAGE_VEHICLE_RETENTION_MS`
+

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -83,3 +83,4 @@
 | 77 | furniture realtime | Furniture place/remove pushes and retention purge | Extend | Broadcast events and daily purge |
 | 78 | gabz_mrpd | Mission Row PD duty roster with realtime pushes and stale-duty scheduler | Create | Added roster API, WS/webhook events and cleanup task |
 | 79 | gabz_pillbox_hospital | Pillbox hospital admissions realtime and auto-discharge | Extend | Added WS/webhook pushes and scheduler |
+| 80 | garages realtime | Vehicle store/retrieve pushes with retention purge | Extend | Added WS/webhook events and cleanup scheduler |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -370,3 +370,8 @@
 
 - Attempted to clone reference repository `https://github.com/h04X-2K/NoPixelServer` for gabz_pillbox_hospital but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed EMS/hospital flows in ESX and ND Core for admission tracking (conceptual only).
+
+## Research Log – 2025-08-27 (garages realtime)
+
+- Attempted to clone reference repository `https://github.com/h04X-2K/NoPixelServer` garages resource but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed vehicle storage flows in ESX and QB-Core frameworks for naming and retention concepts.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -7,8 +7,8 @@
 - docs/events-and-rpcs.md
 - docs/framework-compliance.md
 - docs/index.md
-- docs/modules/hospital.md
-- docs/naming-map.md
+- docs/migrations.md
+- docs/modules/garages.md
 - docs/progress-ledger.md
 - docs/research-log.md
 - docs/run-docs.md
@@ -16,15 +16,15 @@
 ## Run – 2025-08-27
 
 ### Docs Touched
-- docs/index.md
-- docs/progress-ledger.md
-- docs/framework-compliance.md
-- docs/BASE_API_DOCUMENTATION.md
-- docs/events-and-rpcs.md
-- docs/db-schema.md
 - docs/admin-ops.md
-- docs/modules/hospital.md
-- docs/naming-map.md
+- docs/BASE_API_DOCUMENTATION.md
+- docs/db-schema.md
+- docs/events-and-rpcs.md
+- docs/framework-compliance.md
+- docs/index.md
+- docs/migrations.md
+- docs/modules/garages.md
+- docs/progress-ledger.md
 - docs/research-log.md
 - docs/run-docs.md
 

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -101,6 +101,10 @@ const config = {
     requestTtlMs: parseInt(process.env.TAXI_REQUEST_TTL_MS || '300000', 10),
   },
 
+  garages: {
+    retentionMs: parseInt(process.env.GARAGE_VEHICLE_RETENTION_MS || '2592000000', 10),
+  },
+
   police: {
     dutyTimeoutMs: parseInt(process.env.POLICE_DUTY_TIMEOUT_MS || '3600000', 10),
     checkIntervalMs: parseInt(process.env.POLICE_CHECK_INTERVAL_MS || '300000', 10),

--- a/backend/srp-base/src/migrations/076_add_garage_vehicle_retrieved_index.sql
+++ b/backend/srp-base/src/migrations/076_add_garage_vehicle_retrieved_index.sql
@@ -1,0 +1,3 @@
+-- Index retrieved_at for purge performance
+CREATE INDEX IF NOT EXISTS idx_garage_vehicles_retrieved ON garage_vehicles (retrieved_at);
+

--- a/backend/srp-base/src/repositories/garagesRepository.js
+++ b/backend/srp-base/src/repositories/garagesRepository.js
@@ -107,6 +107,15 @@ async function listGarageVehicles(garageId, characterId) {
   return rows;
 }
 
+/**
+ * Remove retrieved vehicle records older than the provided cutoff.
+ * @param {Date} cutoff - Records with retrieved_at before this date are deleted
+ * @returns {Promise<void>}
+ */
+async function deleteRetrievedBefore(cutoff) {
+  await db.query('DELETE FROM garage_vehicles WHERE retrieved_at IS NOT NULL AND retrieved_at < ?', [cutoff]);
+}
+
 module.exports = {
   listGarages,
   createGarage,
@@ -115,4 +124,5 @@ module.exports = {
   storeVehicle,
   retrieveVehicle,
   listGarageVehicles,
+  deleteRetrievedBefore,
 };

--- a/backend/srp-base/src/routes/garages.routes.js
+++ b/backend/srp-base/src/routes/garages.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const { createRateLimiter } = require('../middleware/rateLimit');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 const {
   listGarages,
   createGarage,
@@ -73,6 +75,16 @@ router.post('/v1/garages/:garageId/store', storeLimiter, async (req, res) => {
   }
   try {
     const record = await storeVehicle(Number(garageId), Number(vehicleId), Number(characterId));
+    websocket.broadcast('vehicles', 'garage.vehicleStored', {
+      garageId: Number(garageId),
+      vehicleId: Number(vehicleId),
+      characterId: Number(characterId),
+    });
+    hooks.dispatch('garage.vehicleStored', {
+      garageId: Number(garageId),
+      vehicleId: Number(vehicleId),
+      characterId: Number(characterId),
+    });
     sendOk(res, { record }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'GARAGE_STORE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
@@ -89,6 +101,16 @@ router.post('/v1/garages/:garageId/retrieve', retrieveLimiter, async (req, res) 
   }
   try {
     await retrieveVehicle(Number(garageId), Number(vehicleId), Number(characterId));
+    websocket.broadcast('vehicles', 'garage.vehicleRetrieved', {
+      garageId: Number(garageId),
+      vehicleId: Number(vehicleId),
+      characterId: Number(characterId),
+    });
+    hooks.dispatch('garage.vehicleRetrieved', {
+      garageId: Number(garageId),
+      vehicleId: Number(vehicleId),
+      characterId: Number(characterId),
+    });
     sendOk(res, {}, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'GARAGE_RETRIEVE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
@@ -105,5 +127,5 @@ router.get('/v1/characters/:characterId/garages/:garageId/vehicles', async (req,
     sendError(res, { code: 'GARAGE_VEHICLES_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
   }
 });
-
 module.exports = router;
+

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -28,6 +28,7 @@ const hospitalTasks = require('./tasks/hospital');
 const taxiTasks = require('./tasks/taxi');
 const furnitureTasks = require('./tasks/furniture');
 const policeTasks = require('./tasks/police');
+const garageTasks = require('./tasks/garages');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -177,6 +178,13 @@ scheduler.register(
   () => policeTasks.clearStale(),
   policeTasks.INTERVAL_MS,
   { jitter: 5000, persistName: policeTasks.JOB_NAME },
+);
+
+scheduler.register(
+  garageTasks.JOB_NAME,
+  () => garageTasks.purgeRetrieved(),
+  garageTasks.INTERVAL_MS,
+  { jitter: 60000, persistName: garageTasks.JOB_NAME },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/garages.js
+++ b/backend/srp-base/src/tasks/garages.js
@@ -1,0 +1,18 @@
+const config = require('../config/env');
+const repo = require('../repositories/garagesRepository');
+const logger = require('../utils/logger');
+
+const JOB_NAME = 'garage-vehicle-purge';
+const INTERVAL_MS = 3600000; // hourly
+
+async function purgeRetrieved() {
+  try {
+    const cutoff = new Date(Date.now() - config.garages.retentionMs);
+    await repo.deleteRetrievedBefore(cutoff);
+  } catch (err) {
+    logger.error({ err }, 'Failed to purge retrieved garage vehicles');
+  }
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, purgeRetrieved };
+


### PR DESCRIPTION
## Summary
- broadcast garage vehicle store/retrieve over WebSocket and webhooks
- purge retrieved garage vehicles on hourly scheduler
- document garage retention config and index

## Testing
- `node -e "require('./backend/srp-base/src/app');"` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68ae8ec3a224832d837653e695fdd65d