### PR TITLE
srp-base: add jailbreak expiry scheduler with realtime events

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1627,3 +1627,18 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 * Remove peds-health-regen scheduler and delete `src/tasks/peds.js`.
 * Revert websocket namespace changes in `src/realtime/websocket.js`.
+
+## 2025-08-27 (jailbreak realtime)
+
+### Added
+* WebSocket and webhook events for jailbreak attempts.
+* Scheduler `jailbreak-expire` marks stale attempts failed.
+
+### Migrations
+* 079_add_jailbreak_started_index.sql
+
+### Risks
+* Misconfigured `JAILBREAK_MAX_ACTIVE_MS` may prematurely fail attempts.
+
+### Rollback
+* Drop index `idx_jailbreak_attempts_started_at` and remove scheduler registration.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,22 +1,26 @@
 # Manifest
 
-- Added ped WebSocket and webhook broadcasts with health regeneration scheduler.
+- Added jailbreak expiry scheduler with WebSocket and webhook notifications.
 
 | File | Action | Note |
 |---|---|---|
-| src/repositories/pedsRepository.js | M | Added health regeneration helper |
-| src/routes/peds.routes.js | M | Broadcast ped updates via WebSocket and webhooks |
-| src/realtime/websocket.js | M | Introduced namespaces and typed envelopes |
-| src/tasks/peds.js | A | Scheduler task for ped health regeneration |
-| src/server.js | M | Registered peds-health-regen scheduler |
-| docs/modules/peds.md | M | Documented realtime events and scheduler |
-| docs/BASE_API_DOCUMENTATION.md | M | Added peds WebSocket info |
-| docs/events-and-rpcs.md | M | Mapped isPed events to SRP API |
-| docs/admin-ops.md | M | Listed character_peds table and regen task |
-| docs/index.md | M | Logged isPed update summary |
-| docs/progress-ledger.md | M | Recorded isPed realtime entry |
-| docs/framework-compliance.md | M | Added peds module compliance note |
-| docs/naming-map.md | M | Mapped isPed → peds |
-| docs/research-log.md | M | Logged isPed resource research |
-| docs/todo-gaps.md | M | Added ped attributes outstanding item |
+| src/repositories/jailbreakRepository.js | M | Added expireStale query |
+| src/tasks/jailbreak.js | A | Scheduler to fail stale attempts with broadcasts |
+| src/server.js | M | Registered jailbreak-expire job |
+| src/config/env.js | M | Added jailbreak maxActiveMs config |
+| src/routes/jailbreak.routes.js | M | Broadcast and dispatch jailbreak events |
+| openapi/api.yaml | M | Documented websocket/webhook events for jailbreak |
+| src/migrations/079_add_jailbreak_started_index.sql | A | Index on started_at |
+| docs/modules/jailbreak.md | M | Documented realtime events and scheduler |
+| docs/admin-ops.md | M | Added jailbreak index and scheduler note |
+| docs/events-and-rpcs.md | M | Mapped jailbreak events |
+| docs/db-schema.md | M | Recorded jailbreak index |
+| docs/migrations.md | M | Listed migration 079 |
+| docs/index.md | M | Logged jailbreak update |
+| docs/progress-ledger.md | M | Recorded jailbreak realtime entry |
+| docs/framework-compliance.md | M | Updated jailbreak compliance notes |
+| docs/BASE_API_DOCUMENTATION.md | M | Added jailbreak expiry description |
+| docs/naming-map.md | M | Added np-jailbreak mapping |
+| docs/research-log.md | M | Logged jailbreak research |
 | docs/run-docs.md | M | Consolidated documentation for this run |
+| docs/testing.md | M | Added jailbreak verification steps |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -611,6 +611,7 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
 - `POST /v1/jailbreaks` – start a jailbreak attempt (`characterId`, `prison`).
 - `POST /v1/jailbreaks/{id}/complete` – complete an attempt with `success` flag.
 - `GET /v1/jailbreaks/active` – list active attempts.
+- Scheduler `jailbreak-expire` marks attempts older than `JAILBREAK_MAX_ACTIVE_MS` as failed and emits WebSocket `jailbreaks.expired` and webhook `jailbreak.expired`.
 
 ## Update – 2025-08-25 (k9)
 

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -56,6 +56,7 @@
 - Ensure the `import_pack_orders` table includes `price`, `canceled_at`, `expires_at` and `expired_at` columns with index `idx_import_pack_orders_status_expires`. Scheduler `import-pack-expiry` uses these to mark and broadcast expired orders based on `IMPORT_PACK_EXPIRY_MS`.
 - Ensure the `character_peds` table exists for ped state tracking.
 - Ensure the `jailbreak_attempts` table exists for jailbreak tracking.
+- Ensure index `idx_jailbreak_attempts_started_at` exists; stale attempts older than `JAILBREAK_MAX_ACTIVE_MS` are failed by scheduler `jailbreak-expire`.
 - Ensure the `jobs` and `character_jobs` tables exist for job management.
 - Ensure the `k9_units` table exists after applying migration 057.
 - Ensure the `police_officers` table has `character_id` column and index after migration 075.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -554,6 +554,7 @@ Index `idx_import_pack_orders_status_expires` on `(status, expires_at)` accelera
 | started_at | TIMESTAMP | Start time |
 | ended_at | TIMESTAMP | Completion time |
 | success | TINYINT(1) | 1 success, 0 failure |
+| idx_jailbreak_attempts_started_at | INDEX | Index on started_at for expiry scans |
 
 ## k9_units
 

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -47,7 +47,7 @@
 | ghmattimysql | Exports `execute`, `scalar` and `transaction` for MySQL queries | Core `db` repository offers `query`, `scalar` and `transaction` helpers with named parameters |
 | hardcap | Connection limits and session tracking; broadcasts `hardcap.config.updated`, `hardcap.session.created`, `hardcap.session.ended`, `hardcap.session.expired` | `GET /v1/hardcap/status`, `POST /v1/hardcap/config`, `POST /v1/hardcap/sessions`, `DELETE /v1/hardcap/sessions/{id}` |
 | heli | Resource logs helicopter flight start and end events | `POST /v1/heli/flights`, `POST /v1/heli/flights/{id}/end`, `GET /v1/characters/{characterId}/heli/flights` → `heli.flightStarted`, `heli.flightEnded`, `heli.flightExpired` |
-| jailbreak | Resource triggers jailbreak start and completion events with character and prison info | `POST /v1/jailbreaks`, `POST /v1/jailbreaks/{id}/complete`, `GET /v1/jailbreaks/active` |
+| jailbreak | Resource triggers jailbreak start/completion and auto-expiry events with character and prison info | `POST /v1/jailbreaks`, `POST /v1/jailbreaks/{id}/complete`, `GET /v1/jailbreaks/active` → WS `jailbreaks.attempt`, `jailbreaks.completed`, `jailbreaks.expired`; webhooks mirror `jailbreak.*` |
 | jobsystem | Resource manages job definitions and assignments | `GET /v1/jobs`, `POST /v1/jobs`, `GET /v1/jobs/{id}`, `POST /v1/jobs/assign`, `POST /v1/jobs/duty`, `GET /v1/jobs/{characterId}/assignments` |
 | broadcaster | Event to attempt joining the broadcaster job | `POST /v1/broadcast/attempt` |
 | srp-debug | Developer requests for runtime diagnostics | `GET /v1/debug/status` returns server metrics |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -89,7 +89,7 @@ practice is supported by citations.
 | **heli module** | Heli flight endpoints follow the established layered pattern with authentication and idempotency; broadcasts start/end events and scheduler auto-ends stale flights. |
 | **import-pack module** | Order pricing, retrieval, cancellation and expiry endpoints follow the established layered pattern with authentication, idempotency, WebSocket/webhook events and an expiry scheduler. |
 | **peds module** | Ped state endpoints follow the established layered pattern with authentication and idempotency. |
-| **jailbreak module** | Jailbreak endpoints follow the established layered pattern with authentication and idempotency. |
+| **jailbreak module** | Jailbreak endpoints follow the layered pattern with auth/idempotency and now emit WebSocket/webhook events with an expiry scheduler. |
 | **k9 module** | K9 unit endpoints follow the established layered pattern with authentication and idempotency. |
 | **jobs module** | Job CRUD and assignment endpoints follow the established layered pattern with authentication and idempotency. |
 | **broadcaster module** | Broadcaster assignment uses character-scoped job logic and follows the established layered pattern. || **debug module** | Debug status endpoint follows the established layered pattern with authentication and rate limiting. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -8,3 +8,10 @@ Extended ped persistence for the **isPed** resource with realtime pushes and ser
 
 * `PUT /v1/characters/{characterId}/ped` now dispatches WebSocket `peds.pedUpdated` and webhooks.
 * Scheduler `peds-health-regen` increments stored health and broadcasts `peds.healthRegen`.
+
+## Update – 2025-08-27 (jailbreak)
+
+Auto-expiring jailbreak attempts with realtime notifications.
+
+* `POST /v1/jailbreaks` and `POST /v1/jailbreaks/{id}/complete` emit WebSocket `jailbreaks.*` and webhooks.
+* Scheduler `jailbreak-expire` marks stale attempts failed after `JAILBREAK_MAX_ACTIVE_MS`.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -76,3 +76,4 @@
 | 076_add_garage_vehicle_retrieved_index.sql | Index garage_vehicles retrieved_at column |
 | 077_add_hardcap_session_index.sql | Index hardcap_sessions disconnected_at & connected_at |
 | 078_add_import_pack_expiry.sql | Add expires_at/expired_at columns and index to import_pack_orders |
+| 079_add_jailbreak_started_index.sql | Index jailbreak_attempts started_at column |

--- a/backend/srp-base/docs/modules/jailbreak.md
+++ b/backend/srp-base/docs/modules/jailbreak.md
@@ -8,11 +8,19 @@ Tracks jailbreak attempts and their outcomes for characters.
 - `POST /v1/jailbreaks/{id}/complete` – complete an attempt with `success` flag.
 - `GET /v1/jailbreaks/active` – list active attempts.
 
+### Realtime
+- WebSocket namespace `jailbreaks` emits `attempt`, `completed`, and `expired` events.
+- Webhook dispatcher mirrors events as `jailbreak.attempt`, `jailbreak.completed`, and `jailbreak.expired`.
+
 ## Repository Contracts
 - `createAttempt({ characterId, prison })` → `JailbreakAttempt`.
 - `completeAttempt({ id, success })` → `JailbreakAttempt` or `null` if not found.
 - `listActiveAttempts()` → Array of `JailbreakAttempt`.
+- `expireStale(maxAgeMs)` → Array of expired `JailbreakAttempt`.
 
 ## Edge Cases
 - Returns 400 if required fields are missing.
 - Returns 404 when completing a non-existent attempt.
+
+## Scheduler
+- `jailbreak-expire` runs every minute to fail attempts older than `JAILBREAK_MAX_ACTIVE_MS` (default 5 minutes).

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -39,3 +39,4 @@
 | import-Pack | import-pack |
 | import-Pack2 | import-pack |
 | isPed | peds |
+| np-jailbreak | jailbreak |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -88,3 +88,4 @@
 | 82 | heli realtime | Helicopter flight events with stale-flight auto end | Extend | Broadcast start/end/expired and scheduler `heli-expire-flights` |
 | 83 | import-Pack expiry | Import package auto-expiry with WS/webhook notifications | Extend | Added expiresAt columns, expiry scheduler and broadcasts |
 | 84 | isPed realtime | Ped state persistence with regen pushes | Extend | Added WS/webhook events and health regen scheduler |
+| 85 | jailbreak realtime | Auto-expire attempts with WS/webhook pushes | Extend | Added expiry scheduler, events, index |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -393,3 +393,7 @@
 ## Research Log – 2025-08-27 (isPed)
 - Reviewed `isPed` resource in NoPixel reference for ped model/health persistence.
 - Compared ped health regeneration patterns in EssentialMode, ESX, ND_Core, FSN, QB-Core, vRP and vORP frameworks.
+
+## Research Log – 2025-08-27 (jailbreak)
+- Cloned `https://github.com/h04X-2K/NoPixelServer` and scanned for a `jailbreak` resource; none found, proceeded with internal design.
+- Reviewed jail break flows conceptually across EssentialMode, ESX, ND_Core, FSN, QB-Core, vRP and vORP frameworks for naming and expiry patterns.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -3,30 +3,34 @@
 ## Changed Docs
 - docs/admin-ops.md
 - docs/BASE_API_DOCUMENTATION.md
+- docs/db-schema.md
 - docs/events-and-rpcs.md
 - docs/framework-compliance.md
 - docs/index.md
-- docs/modules/peds.md
+- docs/modules/jailbreak.md
+- docs/migrations.md
 - docs/naming-map.md
 - docs/progress-ledger.md
 - docs/research-log.md
-- docs/todo-gaps.md
 - docs/run-docs.md
+- docs/testing.md
 
 ## Run – 2025-08-27
 
 ### Docs Touched
 - docs/admin-ops.md
 - docs/BASE_API_DOCUMENTATION.md
+- docs/db-schema.md
 - docs/events-and-rpcs.md
 - docs/framework-compliance.md
 - docs/index.md
-- docs/modules/peds.md
+- docs/modules/jailbreak.md
+- docs/migrations.md
 - docs/naming-map.md
 - docs/progress-ledger.md
 - docs/research-log.md
-- docs/todo-gaps.md
 - docs/run-docs.md
+- docs/testing.md
 
 ## Outstanding TODO/Gaps
 | Item | Owner | Priority | Blockers |

--- a/backend/srp-base/docs/testing.md
+++ b/backend/srp-base/docs/testing.md
@@ -369,18 +369,6 @@ curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: ped1' -H 'Content-Type: ap
   http://localhost:3010/v1/characters/1/ped
 ```
 
-Manually verify the jailbreak endpoints:
-
-```sh
-curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: jb1' -H 'Content-Type: application/json' \
-  -d '{"characterId":1,"prison":"bolingbroke"}' \
-  http://localhost:3010/v1/jailbreaks
-curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: jb2' -H 'Content-Type: application/json' \
-  -d '{"success":true}' \
-  http://localhost:3010/v1/jailbreaks/1/complete
-curl -H 'X-API-Token: <token>' http://localhost:3010/v1/jailbreaks/active
-```
-
 Manually verify the k9 endpoints:
 
 ```sh
@@ -454,3 +442,13 @@ curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: pd2' -H 'Content-Type: app
   -d '{"onDuty":false}' \
   http://localhost:3010/v1/police/roster/1:duty
 ```
+# Manually verify the jailbreak endpoints:
+
+```sh
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: jb1' -H 'Content-Type: application/json' \
+  -d '{"characterId":1,"prison":"bolingbroke"}' http://localhost:3010/v1/jailbreaks
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: jb2' -H 'Content-Type: application/json' \
+  -d '{"success":false}' http://localhost:3010/v1/jailbreaks/1/complete
+curl -H 'X-API-Token: <token>' http://localhost:3010/v1/jailbreaks/active
+```
+

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -7302,6 +7302,8 @@ paths:
   /v1/jailbreaks:
     post:
       summary: Start a jailbreak attempt
+      x-websocket-event: jailbreaks.attempt
+      x-webhook-event: jailbreak.attempt
       requestBody:
         required: true
         content:
@@ -7333,6 +7335,8 @@ paths:
   /v1/jailbreaks/{id}/complete:
     post:
       summary: Complete a jailbreak attempt
+      x-websocket-event: jailbreaks.completed
+      x-webhook-event: jailbreak.completed
       parameters:
         - name: id
           in: path

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -124,6 +124,10 @@ const config = {
     sessionTimeoutMs: parseInt(process.env.HARDCAP_SESSION_TIMEOUT_MS || '600000', 10),
   },
 
+  jailbreak: {
+    maxActiveMs: parseInt(process.env.JAILBREAK_MAX_ACTIVE_MS || '300000', 10),
+  },
+
   /**
    * Feature flags for core modules.  Lua consumers still drive
    * behaviour via /v1/config/live, but these flags provide a safe

--- a/backend/srp-base/src/migrations/079_add_jailbreak_started_index.sql
+++ b/backend/srp-base/src/migrations/079_add_jailbreak_started_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_jailbreak_attempts_started_at
+  ON jailbreak_attempts (started_at);

--- a/backend/srp-base/src/repositories/jailbreakRepository.js
+++ b/backend/srp-base/src/repositories/jailbreakRepository.js
@@ -48,8 +48,33 @@ async function listActiveAttempts() {
   );
 }
 
+/**
+ * Mark active attempts older than the provided age as failed.
+ * @param {number} maxAgeMs
+ * @returns {Promise<object[]>} expired attempts
+ */
+async function expireStale(maxAgeMs) {
+  const seconds = Math.floor(maxAgeMs / 1000);
+  const [result] = await db.pool.query(
+    `UPDATE jailbreak_attempts
+     SET status = 'failed', ended_at = CURRENT_TIMESTAMP, success = 0
+     WHERE status = 'active' AND started_at < (CURRENT_TIMESTAMP - INTERVAL ? SECOND)`,
+    [seconds],
+  );
+  if (result.affectedRows === 0) return [];
+  return db.query(
+    `SELECT id, character_id AS characterId, prison, status,
+            started_at AS startedAt, ended_at AS endedAt, success
+       FROM jailbreak_attempts
+      WHERE status = 'failed'
+        AND ended_at >= (CURRENT_TIMESTAMP - INTERVAL ? SECOND)`,
+    [seconds],
+  );
+}
+
 module.exports = {
   createAttempt,
   completeAttempt,
   listActiveAttempts,
+  expireStale,
 };

--- a/backend/srp-base/src/routes/jailbreak.routes.js
+++ b/backend/srp-base/src/routes/jailbreak.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
 const jailbreakRepo = require('../repositories/jailbreakRepository');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
 
 const router = express.Router();
 
@@ -18,6 +20,8 @@ router.post('/v1/jailbreaks', async (req, res, next) => {
       );
     }
     const attempt = await jailbreakRepo.createAttempt({ characterId, prison });
+    websocket.broadcast('jailbreaks', 'attempt', { attempt });
+    dispatcher.dispatch('jailbreak.attempt', { attempt });
     sendOk(res, { attempt }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);
@@ -48,6 +52,8 @@ router.post('/v1/jailbreaks/:id/complete', async (req, res, next) => {
         res.locals.traceId,
       );
     }
+    websocket.broadcast('jailbreaks', 'completed', { attempt });
+    dispatcher.dispatch('jailbreak.completed', { attempt });
     sendOk(res, { attempt }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -33,6 +33,7 @@ const garageTasks = require('./tasks/garages');
 const hardcapTasks = require('./tasks/hardcap');
 const heliTasks = require('./tasks/heli');
 const pedsTasks = require('./tasks/peds');
+const jailbreakTasks = require('./tasks/jailbreak');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -215,6 +216,13 @@ scheduler.register(
   () => pedsTasks.regenAndBroadcast(wss),
   pedsTasks.INTERVAL_MS,
   { jitter: 5000, persistName: pedsTasks.JOB_NAME },
+);
+
+scheduler.register(
+  jailbreakTasks.JOB_NAME,
+  () => jailbreakTasks.expireStale(),
+  jailbreakTasks.INTERVAL_MS,
+  { jitter: 5000, persistName: jailbreakTasks.JOB_NAME },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/jailbreak.js
+++ b/backend/srp-base/src/tasks/jailbreak.js
@@ -1,0 +1,17 @@
+const jailbreakRepo = require('../repositories/jailbreakRepository');
+const websocket = require('../realtime/websocket');
+const dispatcher = require('../hooks/dispatcher');
+const config = require('../config/env');
+
+const JOB_NAME = 'jailbreak-expire';
+const INTERVAL_MS = 60000;
+
+async function expireStale() {
+  const attempts = await jailbreakRepo.expireStale(config.jailbreak.maxActiveMs);
+  attempts.forEach((attempt) => {
+    websocket.broadcast('jailbreaks', 'expired', { attempt });
+    dispatcher.dispatch('jailbreak.expired', { attempt });
+  });
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, expireStale };


### PR DESCRIPTION
## Summary
- expire stale jailbreak attempts server-side
- broadcast jailbreak attempt/completion/expiry over WebSocket and webhook
- index jailbreak_attempts.started_at for efficient purging

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af4beedf9c832dbe3f64ef662abf7a