### PR TITLE
srp-base: vehicle control state API with realtime push

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1769,3 +1769,22 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 
 * Drop `recycling_runs` table and remove recycling routes and scheduler.
+
+## 2025-08-29 (vehicle control)
+
+### Added
+
+* Vehicle control state endpoints `/v1/vehicles/{plate}/control` with WebSocket and webhook broadcasts.
+* Scheduler `vehicle-control-prune` removes stale control records.
+
+### Migrations
+
+* `082_add_vehicle_control_states.sql`
+
+### Risks
+
+* Incorrect cleanup interval may leave stale control states.
+
+### Rollback
+
+* Drop `vehicle_control_states` table and remove control routes and task.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -2,6 +2,7 @@
 
 - Track recycling job deliveries with realtime push and cleanup scheduler.
 - Update OpenAPI validator dependency for install success.
+- Persist and broadcast vehicle control state with cleanup scheduler.
 
 | File | Action | Note |
 |---|---|---|
@@ -25,3 +26,21 @@
 | docs/db-schema.md | M | Describe recycling_runs table |
 | docs/migrations.md | M | List migration 081 |
 | openapi/api.yaml | M | Define recycling schemas and paths |
+| src/routes/vehicles.routes.js | M | Add control state endpoints |
+| src/repositories/vehicleControlRepository.js | A | Persist vehicle control state |
+| src/tasks/vehicleControl.js | A | Purge stale control records |
+| src/config/env.js | M | Add vehicle control retention config |
+| src/server.js | M | Register vehicle control cleanup task |
+| src/migrations/082_add_vehicle_control_states.sql | A | Vehicle control states table |
+| docs/modules/vehicles.md | M | Document control endpoints |
+| docs/BASE_API_DOCUMENTATION.md | M | Add control API mapping |
+| docs/db-schema.md | M | Describe vehicle_control_states table |
+| docs/migrations.md | M | List migration 082 |
+| docs/events-and-rpcs.md | M | Map lux_vehcontrol events |
+| docs/naming-map.md | M | Map lux_vehcontrol to vehicle-control |
+| docs/progress-ledger.md | M | Record vehicle control entry |
+| docs/index.md | M | Note vehicle control update |
+| docs/framework-compliance.md | M | Add vehicle control module note |
+| docs/research-log.md | M | Log lux_vehcontrol research |
+| docs/run-docs.md | M | Summarize vehicle control run |
+| openapi/api.yaml | M | Define vehicle control schemas and paths |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -257,6 +257,8 @@ In addition to the core identity, permissions, characters and admin APIs describ
 | `POST` | `/v1/vehicles` | Register a new vehicle (body: `{ playerId, model, plate, properties? }`). Returns vehicle ID. |
 | `POST` | `/v1/vehicles/:id/update` | Update an existing vehicle (body: partial). |
 | `GET` | `/v1/vehicles/shop` | Placeholder endpoint to list vehicles available for purchase. Returns an empty array by default. |
+| `GET` | `/v1/vehicles/{plate}/control` | Retrieve siren/powercall/indicator state for a vehicle. |
+| `POST` | `/v1/vehicles/{plate}/control` | Update control state fields; broadcasts `vehicles.control.update`. |
 
 #### World (Global State & Events)
 

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -48,6 +48,18 @@ Added `world_forecast` table for weather scheduling. K9 migration renamed to 057
 | nitrous | INT | Remaining nitrous amount |
 | updated_at | DATETIME | Last update timestamp |
 
+## vehicle_control_states
+
+| Column | Type | Notes |
+|---|---|---|
+| plate | VARCHAR(8) | Primary key; vehicle plate |
+| siren_muted | TINYINT(1) | 1 if default siren muted |
+| lx_siren_state | TINYINT | Luxart siren state |
+| powercall_state | TINYINT | Powercall state |
+| air_manu_state | TINYINT | Airhorn/manual state |
+| indicator_state | TINYINT | Indicator toggle state |
+| updated_at | DATETIME | Last update timestamp |
+
 ## dispatch_alerts
 
 | Column | Type | Notes |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -54,3 +54,4 @@
 | srp-weathersync | Resource broadcasts weather and time updates; proxies api.weather.gov | `GET/POST /v1/weathersync/forecast`, `GET /v1/weathersync/weather.gov`, legacy `/v1/world/forecast` (deprecated) |
 | climate-overrides | Resource applies custom timecycle XMLs; emits `world.timecycle.set`/`world.timecycle.clear` | `/v1/world/timecycle` to set or clear presets; scheduler auto-clears expired |
 | lmfao | Recycling job mission events giving money and materials | `POST /v1/recycling/deliveries`, `GET /v1/recycling/deliveries/{characterId}` |
+| lux_vehcontrol | Siren/powercall/indicator toggle events | `GET/POST /v1/vehicles/{plate}/control` → pushes `vehicles.control.update` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -107,6 +107,7 @@ practice is supported by citations.
 | **peds module** | Ped endpoints follow layered design with WebSocket/webhook events and health regeneration scheduler. |
 | **climate-overrides realtime** | Timecycle override endpoints emit WebSocket/webhook events and a scheduler clears expired overrides. |
 | **recycling module** | Recycling delivery endpoints follow layered design with authentication, idempotency and realtime push plus retention purge. |
+| **vehicle control module** | Vehicle control state endpoints follow layered design with authentication, idempotency, WebSocket/webhook events and hourly cleanup scheduler. |
 
 ## Outstanding Items
 

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -60,3 +60,10 @@ Tracked recycling job deliveries with realtime pushes.
 
 * `POST /v1/recycling/deliveries` logs a delivery and emits `recycling.delivery.created` via WebSocket and webhooks.
 * Scheduler `recycling-purge` removes deliveries older than `RECYCLING_RETENTION_MS`.
+
+## Update – 2025-08-29 (vehicle control)
+
+Persist and broadcast vehicle siren/indicator state.
+
+* `GET/POST /v1/vehicles/{plate}/control` manage siren and indicator state.
+* Scheduler `vehicle-control-prune` removes stale control records.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -79,3 +79,4 @@
 | 079_add_jailbreak_started_index.sql | Index jailbreak_attempts started_at column |
 | 080_add_debug.sql | Debug logs and markers tables |
 | 081_add_recycling_runs.sql | Table for recycling job delivery records |
+| 082_add_vehicle_control_states.sql | Vehicle siren/indicator state table |

--- a/backend/srp-base/docs/modules/vehicles.md
+++ b/backend/srp-base/docs/modules/vehicles.md
@@ -22,6 +22,8 @@ consistent source of truth.
 | `GET` | `/v1/vehicles/harness/{plate}` | Retrieve the harness durability for a vehicle.  Returns `null` if no harness value is stored. |
 | `PATCH` | `/v1/vehicles/harness/{plate}` | Update the harness durability for a vehicle.  Returns the number of rows updated. |
 | `POST` | `/v1/vehicles/plate-change` | Change a vehicle’s license plate.  Expects `{ oldPlate, newPlate }` in the body and returns the number of rows updated. |
+| `GET` | `/v1/vehicles/{plate}/control` | Retrieve siren, powercall, airhorn and indicator state for a vehicle. |
+| `POST` | `/v1/vehicles/{plate}/control` | Update control state fields. Broadcasts `vehicles.control.update` over WebSocket and webhooks. |
 
 All endpoints require authentication via `X-API-Token` and optional HMAC
 headers.  Mutating operations (`POST`, `PATCH`) also support
@@ -47,6 +49,7 @@ for this module.  Important methods include:
   update engine/body/fuel fields.  Ignores undefined fields.
 * `updateVehicleDegradationByPlate(plate, degradation)` – update the
   degradation array (stored as comma‑separated string).
+* `vehicleControlRepository.js` – upserts and retrieves siren/powercall/indicator state in `vehicle_control_states`.
 
 ### Database Schema
 
@@ -59,6 +62,7 @@ The `vehicles` table is created in `migration 003` with columns for
   columns.  `degradation` is stored as a `VARCHAR(255)` containing
   comma‑separated integers.  Future migrations may normalise this to a
   separate table if needed.
+* **082_add_vehicle_control_states.sql** – creates `vehicle_control_states` table storing siren and indicator state per plate.
 
 ### Feature Flags
 

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -49,3 +49,4 @@ Upstream name → SRP name mapping for this run.
 | koilWeatherSync | weathersync |
 | koillove | climate-overrides |
 | lmfao | recycling |
+| lux_vehcontrol | vehicle-control |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -102,6 +102,7 @@
 | 88 | koilWeatherSync | Proxy api.weather.gov and periodic forecast sync | Extend | Added weathersync routes and scheduler |
 | 89 | climate-overrides realtime | Timecycle override events and expiry scheduler | Extend | Broadcast set/clear events and auto-clear expired overrides |
 | 90 | lmfao → recycling | Recycling deliveries logging with purge scheduler | Create | Added delivery endpoints and cleanup task |
+| 91 | lux_vehcontrol → vehicles control | Siren and indicator state persistence with realtime push | Extend | Added control state API and purge scheduler |
 
 ## 2025-08-28 — koilWeatherSync
 

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -423,3 +423,8 @@
 
 - Reviewed `resources/lmfao` in NoPixelServer; identified recycling mission events awarding money and materials.
 - Consulted `qbcore-framework/qb-recyclejob` and `ESX-Official/esx_jobs` for recycling job naming patterns.
+
+## Research Log – 2025-08-29 (lux_vehcontrol)
+
+- Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/lux_vehcontrol` for siren and indicator toggle events.
+- Compared vehicle siren handling in ESX and QB-Core vehicle scripts for naming parity.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,3 +1,20 @@
+# Run Summary — 2025-08-29 (vehicle control)
+
+- Persist and broadcast vehicle siren/indicator state with cleanup scheduler.
+
+## API Changes
+
+- `GET /v1/vehicles/{plate}/control`
+- `POST /v1/vehicles/{plate}/control`
+
+## Realtime & Webhooks
+
+- WebSocket namespace `vehicles` emits `control.update` and webhook mirror.
+
+## Migrations
+
+- `082_add_vehicle_control_states.sql` — creates `vehicle_control_states` table.
+
 # Run Summary — 2025-08-29 (recycling)
 
 - Added recycling deliveries logging with purge scheduler.

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -1426,6 +1426,42 @@ components:
         dirt:
           type: integer
           nullable: true
+    VehicleControlState:
+      type: object
+      properties:
+        plate:
+          type: string
+        sirenMuted:
+          type: boolean
+          nullable: true
+        lxSirenState:
+          type: integer
+          nullable: true
+        powercallState:
+          type: integer
+          nullable: true
+        airManuState:
+          type: integer
+          nullable: true
+        indicatorState:
+          type: integer
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+    VehicleControlUpdate:
+      type: object
+      properties:
+        sirenMuted:
+          type: boolean
+        lxSirenState:
+          type: integer
+        powercallState:
+          type: integer
+        airManuState:
+          type: integer
+        indicatorState:
+          type: integer
     ChatMessage:
       type: object
       properties:
@@ -5058,6 +5094,64 @@ paths:
       responses:
         '200':
           description: Plate updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      updated:
+                        type: integer
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+  /v1/vehicles/{plate}/control:
+    get:
+      summary: Get vehicle control state
+      parameters:
+        - in: path
+          name: plate
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Control state
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/VehicleControlState'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+    post:
+      summary: Update vehicle control state
+      parameters:
+        - in: path
+          name: plate
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VehicleControlUpdate'
+      responses:
+        '200':
+          description: Update result
           content:
             application/json:
               schema:

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -141,6 +141,10 @@ const config = {
     fetchIntervalMs: parseInt(process.env.WEATHER_GOV_FETCH_INTERVAL_MS || '300000', 10),
   },
 
+  vehicleControl: {
+    retentionMs: parseInt(process.env.VEHICLE_CONTROL_RETENTION_MS || '3600000', 10),
+  },
+
   /**
    * Feature flags for core modules.  Lua consumers still drive
    * behaviour via /v1/config/live, but these flags provide a safe

--- a/backend/srp-base/src/migrations/082_add_vehicle_control_states.sql
+++ b/backend/srp-base/src/migrations/082_add_vehicle_control_states.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS vehicle_control_states (
+  plate VARCHAR(8) NOT NULL PRIMARY KEY,
+  siren_muted TINYINT(1) DEFAULT NULL,
+  lx_siren_state TINYINT DEFAULT NULL,
+  powercall_state TINYINT DEFAULT NULL,
+  air_manu_state TINYINT DEFAULT NULL,
+  indicator_state TINYINT DEFAULT NULL,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_vehicle_control_updated_at (updated_at)
+);

--- a/backend/srp-base/src/repositories/vehicleControlRepository.js
+++ b/backend/srp-base/src/repositories/vehicleControlRepository.js
@@ -1,0 +1,54 @@
+const db = require('./db');
+
+/**
+ * Retrieve vehicle control state by plate.
+ * @param {string} plate
+ * @returns {Promise<object|null>}
+ */
+async function getByPlate(plate) {
+  const rows = await db.query(
+    'SELECT plate, siren_muted AS sirenMuted, lx_siren_state AS lxSirenState, powercall_state AS powercallState, air_manu_state AS airManuState, indicator_state AS indicatorState, updated_at AS updatedAt FROM vehicle_control_states WHERE plate = ?',[plate]);
+  return rows[0] || null;
+}
+
+/**
+ * Upsert vehicle control state for a plate. Undefined fields keep existing values.
+ * @param {string} plate
+ * @param {object} state
+ * @returns {Promise<number>} affected rows
+ */
+async function upsert(plate, state) {
+  const {
+    sirenMuted = null,
+    lxSirenState = null,
+    powercallState = null,
+    airManuState = null,
+    indicatorState = null,
+  } = state;
+  const result = await db.query(
+    `INSERT INTO vehicle_control_states
+      (plate, siren_muted, lx_siren_state, powercall_state, air_manu_state, indicator_state, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, NOW())
+      ON DUPLICATE KEY UPDATE
+        siren_muted = COALESCE(VALUES(siren_muted), siren_muted),
+        lx_siren_state = COALESCE(VALUES(lx_siren_state), lx_siren_state),
+        powercall_state = COALESCE(VALUES(powercall_state), powercall_state),
+        air_manu_state = COALESCE(VALUES(air_manu_state), air_manu_state),
+        indicator_state = COALESCE(VALUES(indicator_state), indicator_state),
+        updated_at = NOW()`,
+    [plate, sirenMuted, lxSirenState, powercallState, airManuState, indicatorState],
+  );
+  return result.affectedRows;
+}
+
+/**
+ * Delete control states last updated before cutoff.
+ * @param {Date} cutoff
+ * @returns {Promise<number>} number removed
+ */
+async function deleteOlderThan(cutoff) {
+  const result = await db.query('DELETE FROM vehicle_control_states WHERE updated_at < ?', [cutoff]);
+  return result.affectedRows;
+}
+
+module.exports = { getByPlate, upsert, deleteOlderThan };

--- a/backend/srp-base/src/routes/vehicles.routes.js
+++ b/backend/srp-base/src/routes/vehicles.routes.js
@@ -1,6 +1,9 @@
 const express = require('express');
-const { sendOk } = require('../utils/respond');
+const { sendOk, sendError } = require('../utils/respond');
 const vehiclesRepo = require('../repositories/vehiclesRepository');
+const vehicleControlRepo = require('../repositories/vehicleControlRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 
 // Routes for vehicle ownership and registration.  These endpoints
 // persist data about player vehicles and expose basic CRUD
@@ -133,6 +136,63 @@ router.patch('/v1/vehicles/:plate/degradation', async (req, res, next) => {
     const { plate } = req.params;
     const { degradation } = req.body || {};
     const updated = await vehiclesRepo.updateVehicleDegradationByPlate(plate, degradation);
+    sendOk(res, { updated }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Vehicle control state
+//
+// Retrieve current control state for a vehicle (siren, indicator, etc.).
+router.get('/v1/vehicles/:plate/control', async (req, res, next) => {
+  try {
+    const { plate } = req.params;
+    const state = await vehicleControlRepo.getByPlate(plate);
+    sendOk(res, state, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Update control state for a vehicle. Any provided fields overwrite existing values.
+router.post('/v1/vehicles/:plate/control', async (req, res, next) => {
+  try {
+    const { plate } = req.params;
+    const { sirenMuted, lxSirenState, powercallState, airManuState, indicatorState } = req.body || {};
+    if (
+      sirenMuted === undefined &&
+      lxSirenState === undefined &&
+      powercallState === undefined &&
+      airManuState === undefined &&
+      indicatorState === undefined
+    ) {
+      return sendError(
+        res,
+        { code: 'INVALID_INPUT', message: 'at least one control field must be provided' },
+        400,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    const updated = await vehicleControlRepo.upsert(plate, {
+      sirenMuted,
+      lxSirenState,
+      powercallState,
+      airManuState,
+      indicatorState,
+    });
+    const payload = {
+      plate,
+      sirenMuted: sirenMuted ?? undefined,
+      lxSirenState: lxSirenState ?? undefined,
+      powercallState: powercallState ?? undefined,
+      airManuState: airManuState ?? undefined,
+      indicatorState: indicatorState ?? undefined,
+    };
+    websocket.broadcast('vehicles', 'control.update', payload);
+    hooks.dispatch('vehicles.control.update', payload);
     sendOk(res, { updated }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -40,6 +40,7 @@ const jobsTasks = require('./tasks/jobs');
 const debugTasks = require('./tasks/debug');
 const k9Tasks = require('./tasks/k9');
 const recyclingTasks = require('./tasks/recycling');
+const vehicleControlTasks = require('./tasks/vehicleControl');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -262,6 +263,14 @@ scheduler.register(
   () => recyclingTasks.purgeOld(),
   recyclingTasks.INTERVAL_MS,
   { jitter: 60000, persistName: recyclingTasks.JOB_NAME },
+);
+
+// Vehicle control state cleanup
+scheduler.register(
+  vehicleControlTasks.JOB_NAME,
+  () => vehicleControlTasks.purgeOld(),
+  vehicleControlTasks.INTERVAL_MS,
+  { jitter: 60000 },
 );
 
 // Debug domain maintenance (purge expired markers/logs)

--- a/backend/srp-base/src/tasks/vehicleControl.js
+++ b/backend/srp-base/src/tasks/vehicleControl.js
@@ -1,0 +1,18 @@
+const config = require('../config/env');
+const repo = require('../repositories/vehicleControlRepository');
+const logger = require('../utils/logger');
+
+const JOB_NAME = 'vehicle-control-prune';
+const INTERVAL_MS = 3600000; // hourly
+
+async function purgeOld() {
+  try {
+    const cutoff = new Date(Date.now() - config.vehicleControl.retentionMs);
+    const removed = await repo.deleteOlderThan(cutoff);
+    if (removed) logger.info({ removed }, 'Pruned stale vehicle control states');
+  } catch (err) {
+    logger.error({ err }, 'Failed to prune vehicle control states');
+  }
+}
+
+module.exports = { purgeOld, JOB_NAME, INTERVAL_MS };


### PR DESCRIPTION
## Summary
- track vehicle siren/indicator state via REST
- broadcast updates over WebSocket and webhook
- hourly cleanup of stale control records

## Testing
- `git status --short backend/srp-base | head -n 20`
- `git commit -m "srp-base(lux_vehcontrol): add vehicle control persistence and cleanup"`


------
https://chatgpt.com/codex/tasks/task_e_68afe84523f8832db7280d1ee5f4b509