### PR TITLE
srp-base(heli): realtime flight events and expiry scheduler

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1577,3 +1577,18 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Drop index `idx_hardcap_sessions_disconnected_connected` and remove hardcap scheduler registration.
+
+## 2025-08-27 (heli realtime)
+
+### Changed
+* Heli flight start/end broadcasts over WebSocket and webhooks.
+* Scheduler `heli-expire-flights` auto-ends flights beyond `HELI_MAX_FLIGHT_HOURS`.
+
+### Migrations
+* None
+
+### Risks
+* Misconfigured expiry may terminate active flights.
+
+### Rollback
+* Remove `heli-expire-flights` scheduler registration and related config keys.

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -596,6 +596,8 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
 - `POST /v1/heli/flights` – start a flight
 - `POST /v1/heli/flights/{id}/end` – end a flight
 - `GET /v1/characters/{characterId}/heli/flights` – list flights for a character
+  - WebSocket: `heli.flightStarted`, `heli.flightEnded`, `heli.flightExpired` on topic `heli`
+  - Scheduler `heli-expire-flights` ends flights older than `HELI_MAX_FLIGHT_HOURS`
 
 ### Peds
 

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -51,6 +51,7 @@
  - Ensure the `hardcap_config` and `hardcap_sessions` tables exist for player capacity tracking.
  - Ensure index `idx_hardcap_sessions_disconnected_connected` exists; scheduler `hardcap-session-expiry` purges stale sessions after `HARDCAP_SESSION_TIMEOUT_MS`.
 - Ensure the `heli_flights` table exists for helicopter flight logs.
+- Configure `HELI_MAX_FLIGHT_HOURS` and `HELI_CHECK_INTERVAL_MS` to control automatic flight expiry.
 - Ensure the `import_pack_orders` table includes `price` and `canceled_at` columns for import package tracking.
 - Ensure the `character_peds` table exists for ped state tracking.
 - Ensure the `jailbreak_attempts` table exists for jailbreak tracking.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -513,6 +513,8 @@ Indexes: `idx_hospital_admissions_character` (character_id), `idx_hospital_admis
 | created_at | TIMESTAMP | Creation time |
 | updated_at | TIMESTAMP | Update time |
 
+Index: `idx_heli_flights_character` on `character_id`
+
 ## import_pack_orders
 
 | Column | Type | Notes |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -45,7 +45,7 @@
 | garages | Store and retrieve vehicle events | `/v1/garages` CRUD, `/v1/garages/{garageId}/store`, `/v1/garages/{garageId}/retrieve`, `/v1/characters/{characterId}/garages/{garageId}/vehicles` → pushes `garage.vehicleStored`/`garage.vehicleRetrieved` |
 | ghmattimysql | Exports `execute`, `scalar` and `transaction` for MySQL queries | Core `db` repository offers `query`, `scalar` and `transaction` helpers with named parameters |
 | hardcap | Connection limits and session tracking; broadcasts `hardcap.config.updated`, `hardcap.session.created`, `hardcap.session.ended`, `hardcap.session.expired` | `GET /v1/hardcap/status`, `POST /v1/hardcap/config`, `POST /v1/hardcap/sessions`, `DELETE /v1/hardcap/sessions/{id}` |
-| heli | Resource logs helicopter flight start and end events | `POST /v1/heli/flights`, `POST /v1/heli/flights/{id}/end`, `GET /v1/characters/{characterId}/heli/flights` |
+| heli | Resource logs helicopter flight start and end events | `POST /v1/heli/flights`, `POST /v1/heli/flights/{id}/end`, `GET /v1/characters/{characterId}/heli/flights` → `heli.flightStarted`, `heli.flightEnded`, `heli.flightExpired` |
 | isPed | Resource manages ped state updates like model, health and armor | `GET/PUT /v1/characters/{characterId}/ped` |
 | jailbreak | Resource triggers jailbreak start and completion events with character and prison info | `POST /v1/jailbreaks`, `POST /v1/jailbreaks/{id}/complete`, `GET /v1/jailbreaks/active` |
 | jobsystem | Resource manages job definitions and assignments | `GET /v1/jobs`, `POST /v1/jobs`, `GET /v1/jobs/{id}`, `POST /v1/jobs/assign`, `POST /v1/jobs/duty`, `GET /v1/jobs/{characterId}/assignments` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -86,7 +86,7 @@ practice is supported by citations.
 | **garages module** | Garage endpoints follow the layered pattern with authentication, rate limiting and idempotency; store/retrieve actions emit WebSocket/webhook events and hourly purge removes old records. |
 | **database helpers** | Core MySQL adapter now supports named parameters, scalar queries and transaction wrappers for safer, more flexible persistence. |
 | **hardcap module** | Hardcap endpoints follow the layered pattern with auth, rate limiting and idempotency; now emit `hardcap.*` events and scheduler purges stale sessions. |
-| **heli module** | Heli flight endpoints follow the established layered pattern with authentication and idempotency. |
+| **heli module** | Heli flight endpoints follow the established layered pattern with authentication and idempotency; broadcasts start/end events and scheduler auto-ends stale flights. |
 | **import-pack module** | Order pricing, retrieval and cancellation endpoints follow the established layered pattern with authentication and idempotency. |
 | **peds module** | Ped state endpoints follow the established layered pattern with authentication and idempotency. |
 | **jailbreak module** | Jailbreak endpoints follow the established layered pattern with authentication and idempotency. |
@@ -115,3 +115,4 @@ practice is supported by citations.
 - Implement bulk emote sync endpoint and labeling/ordering support.
 - Provide passenger cancellation endpoint for taxi requests.
 - Implement call-sign management for police officers.
+- Add altitude and location tracking for helicopter flights.

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -311,6 +311,15 @@ For resource decisions see `progress-ledger.md`. Module details are documented i
 
 ## Update – 2025-08-27
 
+Extended heli flight tracking with realtime events and stale-flight cleanup.
+
+* Flight start/end emits `heli.flightStarted` and `heli.flightEnded` via WebSocket/webhooks.
+* Scheduler `heli-expire-flights` auto-ends flights past `HELI_MAX_FLIGHT_HOURS`, broadcasting `heli.flightExpired`.
+
+For resource decisions see `progress-ledger.md`. Module details are documented in `modules/heli.md`.
+
+## Update – 2025-08-27
+
 Extended parity for the **hardcap** resource with realtime session notifications and automatic cleanup.
 
 * Configuration and session endpoints now broadcast `hardcap.*` events via WebSocket and webhooks.

--- a/backend/srp-base/docs/modules/heli.md
+++ b/backend/srp-base/docs/modules/heli.md
@@ -1,6 +1,6 @@
 # Heli Module
 
-The heli module records helicopter flights for characters.
+The heli module records helicopter flights for characters and broadcasts flight events.
 
 ## Feature flag
 
@@ -32,9 +32,10 @@ No feature flag; module is always enabled.
 
 ## Implementation details
 
-* **Repository:** `src/repositories/heliRepository.js` persists flight records.
+* **Repository:** `src/repositories/heliRepository.js` persists flight records and expires stale flights.
+* **Routes:** `src/routes/heli.routes.js` defines the REST API and broadcasts `heli.flightStarted` and `heli.flightEnded` via WebSocket and webhooks.
+* **Scheduler:** `src/tasks/heli.js` ends flights exceeding `HELI_MAX_FLIGHT_HOURS`, emitting `heli.flightExpired`.
 * **Migration:** `src/migrations/051_add_heli_flights.sql` creates the `heli_flights` table.
-* **Routes:** `src/routes/heli.routes.js` defines the REST API.
 * **OpenAPI:** `openapi/api.yaml` documents schemas and paths.
 
 ## Future work

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -35,3 +35,4 @@
 | gabz_pillbox_hospital | hospital |
 | police_officers | police roster |
 | player_id | character_id |
+| heli | heli |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -85,3 +85,4 @@
 | 79 | gabz_pillbox_hospital | Pillbox hospital admissions realtime and auto-discharge | Extend | Added WS/webhook pushes and scheduler |
 | 80 | garages realtime | Vehicle store/retrieve pushes with retention purge | Extend | Added WS/webhook events and cleanup scheduler |
 | 81 | hardcap realtime | Session WS/webhook pushes and stale session purge | Extend | Broadcast config/session events; cleanup job |
+| 82 | heli realtime | Helicopter flight events with stale-flight auto end | Extend | Broadcast start/end/expired and scheduler `heli-expire-flights` |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -379,3 +379,8 @@
 ## Research Log – 2025-08-27 (hardcap realtime)
 
 - Attempted to clone `https://github.com/h04X-2K/NoPixelServer` hardcap resource but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
+
+## Research Log – 2025-08-27 (heli)
+
+- Attempted to clone reference resources repository `https://github.com/h04X-2K/NoPixelServer` but received HTTP 403. Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed helicopter job/vehicle flows in EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP conceptually to align naming and event patterns.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -7,8 +7,7 @@
 - docs/events-and-rpcs.md
 - docs/framework-compliance.md
 - docs/index.md
-- docs/migrations.md
-- docs/modules/hardcap.md
+- docs/modules/heli.md
 - docs/naming-map.md
 - docs/progress-ledger.md
 - docs/research-log.md
@@ -23,8 +22,7 @@
 - docs/events-and-rpcs.md
 - docs/framework-compliance.md
 - docs/index.md
-- docs/migrations.md
-- docs/modules/hardcap.md
+- docs/modules/heli.md
 - docs/naming-map.md
 - docs/progress-ledger.md
 - docs/research-log.md
@@ -44,3 +42,4 @@
 | Bulk sync endpoint for favorite emotes | backend | low | design |
 | Allow labeling/ordering of favorite emotes | backend | low | design |
 | Implement call-sign management for police officers | backend | medium | design |
+| Add altitude and location tracking for helicopter flights | backend | low | design |

--- a/backend/srp-base/docs/todo-gaps.md
+++ b/backend/srp-base/docs/todo-gaps.md
@@ -13,3 +13,4 @@
 | Bulk sync endpoint for favorite emotes | backend | low | design |
 | Allow labeling/ordering of favorite emotes | backend | low | design |
 | Implement call-sign management for police officers | backend | medium | design |
+| Add altitude and location tracking for helicopter flights | backend | low | design |

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -110,6 +110,11 @@ const config = {
     checkIntervalMs: parseInt(process.env.POLICE_CHECK_INTERVAL_MS || '300000', 10),
   },
 
+  heli: {
+    maxFlightHours: parseInt(process.env.HELI_MAX_FLIGHT_HOURS || '6', 10),
+    checkIntervalMs: parseInt(process.env.HELI_CHECK_INTERVAL_MS || '300000', 10),
+  },
+
   hardcap: {
     sessionTimeoutMs: parseInt(process.env.HARDCAP_SESSION_TIMEOUT_MS || '600000', 10),
   },

--- a/backend/srp-base/src/repositories/heliRepository.js
+++ b/backend/srp-base/src/repositories/heliRepository.js
@@ -34,4 +34,16 @@ async function listFlightsByCharacter(characterId, limit = 50) {
   return rows;
 }
 
-module.exports = { createFlight, endFlight, listFlightsByCharacter };
+async function endStaleFlights(maxAgeHours) {
+  const [rows] = await db.query(
+    'SELECT id, character_id AS characterId, purpose, start_time AS startTime FROM heli_flights WHERE end_time IS NULL AND start_time < DATE_SUB(NOW(), INTERVAL ? HOUR)',
+    [maxAgeHours],
+  );
+  if (rows.length === 0) return [];
+  const ids = rows.map((r) => r.id);
+  await db.query('UPDATE heli_flights SET end_time = NOW() WHERE id IN (?)', [ids]);
+  const ended = rows.map((r) => ({ ...r, endTime: new Date().toISOString() }));
+  return ended;
+}
+
+module.exports = { createFlight, endFlight, listFlightsByCharacter, endStaleFlights };

--- a/backend/srp-base/src/routes/heli.routes.js
+++ b/backend/srp-base/src/routes/heli.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const heliRepo = require('../repositories/heliRepository');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -27,6 +29,8 @@ router.post('/v1/heli/flights', async (req, res) => {
   }
   try {
     const flight = await heliRepo.createFlight({ characterId, purpose });
+    websocket.broadcast('heli', 'heli.flightStarted', flight);
+    dispatcher.dispatch('heli.flightStarted', flight);
     sendOk(res, { flight }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'HELI_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
@@ -65,6 +69,8 @@ router.post('/v1/heli/flights/:id/end', async (req, res) => {
         res.locals.traceId,
       );
     }
+    websocket.broadcast('heli', 'heli.flightEnded', flight);
+    dispatcher.dispatch('heli.flightEnded', flight);
     sendOk(res, { flight }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'HELI_END_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -30,6 +30,7 @@ const furnitureTasks = require('./tasks/furniture');
 const policeTasks = require('./tasks/police');
 const garageTasks = require('./tasks/garages');
 const hardcapTasks = require('./tasks/hardcap');
+const heliTasks = require('./tasks/heli');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -150,6 +151,13 @@ scheduler.register(
   () => emotesTasks.purgeOld(),
   emotesTasks.INTERVAL_MS,
   { jitter: 60000 },
+);
+
+scheduler.register(
+  heliTasks.JOB_NAME,
+  () => heliTasks.expireStale(),
+  heliTasks.INTERVAL_MS,
+  { jitter: 5000, persistName: heliTasks.JOB_NAME },
 );
 
 scheduler.register(

--- a/backend/srp-base/src/tasks/heli.js
+++ b/backend/srp-base/src/tasks/heli.js
@@ -1,0 +1,21 @@
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
+const heliRepo = require('../repositories/heliRepository');
+const config = require('../config/env');
+const logger = require('../utils/logger');
+
+const JOB_NAME = 'heli-expire-flights';
+const INTERVAL_MS = config.heli.checkIntervalMs;
+
+async function expireStale() {
+  const flights = await heliRepo.endStaleFlights(config.heli.maxFlightHours);
+  flights.forEach((flight) => {
+    websocket.broadcast('heli', 'heli.flightExpired', flight);
+    dispatcher.dispatch('heli.flightExpired', flight);
+  });
+  if (flights.length > 0) {
+    logger.info({ count: flights.length }, 'heli: ended stale flights');
+  }
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, expireStale };


### PR DESCRIPTION
## Summary
- broadcast heli flight start/end events over WebSocket and webhooks
- auto-expire stale helicopter flights via scheduler
- document heli config and mappings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx @redocly/cli lint openapi/api.yaml` *(fails: package install prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9502700c832d98cdeb397a9eedfc