### PR TITLE
srp-base: noclip admin toggle

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1851,3 +1851,17 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Drop `minimap_blips` table and remove minimap routes and scheduler registration.
+
+## 2025-08-29 (noclip)
+
+### Added
+* Admin noclip toggle via `POST /v1/admin/noclip` with WebSocket `admin.noclip` broadcast.
+
+### Migrations
+* `086_add_noclip_events.sql` – audit table for noclip actions.
+
+### Risks
+* Misuse if permission scopes misconfigured.
+
+### Rollback
+* Delete `noclip_events` table and remove noclip route and broadcasts.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -6,6 +6,7 @@
 - Persist and broadcast vehicle control state with cleanup scheduler.
 - Webhook dispatch for interior proxy updates.
 - Dynamic minimap blip service with scheduler and WS broadcasts.
+- Admin noclip toggle with audit log and realtime broadcast.
 
 | File | Action | Note |
 |---|---|---|
@@ -138,3 +139,20 @@
 | docs/naming-map.md | M | Map minimap → minimap |
 | docs/research-log.md | M | Log minimap research |
 | docs/run-docs.md | M | Summarize minimap run |
+| src/repositories/adminRepository.js | M | Add noclip logging helper |
+| src/routes/admin.routes.js | M | Add `/v1/admin/noclip` endpoint |
+| src/migrations/086_add_noclip_events.sql | A | Noclip audit table |
+| openapi/api.yaml | M | Document noclip endpoint |
+| docs/modules/admin.md | M | Document ban and noclip APIs |
+| docs/index.md | M | Log noclip update |
+| docs/progress-ledger.md | M | Record noclip entry |
+| docs/naming-map.md | M | Map noclip events |
+| docs/events-and-rpcs.md | M | Map noclip resource |
+| docs/db-schema.md | M | Describe `noclip_events` table |
+| docs/migrations.md | M | List migration 086 |
+| docs/admin-ops.md | M | Add noclip operational note |
+| docs/security.md | M | Note scope check for noclip |
+| docs/framework-compliance.md | M | Add admin module compliance |
+| docs/BASE_API_DOCUMENTATION.md | M | Document noclip API |
+| docs/research-log.md | M | Log noclip research |
+| docs/run-docs.md | M | Summarize noclip run |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -340,6 +340,7 @@ These endpoints round out the foundation of `srp-base`.  Together with the previ
 | Method | Path | Description |
 |-------|-----|-------------|
 | `POST` | `/v1/admin/ban` | Ban a player.  Body `{ playerId, reason, until? }`.  Persists to the bans table and returns ban status. |
+| `POST` | `/v1/admin/noclip` | Enable or disable noclip for a player. Body `{ playerId, actorId, enabled }`. Emits `admin.noclip` WS event. |
 | `POST` | `/v1/admin/kick` | Kick a player (future extension). |
 | `GET` | `/v1/admin/audit` | Fetch audit logs (future extension). |
 

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -69,3 +69,4 @@
 - Ensure the `ems_vehicle_spawns` table exists; tune `EMS_VEHICLE_SPAWN_RETENTION_MS` and `EMS_VEHICLE_SPAWN_PURGE_INTERVAL_MS` for spawn log cleanup.
 - Ensure the `minimap_blips` table exists; scheduler `minimap-blips-broadcast` pushes updates every 30s.
 - Runtime sinks can be managed with `GET/POST/DELETE /v1/hooks/endpoints` (admin only). Rotate secrets by re-registering endpoints and removing old entries.
+- Ensure the `noclip_events` table exists for auditing admin/dev noclip usage.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -688,3 +688,15 @@ Records EMS vehicle spawn requests.
 | created_at | DATETIME | Creation time |
 | updated_at | DATETIME | Update time |
 | INDEX idx_minimap_blips_created | (created_at) |
+
+## noclip_events
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INT AUTO_INCREMENT | Primary key |
+| player_id | VARCHAR(64) | Target player identifier |
+| actor_id | VARCHAR(64) | Admin/developer who toggled |
+| enabled | TINYINT(1) | 1 when enabled |
+| created_at | TIMESTAMP | Creation time |
+| INDEX idx_noclip_player | (player_id) |
+| INDEX idx_noclip_created | (created_at) |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -57,3 +57,4 @@
 | lmfao | Recycling job mission events giving money and materials | `POST /v1/recycling/deliveries`, `GET /v1/recycling/deliveries/{characterId}` |
 | lux_vehcontrol | Siren/powercall/indicator toggle events | `GET/POST /v1/vehicles/{plate}/control` → pushes `vehicles.control.update` |
 | minimap | Minimap zoom/blip configuration | `GET/POST/DELETE /v1/minimap/blips` → WS `minimap.blips` |
+| noclip | Admin/dev noclip toggles | `POST /v1/admin/noclip` | `admin.noclip` (player namespace) |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -110,6 +110,7 @@ practice is supported by citations.
 | **vehicle control module** | Vehicle control state endpoints follow layered design with authentication, idempotency, WebSocket/webhook events and hourly cleanup scheduler. |
 | **hacking module** | Hacking attempt endpoints follow layered design with authentication, idempotency, WebSocket/webhook events and retention purge scheduler. |
 | **minimap module** | Minimap blip endpoints follow layered design with authentication, idempotency and WebSocket broadcasts. |
+| **admin module** | Ban and noclip endpoints follow layered design with authentication and realtime push. |
 
 ## Outstanding Items
 

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -97,3 +97,9 @@ Dynamic minimap blip service.
 
 * `GET /v1/minimap/blips`, `POST /v1/minimap/blips`, and `DELETE /v1/minimap/blips/{id}` manage blips.
 * Scheduler `minimap-blips-broadcast` pushes `world.minimap.blips` events over WebSocket.
+
+## Update – 2025-08-29 (noclip)
+
+Admin noclip control with permission enforcement and realtime signal.
+
+* `POST /v1/admin/noclip` emits `admin.noclip` to the targeted player's namespace.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -83,3 +83,4 @@
 | 083_add_ems_vehicle_spawns.sql | EMS vehicle spawn log table |
 | 084_add_hacking_attempts.sql | Table for hacking attempt logs |
 | 085_add_minimap_blips.sql | Minimap blips table |
+| 086_add_noclip_events.sql | Table for noclip enable/disable logs |

--- a/backend/srp-base/docs/modules/admin.md
+++ b/backend/srp-base/docs/modules/admin.md
@@ -35,22 +35,44 @@ Successful responses use the standard envelope and return the ban details:
 }
 ```
 
+
+### `POST /v1/admin/noclip`
+
+Enables or disables noclip for a player. Body must include `playerId`, `actorId`, and `enabled` boolean. Only players with the `admin` or `dev` scope may receive noclip.
+
+Example request body:
+
+```json
+{
+  "playerId": "steam:110000100000001",
+  "actorId": "steam:110000100000002",
+  "enabled": true
+}
+```
+
+On success the service records the action and emits a WebSocket event:
+
+```json
+{
+  "ok": true,
+  "data": { "playerId": "steam:110000100000001", "enabled": true },
+  "requestId": "uuid",
+  "traceId": "trace"
+}
+```
+
 ## Repository
 
-`adminRepository.js` provides the `banPlayer` function which inserts a row into the `bans` table using parameterised queries:
+`adminRepository.js` exposes helper functions:
 
-- **banPlayer(playerId, reason, until)** – Persists a ban for the specified player. `until` may be `null` for permanent bans.
+- **banPlayer(playerId, reason, until)** – Insert a ban record; `until` may be `null`.
+- **setNoclip(playerId, actorId, enabled)** – Log a noclip toggle event.
 
 ## Database Migration
 
-`020_add_bans.sql` creates the `bans` table with columns:
+`020_add_bans.sql` creates the `bans` table.
 
-- **player_id** (`VARCHAR(64)`) – Identifier for the banned player.
-- **reason** (`VARCHAR(255)`) – Reason for the ban.
-- **until** (`DATETIME`, nullable) – When present, the ban expires at this time.
-- **created_at** (`TIMESTAMP`) – Creation timestamp.
-
-An index on `player_id` accelerates lookups.
+`086_add_noclip_events.sql` creates the `noclip_events` table with indexes on `player_id` and `created_at`.
 
 ## Notes
 

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -55,3 +55,6 @@ Upstream name → SRP name mapping for this run.
 | medicgarage | ems-vehicles |
 
 | minimap | minimap |
+| noclip | admin noclip |
+| np-admin:noclipsway | admin.noclip.enable |
+| np-admin:nofc | admin.noclip.disable |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -113,6 +113,7 @@
 | 93 | mhacking → hacking | Hacking attempt logging with realtime push and purge scheduler | Create | Added attempt API and cleanup task |
 | 93 | medicgarage | EMS vehicle spawn logging and push | Create | Added spawn API and purge task |
 | 94 | minimap | Dynamic minimap blip service | Create | Added blip APIs and broadcast task |
+| 95 | noclip | Admin noclip toggle with realtime push | Create | Added noclip API and audit table |
 
 ## 2025-08-28 — koilWeatherSync
 

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -441,3 +441,7 @@
 
 - Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/minimap` for radar zoom behavior.
 - Reviewed map blip systems conceptually in ESX, ND Core, FSN Framework, QB-Core, vRP and vORP for naming and push patterns.
+
+## Research Log – 2025-08-29 (noclip)
+
+- Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/noclip` to map events `np-admin:noclipsway` and `np-admin:nofc` to SRP `admin.noclip`.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,3 +1,23 @@
+# Run Summary — 2025-08-29 (noclip)
+
+- Added admin noclip endpoint with permission checks and realtime signal.
+
+## API Changes
+
+- `POST /v1/admin/noclip`
+
+## Realtime & Webhooks
+
+- WebSocket `admin.noclip` broadcast to player namespace.
+
+## Migrations
+
+- `086_add_noclip_events.sql` — records noclip toggle actions.
+
+## Outstanding TODO/Gaps
+
+- None.
+
 # Run Summary — 2025-02-14 (medicgarage)
 
 - Added EMS vehicle spawn endpoint with realtime push and purge scheduler.

--- a/backend/srp-base/docs/security.md
+++ b/backend/srp-base/docs/security.md
@@ -46,3 +46,4 @@
 - Debug routes inherit the same authentication and rate limiting requirements.
 - World routes (state, forecast and timecycle) inherit the same authentication and idempotency requirements.
 - Minimap routes inherit the same authentication and idempotency requirements.
+- Admin noclip endpoint verifies target player has `admin` or `dev` scope before broadcasting.

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -31,6 +31,22 @@ components:
                     type: string
                   message:
                     type: string
+    Forbidden:
+      description: Action not allowed
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              ok:
+                type: boolean
+              error:
+                type: object
+                properties:
+                  code:
+                    type: string
+                  message:
+                    type: string
   schemas:
     MinimapBlip:
       type: object
@@ -3074,6 +3090,55 @@ paths:
                     type: string
         '400':
           $ref: '#/components/responses/BadRequest'
+
+  /v1/admin/noclip:
+    post:
+      summary: Toggle noclip for a player
+      operationId: toggleNoclip
+      security:
+        - ApiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - playerId
+                - actorId
+                - enabled
+              properties:
+                playerId:
+                  type: string
+                actorId:
+                  type: string
+                enabled:
+                  type: boolean
+      responses:
+        '200':
+          description: Noclip toggled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      playerId:
+                        type: string
+                      enabled:
+                        type: boolean
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/Forbidden'
 
   /v1/heli/flights:
     post:

--- a/backend/srp-base/src/migrations/086_add_noclip_events.sql
+++ b/backend/srp-base/src/migrations/086_add_noclip_events.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS noclip_events (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  player_id VARCHAR(64) NOT NULL,
+  actor_id VARCHAR(64) NOT NULL,
+  enabled TINYINT(1) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_noclip_player (player_id),
+  INDEX idx_noclip_created (created_at)
+);

--- a/backend/srp-base/src/repositories/adminRepository.js
+++ b/backend/srp-base/src/repositories/adminRepository.js
@@ -15,6 +15,21 @@ async function banPlayer(playerId, reason, until) {
   );
 }
 
+/**
+ * Record a noclip toggle event for a player.
+ *
+ * @param {string} playerId - Player receiving noclip.
+ * @param {string} actorId - Admin or developer performing the action.
+ * @param {boolean} enabled - Whether noclip is enabled.
+ */
+async function setNoclip(playerId, actorId, enabled) {
+  await db.query(
+    'INSERT INTO noclip_events (player_id, actor_id, enabled) VALUES (?, ?, ?)',
+    [playerId, actorId, enabled ? 1 : 0],
+  );
+}
+
 module.exports = {
   banPlayer,
+  setNoclip,
 };

--- a/backend/srp-base/src/routes/admin.routes.js
+++ b/backend/srp-base/src/routes/admin.routes.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
-const { banPlayer } = require('../repositories/adminRepository');
+const { banPlayer, setNoclip } = require('../repositories/adminRepository');
+const permissionsRepo = require('../repositories/permissionsRepository');
+const websocket = require('../realtime/websocket');
 
 const router = express.Router();
 
@@ -56,6 +58,71 @@ router.post('/v1/admin/ban', async (req, res) => {
     sendError(
       res,
       { code: 'BAN_FAILED', message: err.message },
+      500,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+});
+
+/**
+ * Toggle noclip for a player. Only players with admin or dev scope may receive noclip.
+ *
+ * Route: POST /v1/admin/noclip
+ * Body: { playerId: string, actorId: string, enabled: boolean }
+ */
+router.post('/v1/admin/noclip', async (req, res) => {
+  const { playerId, actorId, enabled } = req.body || {};
+  if (!playerId || typeof playerId !== 'string') {
+    return sendError(
+      res,
+      { code: 'INVALID_INPUT', message: 'playerId is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  if (!actorId || typeof actorId !== 'string') {
+    return sendError(
+      res,
+      { code: 'INVALID_INPUT', message: 'actorId is required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  if (typeof enabled !== 'boolean') {
+    return sendError(
+      res,
+      { code: 'INVALID_INPUT', message: 'enabled must be boolean' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const scopes = await permissionsRepo.getPlayerScopes(playerId);
+    if (!scopes.includes('admin') && !scopes.includes('dev')) {
+      return sendError(
+        res,
+        { code: 'FORBIDDEN', message: 'Player lacks noclip permission' },
+        403,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    await setNoclip(playerId, actorId, enabled);
+    if (websocket) websocket.broadcast(`player:${playerId}`, 'admin.noclip', { enabled });
+    sendOk(
+      res,
+      { playerId, enabled },
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  } catch (err) {
+    sendError(
+      res,
+      { code: 'NOCLIP_FAILED', message: err.message },
       500,
       res.locals.requestId,
       res.locals.traceId,


### PR DESCRIPTION
## Summary
- add admin noclip toggle endpoint with permission checks
- log noclip actions and broadcast to target player
- document noclip audit table and API

## Testing
- `node -e "require('fs').readFileSync('backend/srp-base/openapi/api.yaml'); console.log('openapi read');"`
- `git push origin codex/srp-base-gap-20250829-0526-AZ` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68b139e5aaec832daa5bb01d056dc908