### PR TITLE
srp-base(medicgarage): add EMS vehicle spawn logging

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1806,3 +1806,18 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 
 * Remove webhook dispatch calls in `world.routes.js`.
+
+## 2025-02-14 (medicgarage)
+
+### Added
+* EMS vehicle spawn logging via `POST /v1/ems/vehicles` with job validation and realtime push.
+* Scheduler `ems-vehicle-spawn-purge` removes old spawn records.
+
+### Migrations
+* `083_add_ems_vehicle_spawns.sql` – create table for EMS vehicle spawn logs.
+
+### Risks
+* Excessive spawn requests could flood logs; rate limiter enforced.
+
+### Rollback
+* Drop `ems_vehicle_spawns` table and remove EMS vehicle routes and tasks.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -1,5 +1,6 @@
 # Manifest
 
+- EMS vehicle spawn logging with realtime push and purge scheduler.
 - Track recycling job deliveries with realtime push and cleanup scheduler.
 - Update OpenAPI validator dependency for install success.
 - Persist and broadcast vehicle control state with cleanup scheduler.
@@ -95,3 +96,23 @@
 | docs/research-log.md | M | Logged mapmanager research |
 | docs/run-docs.md | M | Added mapmanager run summary |
 | CHANGELOG.md | M | Document IPL webhook addition |
+| src/repositories/emsVehiclesRepository.js | A | Log EMS vehicle spawns |
+| src/tasks/emsVehicles.js | A | Purge old EMS vehicle spawns |
+| src/config/env.js | M | Add emsVehicles retention config |
+| src/migrations/083_add_ems_vehicle_spawns.sql | A | Table for EMS vehicle spawn logs |
+| src/routes/ems.routes.js | M | Add vehicle spawn route |
+| src/server.js | M | Register EMS vehicle purge task |
+| openapi/api.yaml | M | Document EMS vehicle spawn endpoint |
+| docs/modules/ems.md | M | Document spawn route and event |
+| docs/index.md | M | Log EMS vehicles update |
+| docs/progress-ledger.md | M | Add medicgarage entry |
+| docs/framework-compliance.md | M | Note EMS vehicle spawn compliance |
+| docs/BASE_API_DOCUMENTATION.md | M | Describe EMS vehicle spawn API |
+| docs/events-and-rpcs.md | M | Map medicgarage events |
+| docs/db-schema.md | M | Document ems_vehicle_spawns table |
+| docs/migrations.md | M | List migration 083 |
+| docs/admin-ops.md | M | Add ems_vehicle_spawns operational notes |
+| docs/testing.md | M | Add EMS vehicle spawn test |
+| docs/naming-map.md | M | Map medicgarage → ems-vehicles |
+| docs/research-log.md | M | Log medicgarage research |
+| docs/run-docs.md | M | Summarize medicgarage run |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -412,6 +412,7 @@ To support all features present in the original server resources at the framewor
   - `GET /v1/ems/shifts/active` – List active EMS shifts.
   - `POST /v1/ems/shifts` – Start a shift (`characterId`).
   - `POST /v1/ems/shifts/{id}/end` – End a shift.
+  - `POST /v1/ems/vehicles` – Spawn an EMS vehicle (requires EMS job).
 
 - **srp-keys** – Assign and manage keys for players.  Keys may represent vehicle keys, property keys or any other access tokens.  Endpoints are:
   - `POST /v1/keys` – Assign a new key (requires `player_id`, `key_type` and `target_id`; optional `metadata`).

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -65,4 +65,5 @@
 - Carwash dirt updates are dispatched via webhook; register sinks if external systems require notifications.
 - Ensure the `world_timecycle` table exists for timecycle overrides.
 - Ensure the `ipl_states` table exists for interior proxy toggles.
+- Ensure the `ems_vehicle_spawns` table exists; tune `EMS_VEHICLE_SPAWN_RETENTION_MS` and `EMS_VEHICLE_SPAWN_PURGE_INTERVAL_MS` for spawn log cleanup.
 - Runtime sinks can be managed with `GET/POST/DELETE /v1/hooks/endpoints` (admin only). Rotate secrets by re-registering endpoints and removing old entries.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -665,3 +665,11 @@ Retention of sound play logs is controlled by `INTERACT_SOUND_RETENTION_MS`; old
 | materials | INT | Amount of material delivered |
 | created_at | TIMESTAMP | Creation time |
 | INDEX idx_recycling_runs_character_created | (character_id, created_at) |
+
+### ems_vehicle_spawns
+Records EMS vehicle spawn requests.
+- `id` INT PK
+- `character_id` INT FK -> characters.id
+- `vehicle_type` VARCHAR(50)
+- `created_at` TIMESTAMP default CURRENT_TIMESTAMP
+- Index `idx_ems_vehicle_spawns_character_id` on `character_id`

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -3,6 +3,7 @@
 | Resource | In-Game Events/RPCs | SRP Base API Mapping |
 |---|---|---|
 | DiamondCasino | Resource emits events for casino games such as blackjack, slots and horse racing | `POST /v1/diamond-casino/games` creates a game; bets via `POST /v1/diamond-casino/games/{gameId}/bets` and history via `GET /v1/diamond-casino/games/{gameId}` |
+| medicgarage | Events `medicg:s_classic*`, `medicg:s_helico`, `medicg:firetruk` spawn EMS vehicles | `POST /v1/ems/vehicles` (vehicleType) → WebSocket `ems.vehicle.spawn` |
 | PolicePack | Resource emits events for evidence custody updates and character selections | Custody via `GET/POST /v1/evidence/items/{id}/custody`; selection via `POST /v1/accounts/{accountId}/characters/{characterId}:select` |
 | InteractSound | Resource triggers audio playback events specifying sound name and volume to target clients | `POST /v1/interact-sound/plays` logs and broadcasts; history via `GET /v1/interact-sound/plays/:characterId` |
 | PolyZone | Resource defines polygonal zones for triggers | `GET /v1/zones`, `POST /v1/zones`, `DELETE /v1/zones/:id` manage zone records; `zone.created` and `zone.deleted` pushed via WebSocket/webhooks |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -78,7 +78,7 @@ practice is supported by citations.
 | **coordinates module** | Coordinate endpoints follow the established layered pattern with authentication, idempotency, WebSocket/webhook events and scheduled cleanup. |
 | **interiors module** | Interior endpoints follow the layered pattern with authentication, idempotency, WebSocket/webhook broadcasts and per-character uniqueness. |
 | **emotes module** | Favorite emote endpoints follow the established layered pattern with authentication, idempotency, realtime pushes and retention purge. |
-| **ems module** | EMS record and shift endpoints follow the established layered pattern with authentication and idempotency. |
+| **ems module** | EMS record, shift, and vehicle spawn endpoints follow the established layered pattern with authentication and idempotency. |
 | **taxi module** | Taxi ride endpoints follow the established layered pattern with authentication and idempotency. |
 | **furniture module** | Furniture endpoints follow the established layered pattern with authentication and idempotency. |
 | **characters module** | Added endpoint to retrieve the active character, maintaining layered design and validation. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -76,3 +76,10 @@ Persist and broadcast vehicle siren/indicator state.
 Webhooks added for interior proxy updates.
 
 * `POST /v1/world/ipls` and `DELETE /v1/world/ipls/{name}` now emit `world.ipl.updated` and `world.ipl.removed` via WebSocket and webhooks.
+
+## Update – 2025-02-14 (ems vehicles)
+
+Logged EMS vehicle spawns with realtime push and retention purge.
+
+* `POST /v1/ems/vehicles` records spawns and emits `ems.vehicle.spawn`.
+* Scheduler `ems-vehicle-spawn-purge` removes old spawn logs.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -80,3 +80,4 @@
 | 080_add_debug.sql | Debug logs and markers tables |
 | 081_add_recycling_runs.sql | Table for recycling job delivery records |
 | 082_add_vehicle_control_states.sql | Vehicle siren/indicator state table |
+| 083_add_ems_vehicle_spawns.sql | EMS vehicle spawn log table |

--- a/backend/srp-base/docs/modules/ems.md
+++ b/backend/srp-base/docs/modules/ems.md
@@ -12,18 +12,20 @@ Logs medical treatment records and tracks EMS duty shifts.
 - `GET /v1/ems/shifts/active` – List active EMS shifts.
 - `POST /v1/ems/shifts` – Start a shift (`characterId`).
 - `POST /v1/ems/shifts/{id}/end` – End a shift.
+- `POST /v1/ems/vehicles` – Spawn an EMS vehicle (requires assignment)
 
 ## Realtime
 - WebSocket topic `ems` broadcasts:
-  - `record.created`, `record.updated`, `record.deleted`
-  - `shift.started`, `shift.ended`
-  - `shifts.active` snapshot of all active shifts
+- `record.created`, `record.updated`, `record.deleted`
+- `shift.started`, `shift.ended`
+- `shifts.active` snapshot of all active shifts
+- `vehicle.spawn` when an EMS vehicle is spawned
 - Webhook dispatcher mirrors these events for external sinks.
 
 ## Scheduler
 - Job `ems-shift-sync` runs every `EMS_BROADCAST_INTERVAL_MS`.
-  - Ends shifts exceeding `EMS_MAX_SHIFT_DURATION_MS`.
-  - Broadcasts `shifts.active` after cleanup.
+- Ends shifts exceeding `EMS_MAX_SHIFT_DURATION_MS`.
+- Broadcasts `shifts.active` after cleanup.
 
 ## Repository Contracts
 - `getRecords()` → Array of records.

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -51,3 +51,4 @@ Upstream name → SRP name mapping for this run.
 | lmfao | recycling |
 | lux_vehcontrol | vehicle-control |
 | mapmanager | world.ipls |
+| medicgarage | ems-vehicles |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -110,6 +110,7 @@
 | 90 | lmfao → recycling | Recycling deliveries logging with purge scheduler | Create | Added delivery endpoints and cleanup task |
 | 91 | lux_vehcontrol → vehicles control | Siren and indicator state persistence with realtime push | Extend | Added control state API and purge scheduler |
 | 92 | mapmanager | Map/gametype discovery and interior proxy updates | Extend | Added webhook dispatch for IPL state changes |
+| 93 | medicgarage | EMS vehicle spawn logging and push | Create | Added spawn API and purge task |
 
 ## 2025-08-28 — koilWeatherSync
 

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -433,3 +433,6 @@
 
 - Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/lux_vehcontrol` for siren and indicator toggle events.
 - Compared vehicle siren handling in ESX and QB-Core vehicle scripts for naming parity.
+## Research Log – 2025-02-14 (medicgarage)
+- Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/medicgarage` for EMS vehicle spawn events.
+- Reviewed job assignment handling in ESX (`es_extended`) and QB-Core (`qb-core`) for EMS role checks.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,3 +1,23 @@
+# Run Summary — 2025-02-14 (medicgarage)
+
+- Added EMS vehicle spawn endpoint with realtime push and purge scheduler.
+
+## API Changes
+
+- `POST /v1/ems/vehicles`
+
+## Realtime & Webhooks
+
+- WebSocket `ems.vehicle.spawn` and webhook mirror.
+
+## Migrations
+
+- `083_add_ems_vehicle_spawns.sql` — logs EMS vehicle spawns.
+
+## Outstanding TODO/Gaps
+
+- None.
+
 # Run Summary — 2025-08-29 (mapmanager)
 
 - Added webhook dispatch for interior proxy (IPL) updates and removals.

--- a/backend/srp-base/docs/testing.md
+++ b/backend/srp-base/docs/testing.md
@@ -452,3 +452,10 @@ curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: jb2' -H 'Content-Type: app
 curl -H 'X-API-Token: <token>' http://localhost:3010/v1/jailbreaks/active
 ```
 
+
+# Manually verify EMS vehicle spawn:
+
+```sh
+curl -H 'X-API-Token: <token>' -H 'X-Idempotency-Key: ems1' -H 'Content-Type: application/json' \
+  -d '{"characterId":1,"vehicleType":"classic"}' http://localhost:3010/v1/ems/vehicles
+```

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -1747,6 +1747,27 @@ components:
       properties:
         characterId:
           type: integer
+
+    EmsVehicleSpawn:
+      type: object
+      properties:
+        id:
+          type: integer
+        characterId:
+          type: integer
+        vehicleType:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+    EmsVehicleSpawnRequest:
+      type: object
+      required: [characterId, vehicleType]
+      properties:
+        characterId:
+          type: integer
+        vehicleType:
+          type: string
   TaxiRequest:
     type: object
     properties:
@@ -8903,3 +8924,32 @@ paths:
                     type: string
                   traceId:
                     type: string
+  /v1/ems/vehicles:
+    post:
+      summary: Spawn EMS vehicle
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EmsVehicleSpawnRequest'
+      responses:
+        '200':
+          description: Spawn logged
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/EmsVehicleSpawn'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '403':
+          description: Character not permitted
+        '400':
+          $ref: '#/components/responses/BadRequest'

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -117,6 +117,11 @@ const config = {
     retentionMs: parseInt(process.env.GARAGE_VEHICLE_RETENTION_MS || '2592000000', 10),
   },
 
+  emsVehicles: {
+    retentionMs: parseInt(process.env.EMS_VEHICLE_SPAWN_RETENTION_MS || '2592000000', 10),
+    purgeIntervalMs: parseInt(process.env.EMS_VEHICLE_SPAWN_PURGE_INTERVAL_MS || '3600000', 10),
+  },
+
   police: {
     dutyTimeoutMs: parseInt(process.env.POLICE_DUTY_TIMEOUT_MS || '3600000', 10),
     checkIntervalMs: parseInt(process.env.POLICE_CHECK_INTERVAL_MS || '300000', 10),

--- a/backend/srp-base/src/migrations/083_add_ems_vehicle_spawns.sql
+++ b/backend/srp-base/src/migrations/083_add_ems_vehicle_spawns.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS ems_vehicle_spawns (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  character_id INT NOT NULL,
+  vehicle_type VARCHAR(50) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  KEY idx_ems_vehicle_spawns_character_id (character_id),
+  CONSTRAINT fk_ems_vehicle_spawns_character FOREIGN KEY (character_id) REFERENCES characters(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/srp-base/src/repositories/emsVehiclesRepository.js
+++ b/backend/srp-base/src/repositories/emsVehiclesRepository.js
@@ -1,0 +1,25 @@
+const db = require('./db');
+
+async function logSpawn(characterId, vehicleType) {
+  const [result] = await db.pool.query(
+    'INSERT INTO ems_vehicle_spawns (character_id, vehicle_type) VALUES (?, ?)',
+    [characterId, vehicleType],
+  );
+  const rows = await db.query(
+    'SELECT id, character_id AS characterId, vehicle_type AS vehicleType, created_at AS createdAt FROM ems_vehicle_spawns WHERE id = ?',
+    [result.insertId],
+  );
+  return rows[0];
+}
+
+async function deleteSpawnsBefore(cutoffMs) {
+  await db.query(
+    'DELETE FROM ems_vehicle_spawns WHERE created_at < FROM_UNIXTIME(?)',
+    [Math.floor(cutoffMs / 1000)],
+  );
+}
+
+module.exports = {
+  logSpawn,
+  deleteSpawnsBefore,
+};

--- a/backend/srp-base/src/routes/ems.routes.js
+++ b/backend/srp-base/src/routes/ems.routes.js
@@ -152,4 +152,23 @@ router.post('/v1/ems/shifts/:id/end', async (req, res) => {
   }
 });
 
+const spawnLimiter = createRateLimiter({ windowMs: 60000, max: 5, errorCode: 'RATE_LIMIT', message: 'Too many spawns' });
+router.post('/v1/ems/vehicles', spawnLimiter, express.json(), async (req, res) => {
+  const { characterId, vehicleType } = req.body || {};
+  if (!characterId || !vehicleType) {
+    return sendError(res, { code: 'INVALID_INPUT', message: 'characterId and vehicleType are required' }, 400, res.locals.requestId, res.locals.traceId);
+  }
+  try {
+    const assignments = await jobsRepo.getCharacterJobs(characterId);
+    if (!assignments.some((j) => j.name === 'ems')) {
+      return sendError(res, { code: 'FORBIDDEN', message: 'Character not assigned to EMS' }, 403, res.locals.requestId, res.locals.traceId);
+    }
+    const record = await emsVehiclesRepo.logSpawn(characterId, vehicleType);
+    if (websocket) websocket.broadcast('ems', 'vehicle.spawn', record);
+    dispatcher.dispatch('ems.vehicle.spawn', record);
+    sendOk(res, record, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'INTERNAL_ERROR', message: 'Failed to spawn vehicle' }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
 module.exports = router;

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -40,6 +40,7 @@ const jobsTasks = require('./tasks/jobs');
 const debugTasks = require('./tasks/debug');
 const k9Tasks = require('./tasks/k9');
 const recyclingTasks = require('./tasks/recycling');
+const emsVehicleTasks = require('./tasks/emsVehicles');
 const vehicleControlTasks = require('./tasks/vehicleControl');
 
 // Register Prometheus metrics if enabled.  This must be done before
@@ -263,6 +264,13 @@ scheduler.register(
   () => recyclingTasks.purgeOld(),
   recyclingTasks.INTERVAL_MS,
   { jitter: 60000, persistName: recyclingTasks.JOB_NAME },
+);
+
+scheduler.register(
+  emsVehicleTasks.JOB_NAME,
+  () => emsVehicleTasks.purgeOld(),
+  emsVehicleTasks.INTERVAL_MS,
+  { jitter: 60000, persistName: emsVehicleTasks.JOB_NAME },
 );
 
 // Vehicle control state cleanup

--- a/backend/srp-base/src/tasks/emsVehicles.js
+++ b/backend/srp-base/src/tasks/emsVehicles.js
@@ -1,0 +1,13 @@
+const repo = require('../repositories/emsVehiclesRepository');
+const config = require('../config/env');
+
+const JOB_NAME = 'ems-vehicle-spawn-purge';
+const INTERVAL_MS = config.emsVehicles.purgeIntervalMs || 3600000;
+
+async function purgeOld() {
+  const retention = config.emsVehicles.retentionMs || 2592000000;
+  const cutoff = Date.now() - retention;
+  await repo.deleteSpawnsBefore(cutoff);
+}
+
+module.exports = { JOB_NAME, INTERVAL_MS, purgeOld };


### PR DESCRIPTION
## Summary
- log EMS vehicle spawns with job validation
- broadcast `ems.vehicle.spawn` over websocket and webhooks
- purge old EMS spawn logs via scheduler

## Testing
- `node -e "require('./src/routes/ems.routes.js'); console.log('ems routes ok')"` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68aff7e1b224832d8d8e020a8a690742