### PR TITLE
feat(srp-base): mapmanager IPL webhooks

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1788,3 +1788,21 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 
 * Drop `vehicle_control_states` table and remove control routes and task.
+
+## 2025-08-29 (mapmanager)
+
+### Added
+
+* Webhook dispatch for interior proxy (IPL) updates and removals.
+
+### Migrations
+
+* None.
+
+### Risks
+
+* External webhook endpoints may receive additional traffic.
+
+### Rollback
+
+* Remove webhook dispatch calls in `world.routes.js`.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -3,6 +3,7 @@
 - Track recycling job deliveries with realtime push and cleanup scheduler.
 - Update OpenAPI validator dependency for install success.
 - Persist and broadcast vehicle control state with cleanup scheduler.
+- Webhook dispatch for interior proxy updates.
 
 | File | Action | Note |
 |---|---|---|
@@ -84,3 +85,13 @@
 | docs/research-log.md | M | Log lux_vehcontrol research |
 | docs/run-docs.md | M | Summarize vehicle control run |
 | openapi/api.yaml | M | Define vehicle control schemas and paths |
+| src/routes/world.routes.js | M | Dispatch webhooks for IPL set/remove |
+| openapi/api.yaml | M | Document IPL webhook behaviour |
+| docs/modules/world.md | M | Note `world.ipl.*` events |
+| docs/events-and-rpcs.md | M | Map bob74_ipl to `world.ipl.updated` via webhooks |
+| docs/index.md | M | Logged mapmanager update |
+| docs/naming-map.md | M | Added mapmanager mapping |
+| docs/progress-ledger.md | M | Recorded mapmanager entry |
+| docs/research-log.md | M | Logged mapmanager research |
+| docs/run-docs.md | M | Added mapmanager run summary |
+| CHANGELOG.md | M | Document IPL webhook addition |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -16,7 +16,7 @@
 | assets_clothes | Resource saves and retrieves character outfits | `GET /v1/clothes`, `POST /v1/clothes`, `DELETE /v1/clothes/{id}` |
 | properties | Resource manages apartments, garages and rentals with ownership and lease events | `GET/POST/PATCH/DELETE /v1/properties`; broadcasts `properties.propertyCreated`/`properties.propertyUpdated`/`properties.propertyDeleted` |
 | banking | Resource processes deposits, withdrawals, transfers and invoices | `POST /v1/characters/{characterId}/account:deposit`, `POST /v1/characters/{characterId}/account:withdraw`, `POST /v1/transactions`, `POST /v1/invoices` |
-| bob74_ipl | Resource toggles interior proxies (IPLs) for world interiors | `GET/POST/DELETE /v1/world/ipls` → pushes `world.ipl.updated`; scheduler broadcasts `world.ipl.sync` |
+| bob74_ipl | Resource toggles interior proxies (IPLs) for world interiors | `GET/POST/DELETE /v1/world/ipls` → pushes `world.ipl.updated` via WebSocket/webhooks; scheduler broadcasts `world.ipl.sync` |
 | maps | No server events; world mapping assets | N/A |
 | furnished-shells | No server events; interior shell assets | N/A |
 | Cron | Resource triggers scheduled events for maintenance and gameplay loops | `GET /v1/cron/jobs`, `POST /v1/cron/jobs`; scheduler broadcasts `cron.execute` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -101,7 +101,7 @@ practice is supported by citations.
 | **world module** | World state, forecast and timecycle endpoints follow the established layered pattern with authentication and idempotency. |
 | **dispatch module** | Dispatch alert endpoints follow the established layered pattern with authentication and idempotency. |
 | **properties module** | Property endpoints consolidate apartments, garages and rentals with layered design, rate limiting, idempotency, WebSocket/webhook events and lease expiry scheduler. |
-| **world IPL module** | Interior proxy endpoints follow layered design with WebSocket sync and scheduler broadcast. |
+| **world IPL module** | Interior proxy endpoints follow layered design with WebSocket/webhook sync and scheduler broadcast. |
 | **taxi module** | Taxi request endpoints follow layered design with WebSocket/webhook events and expiry scheduler. |
 | **police module** | Duty roster endpoints follow layered design with authentication, idempotency, WebSocket/webhook pushes and stale-duty scheduler. |
 | **peds module** | Ped endpoints follow layered design with WebSocket/webhook events and health regeneration scheduler. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -70,3 +70,9 @@ Persist and broadcast vehicle siren/indicator state.
 * `GET/POST /v1/vehicles/{plate}/control` manage siren and indicator state.
 * Scheduler `vehicle-control-prune` removes stale control records.
 * Scheduler `recycling-purge` removes deliveries older than `RECYCLING_RETENTION_MS`.
+
+## Update – 2025-08-29 (mapmanager)
+
+Webhooks added for interior proxy updates.
+
+* `POST /v1/world/ipls` and `DELETE /v1/world/ipls/{name}` now emit `world.ipl.updated` and `world.ipl.removed` via WebSocket and webhooks.

--- a/backend/srp-base/docs/modules/world.md
+++ b/backend/srp-base/docs/modules/world.md
@@ -17,7 +17,7 @@ Provides APIs to read and update global world state, manage weather forecasts an
 
 ## Realtime & Scheduler
 
-- WebSocket `world.timecycle.set` and `world.timecycle.clear` plus matching webhooks.
+- WebSocket `world.timecycle.set`, `world.timecycle.clear`, `world.ipl.updated` and `world.ipl.removed` with matching webhooks.
 - Scheduler `timecycle-expiry` clears overrides past `expiresAt`.
 
 ## Repository Contracts

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -50,3 +50,4 @@ Upstream name → SRP name mapping for this run.
 | koillove | climate-overrides |
 | lmfao | recycling |
 | lux_vehcontrol | vehicle-control |
+| mapmanager | world.ipls |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -109,6 +109,7 @@
 | 89 | climate-overrides realtime | Timecycle override events and expiry scheduler | Extend | Broadcast set/clear events and auto-clear expired overrides |
 | 90 | lmfao → recycling | Recycling deliveries logging with purge scheduler | Create | Added delivery endpoints and cleanup task |
 | 91 | lux_vehcontrol → vehicles control | Siren and indicator state persistence with realtime push | Extend | Added control state API and purge scheduler |
+| 92 | mapmanager | Map/gametype discovery and interior proxy updates | Extend | Added webhook dispatch for IPL state changes |
 
 ## 2025-08-28 — koilWeatherSync
 

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -424,6 +424,11 @@
 - Reviewed `resources/lmfao` in NoPixelServer; identified recycling mission events awarding money and materials.
 - Consulted `qbcore-framework/qb-recyclejob` and `ESX-Official/esx_jobs` for recycling job naming patterns.
 
+## Research Log – 2025-08-29 (mapmanager)
+
+- Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/mapmanager` for map and gametype flows.
+- Compared map toggling approaches with ESX and QB-Core zone management to align event naming.
+
 ## Research Log – 2025-08-29 (lux_vehcontrol)
 
 - Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/lux_vehcontrol` for siren and indicator toggle events.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,3 +1,19 @@
+# Run Summary — 2025-08-29 (mapmanager)
+
+- Added webhook dispatch for interior proxy (IPL) updates and removals.
+
+## API Changes
+
+- None.
+
+## Realtime & Webhooks
+
+- `world.ipl.updated` and `world.ipl.removed` broadcast via WebSocket and webhooks.
+
+## Migrations
+
+- None.
+
 # Run Summary — 2025-08-29 (vehicle control)
 
 - Persist and broadcast vehicle siren/indicator state with cleanup scheduler.

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -8213,6 +8213,7 @@ paths:
   /v1/world/ipls:
     get:
       summary: List interior proxy states
+      description: Retrieve stored interior proxy states for dynamic map loading.
       responses:
         '200':
           description: List of IPL states
@@ -8238,6 +8239,9 @@ paths:
           $ref: '#/components/responses/BadRequest'
     post:
       summary: Upsert an interior proxy state
+      description: |
+        Enables or disables an interior proxy (IPL) and broadcasts
+        `world.ipl.updated` via WebSocket and webhooks.
       requestBody:
         required: true
         content:
@@ -8268,6 +8272,9 @@ paths:
   /v1/world/ipls/{name}:
     delete:
       summary: Remove an interior proxy state
+      description: |
+        Deletes an interior proxy (IPL) state and broadcasts
+        `world.ipl.removed` via WebSocket and webhooks.
       parameters:
         - name: name
           in: path

--- a/backend/srp-base/src/routes/world.routes.js
+++ b/backend/srp-base/src/routes/world.routes.js
@@ -114,6 +114,7 @@ router.post('/v1/world/ipls', async (req, res, next) => {
     const { name, enabled } = req.body || {};
     await iplRepo.set(name, !!enabled);
     websocket.broadcast('world', 'ipl.updated', { name, enabled: !!enabled });
+    hooks.dispatch('world.ipl.updated', { name, enabled: !!enabled });
     sendOk(res, { message: 'IPL state updated' }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);
@@ -126,6 +127,7 @@ router.delete('/v1/world/ipls/:name', async (req, res, next) => {
     const { name } = req.params;
     await iplRepo.remove(name);
     websocket.broadcast('world', 'ipl.removed', { name });
+    hooks.dispatch('world.ipl.removed', { name });
     sendOk(res, { message: 'IPL state removed' }, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);


### PR DESCRIPTION
## Summary
- dispatch webhooks when interior proxies (IPLs) toggle
- document mapmanager naming and world module realtime events

## Testing
- `npm install`
- `API_TOKEN=dummy node -e "require('./src/routes/world.routes'); console.log('routes ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68afec9cff44832d85e3a6d08cc02929