### PR TITLE
feat(srp-base): realtime jobs roster and duty events

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1642,3 +1642,18 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Drop index `idx_jailbreak_attempts_started_at` and remove scheduler registration.
+
+## 2025-08-28 (jobsystem realtime)
+
+### Added
+* WebSocket and webhook events for job assignments and duty changes.
+* Scheduler `jobs-roster-sync` broadcasts on-duty rosters.
+
+### Migrations
+* None
+
+### Risks
+* Frequent roster broadcasts may increase bandwidth for large crews.
+
+### Rollback
+* Remove `src/tasks/jobs.js` and related scheduler registration.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,26 +1,21 @@
 # Manifest
 
-- Added jailbreak expiry scheduler with WebSocket and webhook notifications.
+- Added realtime job assignment pushes and roster scheduler.
 
 | File | Action | Note |
 |---|---|---|
-| src/repositories/jailbreakRepository.js | M | Added expireStale query |
-| src/tasks/jailbreak.js | A | Scheduler to fail stale attempts with broadcasts |
-| src/server.js | M | Registered jailbreak-expire job |
-| src/config/env.js | M | Added jailbreak maxActiveMs config |
-| src/routes/jailbreak.routes.js | M | Broadcast and dispatch jailbreak events |
-| openapi/api.yaml | M | Documented websocket/webhook events for jailbreak |
-| src/migrations/079_add_jailbreak_started_index.sql | A | Index on started_at |
-| docs/modules/jailbreak.md | M | Documented realtime events and scheduler |
-| docs/admin-ops.md | M | Added jailbreak index and scheduler note |
-| docs/events-and-rpcs.md | M | Mapped jailbreak events |
-| docs/db-schema.md | M | Recorded jailbreak index |
-| docs/migrations.md | M | Listed migration 079 |
-| docs/index.md | M | Logged jailbreak update |
-| docs/progress-ledger.md | M | Recorded jailbreak realtime entry |
-| docs/framework-compliance.md | M | Updated jailbreak compliance notes |
-| docs/BASE_API_DOCUMENTATION.md | M | Added jailbreak expiry description |
-| docs/naming-map.md | M | Added np-jailbreak mapping |
-| docs/research-log.md | M | Logged jailbreak research |
-| docs/run-docs.md | M | Consolidated documentation for this run |
-| docs/testing.md | M | Added jailbreak verification steps |
+| src/repositories/jobsRepository.js | M | Added on-duty roster query |
+| src/routes/jobs.routes.js | M | Broadcast/dispatch `jobs.assigned` and `jobs.duty` |
+| src/tasks/jobs.js | A | Scheduler broadcasting `jobs.roster` |
+| src/server.js | M | Registered jobs roster sync task |
+| openapi/api.yaml | M | Documented job webhook events |
+| docs/modules/jobs.md | M | Added WS/webhook and scheduler notes |
+| docs/BASE_API_DOCUMENTATION.md | M | Documented job events |
+| docs/events-and-rpcs.md | M | Mapped `jobs.*` events |
+| docs/framework-compliance.md | M | Updated jobs module compliance |
+| docs/index.md | M | Logged jobs update |
+| docs/naming-map.md | M | Added jobsystem mapping |
+| docs/progress-ledger.md | M | Recorded jobs realtime entry |
+| docs/research-log.md | M | Logged jobs research |
+| docs/todo-gaps.md | M | Added job progression TODO |
+| docs/run-docs.md | A | Consolidated doc summary for this run |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -280,9 +280,9 @@ In addition to the core identity, permissions, characters and admin APIs describ
 | `GET` | `/v1/jobs` | List all defined jobs. |
 | `POST` | `/v1/jobs` | Create a new job (body: `{ name, label?, description? }`). |
 | `GET` | `/v1/jobs/:id` | Retrieve a job by ID. |
-| `POST` | `/v1/jobs/assign` | Assign a player to a job (body: `{ playerId, jobId }`). |
-| `POST` | `/v1/jobs/duty` | Toggle a player’s duty status for a job (body: `{ playerId, jobId, onDuty }`). |
-| `GET` | `/v1/jobs/:playerId/assignments` | List all job assignments for a player with duty status. |
+| `POST` | `/v1/jobs/assign` | Assign a character to a job (body: `{ characterId, jobId, grade? }`) — broadcasts `jobs.assigned`. |
+| `POST` | `/v1/jobs/duty` | Toggle a character’s duty status (body: `{ characterId, jobId, onDuty }`) — broadcasts `jobs.duty`. |
+| `GET` | `/v1/jobs/:characterId/assignments` | List all job assignments for a character with duty status. |
 
 #### Weapons & Ammo
 
@@ -562,6 +562,7 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
 - `POST /v1/jobs/assign` – assign a job to a character (`characterId`, `jobId`, optional `grade`)
 - `POST /v1/jobs/duty` – set job duty status (`characterId`, `jobId`, `onDuty`)
 - `GET /v1/jobs/{characterId}/assignments` – list assignments for a character
+- WebSocket: `jobs.assigned`, `jobs.duty`, `jobs.roster`
 - `POST /v1/broadcast/attempt` – attempt to become a broadcaster
 
 ### Taxi

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -48,7 +48,7 @@
 | hardcap | Connection limits and session tracking; broadcasts `hardcap.config.updated`, `hardcap.session.created`, `hardcap.session.ended`, `hardcap.session.expired` | `GET /v1/hardcap/status`, `POST /v1/hardcap/config`, `POST /v1/hardcap/sessions`, `DELETE /v1/hardcap/sessions/{id}` |
 | heli | Resource logs helicopter flight start and end events | `POST /v1/heli/flights`, `POST /v1/heli/flights/{id}/end`, `GET /v1/characters/{characterId}/heli/flights` → `heli.flightStarted`, `heli.flightEnded`, `heli.flightExpired` |
 | jailbreak | Resource triggers jailbreak start/completion and auto-expiry events with character and prison info | `POST /v1/jailbreaks`, `POST /v1/jailbreaks/{id}/complete`, `GET /v1/jailbreaks/active` → WS `jailbreaks.attempt`, `jailbreaks.completed`, `jailbreaks.expired`; webhooks mirror `jailbreak.*` |
-| jobsystem | Resource manages job definitions and assignments | `GET /v1/jobs`, `POST /v1/jobs`, `GET /v1/jobs/{id}`, `POST /v1/jobs/assign`, `POST /v1/jobs/duty`, `GET /v1/jobs/{characterId}/assignments` |
+| jobsystem | Resource manages job definitions and assignments | `GET /v1/jobs`, `POST /v1/jobs`, `GET /v1/jobs/{id}`, `POST /v1/jobs/assign`, `POST /v1/jobs/duty`, `GET /v1/jobs/{characterId}/assignments`; WS `jobs.assigned`, `jobs.duty`, `jobs.roster` |
 | broadcaster | Event to attempt joining the broadcaster job | `POST /v1/broadcast/attempt` |
 | srp-debug | Developer requests for runtime diagnostics | `GET /v1/debug/status` returns server metrics |
 | srp-weathersync | Resource broadcasts weather and time updates to clients | `GET /v1/world/state`, `POST /v1/world/state`, `GET /v1/world/forecast`, `POST /v1/world/forecast` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -91,7 +91,7 @@ practice is supported by citations.
 | **peds module** | Ped state endpoints follow the established layered pattern with authentication and idempotency. |
 | **jailbreak module** | Jailbreak endpoints follow the layered pattern with auth/idempotency and now emit WebSocket/webhook events with an expiry scheduler. |
 | **k9 module** | K9 unit endpoints follow the established layered pattern with authentication and idempotency. |
-| **jobs module** | Job CRUD and assignment endpoints follow the established layered pattern with authentication and idempotency. |
+| **jobs module** | Job CRUD and assignment endpoints follow the layered pattern with authentication, idempotency, WebSocket/webhook events and roster scheduler. |
 | **broadcaster module** | Broadcaster assignment uses character-scoped job logic and follows the established layered pattern. || **debug module** | Debug status endpoint follows the established layered pattern with authentication and rate limiting. |
 | **world module** | World state and forecast endpoints follow the established layered pattern with authentication and idempotency. |
 | **diamondCasino module** | Casino game endpoints follow the established layered pattern with authentication and idempotency. |
@@ -118,3 +118,4 @@ practice is supported by citations.
 - Implement call-sign management for police officers.
 - Add altitude and location tracking for helicopter flights.
 - Persist additional ped attributes such as position and appearance customization.
+- Implement paycheck and grade progression logic for jobs.

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -15,3 +15,10 @@ Auto-expiring jailbreak attempts with realtime notifications.
 
 * `POST /v1/jailbreaks` and `POST /v1/jailbreaks/{id}/complete` emit WebSocket `jailbreaks.*` and webhooks.
 * Scheduler `jailbreak-expire` marks stale attempts failed after `JAILBREAK_MAX_ACTIVE_MS`.
+
+## Update – 2025-08-28
+
+Realtime job assignments and roster broadcast.
+
+* `POST /v1/jobs/assign` and `POST /v1/jobs/duty` emit `jobs.*` events over WebSocket and webhooks.
+* Scheduler `jobs-roster-sync` broadcasts on-duty rosters every minute.

--- a/backend/srp-base/docs/modules/jobs.md
+++ b/backend/srp-base/docs/modules/jobs.md
@@ -2,7 +2,9 @@
 
 The Jobs module provides REST endpoints for defining jobs and assigning them to characters.
 It mirrors the responsibilities of the original `jobsystem` resource while enforcing
-character-based ownership and optional grade tracking.
+character-based ownership and optional grade tracking. Job changes are
+pushed to clients via WebSocket and external systems via webhooks so
+they no longer need to poll for updates.
 
 ## Endpoints
 
@@ -26,6 +28,7 @@ Body:
 }
 ```
 Returns the stored assignment.
+Broadcasts `jobs.assigned` over WebSocket and webhooks.
 
 ### `POST /v1/jobs/duty`
 Toggle duty status for a character and job.
@@ -37,9 +40,14 @@ Body:
   "onDuty": true
 }
 ```
+Broadcasts `jobs.duty` over WebSocket and webhooks.
 
 ### `GET /v1/jobs/{characterId}/assignments`
 List all job assignments for a character.
+
+### Scheduler
+`jobs-roster-sync` runs every minute to broadcast on-duty rosters via
+WebSocket `jobs.roster` and matching webhooks.
 
 ## Database Schema
 
@@ -54,3 +62,4 @@ Jobs are stored in the `jobs` table and character assignments in `character_jobs
 
 * Assignments are scoped by `character_id`; `grade` defaults to `0`.
 * All endpoints require an `X-API-Token` header. Mutating requests honor idempotency and rate limits.
+* WebSocket namespace: `/jobs`.

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -40,3 +40,4 @@
 | import-Pack2 | import-pack |
 | isPed | peds |
 | np-jailbreak | jailbreak |
+| jobsystem | jobs |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -89,3 +89,4 @@
 | 83 | import-Pack expiry | Import package auto-expiry with WS/webhook notifications | Extend | Added expiresAt columns, expiry scheduler and broadcasts |
 | 84 | isPed realtime | Ped state persistence with regen pushes | Extend | Added WS/webhook events and health regen scheduler |
 | 85 | jailbreak realtime | Auto-expire attempts with WS/webhook pushes | Extend | Added expiry scheduler, events, index |
+| 86 | jobsystem realtime | Job assignment pushes and roster scheduler | Extend | Broadcast `jobs.*` events and minute roster sync |

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -397,3 +397,8 @@
 ## Research Log – 2025-08-27 (jailbreak)
 - Cloned `https://github.com/h04X-2K/NoPixelServer` and scanned for a `jailbreak` resource; none found, proceeded with internal design.
 - Reviewed jail break flows conceptually across EssentialMode, ESX, ND_Core, FSN, QB-Core, vRP and vORP frameworks for naming and expiry patterns.
+
+## Research Log – 2025-08-28 (jobs)
+
+- Attempted to clone `https://github.com/h04X-2K/NoPixelServer` jobsystem resource but checkout failed (repository too large). Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed job and duty flow patterns across EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP to align terminology and roster broadcast concepts.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,36 +1,28 @@
-# Run Documentation – 2025-08-27
+# Run Documentation – 2025-08-28
 
 ## Changed Docs
-- docs/admin-ops.md
 - docs/BASE_API_DOCUMENTATION.md
-- docs/db-schema.md
 - docs/events-and-rpcs.md
 - docs/framework-compliance.md
 - docs/index.md
-- docs/modules/jailbreak.md
-- docs/migrations.md
+- docs/modules/jobs.md
 - docs/naming-map.md
 - docs/progress-ledger.md
 - docs/research-log.md
-- docs/run-docs.md
-- docs/testing.md
+- docs/todo-gaps.md
 
-## Run – 2025-08-27
+## Run – 2025-08-28
 
 ### Docs Touched
-- docs/admin-ops.md
-- docs/BASE_API_DOCUMENTATION.md
-- docs/db-schema.md
-- docs/events-and-rpcs.md
-- docs/framework-compliance.md
-- docs/index.md
-- docs/modules/jailbreak.md
-- docs/migrations.md
-- docs/naming-map.md
-- docs/progress-ledger.md
-- docs/research-log.md
-- docs/run-docs.md
-- docs/testing.md
+- BASE_API_DOCUMENTATION
+- events-and-rpcs
+- framework-compliance
+- index
+- modules/jobs
+- naming-map
+- progress-ledger
+- research-log
+- todo-gaps
 
 ## Outstanding TODO/Gaps
 | Item | Owner | Priority | Blockers |
@@ -49,3 +41,4 @@
 | Add altitude and location tracking for helicopter flights | backend | low | design |
 | Support editing existing import pack orders | backend | low | design |
 | Persist additional ped attributes such as position and appearance | backend | low | none |
+| Implement paycheck and grade progression logic for jobs | backend | medium | design |

--- a/backend/srp-base/docs/todo-gaps.md
+++ b/backend/srp-base/docs/todo-gaps.md
@@ -16,3 +16,4 @@
 | Add altitude and location tracking for helicopter flights | backend | low | design |
 | Support editing existing import pack orders | backend | low | design |
 | Persist additional ped attributes such as position and appearance | backend | low | none |
+| Implement paycheck and grade progression logic for jobs | backend | medium | design |

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -3583,6 +3583,8 @@ paths:
     post:
       summary: Assign job to character
       operationId: assignJob
+      description: Stores the assignment and broadcasts `jobs.assigned` via WebSocket and webhooks.
+      x-webhook-event: jobs.assigned
       security:
         - ApiToken: []
       requestBody:
@@ -3623,6 +3625,8 @@ paths:
     post:
       summary: Set job duty status
       operationId: setJobDuty
+      description: Updates duty status and broadcasts `jobs.duty` via WebSocket and webhooks.
+      x-webhook-event: jobs.duty
       security:
         - ApiToken: []
       requestBody:

--- a/backend/srp-base/src/repositories/jobsRepository.js
+++ b/backend/srp-base/src/repositories/jobsRepository.js
@@ -125,6 +125,23 @@ async function getCharacterJobs(characterId) {
   );
 }
 
+/**
+ * List all on-duty characters grouped by job name. Returns an array
+ * of objects like `{ job: 'police', characterId: 123 }` for each
+ * active duty assignment. Used by the scheduler to broadcast duty
+ * rosters so clients do not need to poll.
+ *
+ * @returns {Promise<Array<{job: string, characterId: number}>>}
+ */
+async function listOnDutyRoster() {
+  return db.query(
+    `SELECT j.name AS job, cj.character_id AS characterId
+       FROM character_jobs cj
+       JOIN jobs j ON cj.job_id = j.id
+      WHERE cj.on_duty = 1`,
+  );
+}
+
 module.exports = {
   listJobs,
   createJob,
@@ -133,6 +150,7 @@ module.exports = {
   assignJob,
   setDuty,
   getCharacterJobs,
+  listOnDutyRoster,
   /**
    * Count the number of characters currently assigned to a given job.  This
    * helper is used by modules like broadcaster to enforce limits on how

--- a/backend/srp-base/src/routes/jobs.routes.js
+++ b/backend/srp-base/src/routes/jobs.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk } = require('../utils/respond');
 const jobsRepo = require('../repositories/jobsRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 
 // Routes for job management.  These endpoints expose CRUD for
 // job definitions and allow characters to be assigned to jobs and
@@ -51,6 +53,8 @@ router.post('/v1/jobs/assign', async (req, res, next) => {
       parseInt(jobId, 10),
       grade !== undefined ? parseInt(grade, 10) : 0,
     );
+    websocket.broadcast('jobs', 'jobs.assigned', assignment);
+    hooks.dispatch('jobs.assigned', assignment);
     sendOk(res, assignment, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);
@@ -67,6 +71,8 @@ router.post('/v1/jobs/duty', async (req, res, next) => {
       parseInt(jobId, 10),
       Boolean(onDuty),
     );
+    websocket.broadcast('jobs', 'jobs.duty', assignment);
+    hooks.dispatch('jobs.duty', assignment);
     sendOk(res, assignment, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -34,6 +34,7 @@ const hardcapTasks = require('./tasks/hardcap');
 const heliTasks = require('./tasks/heli');
 const pedsTasks = require('./tasks/peds');
 const jailbreakTasks = require('./tasks/jailbreak');
+const jobsTasks = require('./tasks/jobs');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -223,6 +224,13 @@ scheduler.register(
   () => jailbreakTasks.expireStale(),
   jailbreakTasks.INTERVAL_MS,
   { jitter: 5000, persistName: jailbreakTasks.JOB_NAME },
+);
+
+scheduler.register(
+  jobsTasks.JOB_NAME,
+  () => jobsTasks.syncRoster(wss),
+  jobsTasks.INTERVAL_MS,
+  { jitter: 5000, persistName: jobsTasks.JOB_NAME },
 );
 
 // Handle graceful shutdown

--- a/backend/srp-base/src/tasks/jobs.js
+++ b/backend/srp-base/src/tasks/jobs.js
@@ -1,0 +1,13 @@
+const jobsRepo = require('../repositories/jobsRepository');
+const dispatcher = require('../hooks/dispatcher');
+
+const JOB_NAME = 'jobs-roster-sync';
+const INTERVAL_MS = 60000; // 1 minute
+
+async function syncRoster(wss) {
+  const roster = await jobsRepo.listOnDutyRoster();
+  if (wss) wss.broadcast('jobs', 'jobs.roster', { roster });
+  dispatcher.dispatch('jobs.roster', { roster });
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, syncRoster };


### PR DESCRIPTION
## Summary
- push job assignment and duty changes over WebSocket and webhooks
- schedule minute roster sync for on-duty jobs
- document job events and update compliance

## Testing
- `node -e "const fs=require('fs'); const yaml=require('yaml'); yaml.parse(fs.readFileSync('backend/srp-base/openapi/api.yaml','utf8')); console.log('openapi ok')"` *(fails: Cannot find module 'yaml')*
- `node -e "require('./backend/srp-base/src/routes/jobs.routes.js'); console.log('routes ok')"` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68afc3920ab4832dab70a1ea0a072f31