### PR TITLE
srp-base(np-admin): unban audit and ban status query

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1879,3 +1879,18 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 
 ### Rollback
 * Drop `action_bar_slots` table and remove action bar routes.
+
+## 2025-08-30 (admin unban)
+
+### Added
+* Ban status query `GET /v1/admin/bans/{playerId}`.
+* Unban endpoint `POST /v1/admin/unban` broadcasting `admin.ban.removed`.
+
+### Migrations
+* `088_add_unban_events.sql` – audit table for unban actions.
+
+### Risks
+* Missing ban records could allow unauthorized access if misused.
+
+### Rollback
+* Delete `unban_events` rows and remove new endpoints.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -7,6 +7,7 @@
 - Webhook dispatch for interior proxy updates.
 - Dynamic minimap blip service with scheduler and WS broadcasts.
 - Admin noclip toggle with audit log and realtime broadcast.
+- Admin unban endpoints with ban status query and audit log.
 
 | File | Action | Note |
 |---|---|---|
@@ -156,3 +157,20 @@
 | docs/BASE_API_DOCUMENTATION.md | M | Document noclip API |
 | docs/research-log.md | M | Log noclip research |
 | docs/run-docs.md | M | Summarize noclip run |
+| src/repositories/adminRepository.js | M | Unban and ban status helpers |
+| src/routes/admin.routes.js | M | Unban/ban status endpoints & WS broadcasts |
+| src/migrations/088_add_unban_events.sql | A | Unban audit table |
+| openapi/api.yaml | M | Document unban and ban status endpoints |
+| docs/modules/admin.md | M | Describe unban features |
+| docs/BASE_API_DOCUMENTATION.md | M | Document admin unban API |
+| docs/events-and-rpcs.md | M | Map admin ban events |
+| docs/naming-map.md | M | Map np-admin unban & status |
+| docs/admin-ops.md | M | Add unban audit note |
+| docs/db-schema.md | M | Document bans and unban_events tables |
+| docs/migrations.md | M | Log migration 088 |
+| docs/index.md | M | Add admin unban update |
+| docs/progress-ledger.md | M | Record admin unban entry |
+| docs/research-log.md | M | Log np-admin research |
+| docs/framework-compliance.md | M | Update admin module compliance |
+| docs/run-docs.md | M | Summarize admin unban run |
+| CHANGELOG.md | M | Log admin unban features |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -722,3 +722,12 @@ Scheduler `recycling-purge` removes records older than `RECYCLING_RETENTION_MS`.
 
 WebSocket namespace `world` emits `minimap.blips`.
 Scheduler `minimap-blips-broadcast` pushes periodic updates.
+
+## Update – 2025-08-30 (admin unban)
+
+### Endpoints
+
+- `POST /v1/admin/unban` – requires `X-Idempotency-Key`
+- `GET /v1/admin/bans/{playerId}`
+
+WebSocket namespace `admin` emits `ban.added` and `ban.removed`.

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -71,3 +71,4 @@
 - Ensure the `minimap_blips` table exists; scheduler `minimap-blips-broadcast` pushes updates every 30s.
 - Runtime sinks can be managed with `GET/POST/DELETE /v1/hooks/endpoints` (admin only). Rotate secrets by re-registering endpoints and removing old entries.
 - Ensure the `noclip_events` table exists for auditing admin/dev noclip usage.
+- Ensure the `bans` and `unban_events` tables exist; WebSocket namespace `admin` emits `ban.added` and `ban.removed` for moderation actions.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -2,6 +2,29 @@
 Added `world_forecast` table for weather scheduling. K9 migration renamed to 057_add_k9_units.sql.
 
 
+## bans
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INT AUTO_INCREMENT | Primary key |
+| player_id | VARCHAR(64) | Target player identifier |
+| reason | VARCHAR(255) | Ban reason |
+| until | DATETIME NULL | Expiration timestamp |
+| created_at | TIMESTAMP | Creation time |
+| INDEX idx_bans_player | (player_id) |
+
+## unban_events
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INT AUTO_INCREMENT | Primary key |
+| player_id | VARCHAR(64) | Unbanned player identifier |
+| actor_id | VARCHAR(64) | Admin who unbanned |
+| reason | VARCHAR(255) | Reason provided |
+| created_at | TIMESTAMP | Creation time |
+| INDEX idx_unban_player | (player_id) |
+| INDEX idx_unban_created | (created_at) |
+
 ## diamond_casino_games
 
 | Column | Type | Notes |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -58,4 +58,4 @@
 | lmfao | Recycling job mission events giving money and materials | `POST /v1/recycling/deliveries`, `GET /v1/recycling/deliveries/{characterId}` |
 | lux_vehcontrol | Siren/powercall/indicator toggle events | `GET/POST /v1/vehicles/{plate}/control` → pushes `vehicles.control.update` |
 | minimap | Minimap zoom/blip configuration | `GET/POST/DELETE /v1/minimap/blips` → WS `minimap.blips` |
-| noclip | Admin/dev noclip toggles | `POST /v1/admin/noclip` | `admin.noclip` (player namespace) |
+| admin | Ban management and noclip toggles | `POST /v1/admin/ban`, `POST /v1/admin/unban`, `GET /v1/admin/bans/{playerId}`, `POST /v1/admin/noclip` | WS `admin.ban.added`, `admin.ban.removed`, `admin.noclip` |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -110,7 +110,7 @@ practice is supported by citations.
 | **vehicle control module** | Vehicle control state endpoints follow layered design with authentication, idempotency, WebSocket/webhook events and hourly cleanup scheduler. |
 | **hacking module** | Hacking attempt endpoints follow layered design with authentication, idempotency, WebSocket/webhook events and retention purge scheduler. |
 | **minimap module** | Minimap blip endpoints follow layered design with authentication, idempotency and WebSocket broadcasts. |
-| **admin module** | Ban and noclip endpoints follow layered design with authentication and realtime push. |
+| **admin module** | Ban/unban and noclip endpoints follow layered design with authentication and realtime push. |
 | **action bar module** | Quick slot endpoints use repository pattern and realtime dispatch. |
 
 ## Outstanding Items

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -109,3 +109,10 @@ Admin noclip control with permission enforcement and realtime signal.
 Persisted per-character quick action slots with realtime push.
 
 * `GET /v1/characters/{characterId}/action-bar`, `PUT /v1/characters/{characterId}/action-bar` manage slots and emit `hud.actionBar.updated`.
+
+## Update – 2025-08-30 (admin unban)
+
+Logged unban actions with audit trail and WebSocket push.
+
+* `POST /v1/admin/unban` logs and broadcasts ban removals.
+* `GET /v1/admin/bans/{playerId}` exposes ban status.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -85,3 +85,4 @@
 | 085_add_minimap_blips.sql | Minimap blips table |
 | 086_add_noclip_events.sql | Table for noclip enable/disable logs |
 | 087_add_action_bar_slots.sql | Action bar slots per character |
+| 088_add_unban_events.sql | Table for unban audit logs |

--- a/backend/srp-base/docs/modules/admin.md
+++ b/backend/srp-base/docs/modules/admin.md
@@ -4,7 +4,7 @@
 
 The **admin** module provides basic moderation capabilities for the SunnyRP platform. It exposes an API for banning players with an optional expiration time so that bans persist across server restarts.
 
-## Endpoint
+## Endpoints
 
 ### `POST /v1/admin/ban`
 
@@ -61,18 +61,40 @@ On success the service records the action and emits a WebSocket event:
 }
 ```
 
+### `POST /v1/admin/unban`
+
+Removes all active bans for a player. Body must include `playerId`, `actorId`, and `reason`.
+
+```json
+{
+  "playerId": "steam:110000100000001",
+  "actorId": "steam:110000100000002",
+  "reason": "Appeal approved"
+}
+```
+
+On success a WebSocket event `admin.ban.removed` broadcasts to the `admin` namespace.
+
+### `GET /v1/admin/bans/{playerId}`
+
+Returns ban status for a player including reason and expiry when present.
+
 ## Repository
 
 `adminRepository.js` exposes helper functions:
 
 - **banPlayer(playerId, reason, until)** – Insert a ban record; `until` may be `null`.
 - **setNoclip(playerId, actorId, enabled)** – Log a noclip toggle event.
+- **unbanPlayer(playerId, actorId, reason)** – Delete ban records and log the action.
+- **isPlayerBanned(playerId)** – Fetch ban status and details.
 
 ## Database Migration
 
 `020_add_bans.sql` creates the `bans` table.
 
 `086_add_noclip_events.sql` creates the `noclip_events` table with indexes on `player_id` and `created_at`.
+
+`088_add_unban_events.sql` creates the `unban_events` table with indexes on `player_id` and `created_at`.
 
 ## Notes
 

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -59,3 +59,5 @@ Upstream name → SRP name mapping for this run.
 | np-admin:noclipsway | admin.noclip.enable |
 | np-admin:nofc | admin.noclip.disable |
 | np-actionbar | action-bar |
+| np-admin:UnbanSteamId | admin.unban |
+| np-admin:IsPlayerBanned | admin.ban.status |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -134,3 +134,7 @@
 ## 2025-08-30 — actionbar
 
 - CREATE: Action bar slots API with WebSocket/webhook push for quick actions.
+
+## 2025-08-30 — admin unban
+
+- EXTEND: Admin moderation with ban status check and unban logging.

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -450,3 +450,8 @@
 
 - Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/np-actionbar` for quick slot and holster flows.
 - Reviewed quick slot handling in ESX and QB-Core inventories to align naming.
+
+## Research Log – 2025-08-30 (np-admin)
+
+- Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/np-admin` for ban/unban flows.
+- Reviewed ban management in EssentialMode, ESX, QB-Core, ND Core, FSN, vRP and vORP to align naming and audit practices.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -18,3 +18,24 @@
 ## Outstanding TODO/Gaps
 
 - None.
+
+# Run Summary — 2025-08-30 (np-admin)
+
+- Extended admin module with ban status query and unban logging.
+
+## API Changes
+
+- `POST /v1/admin/unban`
+- `GET /v1/admin/bans/{playerId}`
+
+## Realtime & Webhooks
+
+- WebSocket namespace `admin` emits `ban.added` and `ban.removed`.
+
+## Migrations
+
+- `088_add_unban_events.sql` — audit log for unban actions.
+
+## Outstanding TODO/Gaps
+
+- None.

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -3152,6 +3152,92 @@ paths:
                     type: string
         '400':
           $ref: '#/components/responses/BadRequest'
+
+  /v1/admin/unban:
+    post:
+      summary: Unban a player
+      operationId: unbanPlayer
+      security:
+        - ApiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - playerId
+                - actorId
+                - reason
+              properties:
+                playerId:
+                  type: string
+                actorId:
+                  type: string
+                reason:
+                  type: string
+      responses:
+        '200':
+          description: Player unbanned
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      unbanned:
+                        type: boolean
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+
+  /v1/admin/bans/{playerId}:
+    get:
+      summary: Check ban status for a player
+      operationId: getBanStatus
+      security:
+        - ApiToken: []
+      parameters:
+        - name: playerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Ban status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      banned:
+                        type: boolean
+                      reason:
+                        type: string
+                        nullable: true
+                      until:
+                        type: string
+                        format: date-time
+                        nullable: true
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
 

--- a/backend/srp-base/src/migrations/088_add_unban_events.sql
+++ b/backend/srp-base/src/migrations/088_add_unban_events.sql
@@ -1,0 +1,10 @@
+-- Track unban actions for audit purposes.
+CREATE TABLE IF NOT EXISTS unban_events (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  player_id VARCHAR(64) NOT NULL,
+  actor_id VARCHAR(64) NOT NULL,
+  reason VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_unban_player (player_id),
+  INDEX idx_unban_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/srp-base/src/repositories/adminRepository.js
+++ b/backend/srp-base/src/repositories/adminRepository.js
@@ -29,7 +29,47 @@ async function setNoclip(playerId, actorId, enabled) {
   );
 }
 
+/**
+ * Remove all active bans for a player and log the action.
+ *
+ * @param {string} playerId - Player identifier to unban.
+ * @param {string} actorId - Admin performing the unban.
+ * @param {string} reason - Reason provided for unbanning.
+ * @returns {Promise<void>} Resolves when the ban has been lifted.
+ */
+async function unbanPlayer(playerId, actorId, reason) {
+  const conn = await db.getConnection();
+  try {
+    await conn.beginTransaction();
+    await conn.query('DELETE FROM bans WHERE player_id = ?', [playerId]);
+    await conn.query(
+      'INSERT INTO unban_events (player_id, actor_id, reason) VALUES (?, ?, ?)',
+      [playerId, actorId, reason],
+    );
+    await conn.commit();
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+/**
+ * Check if a player currently has an active ban.
+ *
+ * @param {string} playerId - Player identifier to check.
+ * @returns {Promise<{ banned: boolean, reason: string|null, until: Date|null }>}
+ */
+async function isPlayerBanned(playerId) {
+  const rows = await db.query('SELECT reason, until FROM bans WHERE player_id = ? LIMIT 1', [playerId]);
+  if (!rows[0]) return { banned: false, reason: null, until: null };
+  return { banned: true, reason: rows[0].reason, until: rows[0].until };
+}
+
 module.exports = {
   banPlayer,
   setNoclip,
+  unbanPlayer,
+  isPlayerBanned,
 };

--- a/backend/srp-base/src/routes/admin.routes.js
+++ b/backend/srp-base/src/routes/admin.routes.js
@@ -1,6 +1,11 @@
 const express = require('express');
 const { sendOk, sendError } = require('../utils/respond');
-const { banPlayer, setNoclip } = require('../repositories/adminRepository');
+const {
+  banPlayer,
+  setNoclip,
+  unbanPlayer,
+  isPlayerBanned,
+} = require('../repositories/adminRepository');
 const permissionsRepo = require('../repositories/permissionsRepository');
 const websocket = require('../realtime/websocket');
 
@@ -48,6 +53,7 @@ router.post('/v1/admin/ban', async (req, res) => {
   }
   try {
     await banPlayer(playerId, reason, untilDate);
+    if (websocket) websocket.broadcast('admin', 'ban.added', { playerId, reason, until: untilDate });
     sendOk(
       res,
       { banned: true, reason, until: untilDate },
@@ -123,6 +129,59 @@ router.post('/v1/admin/noclip', async (req, res) => {
     sendError(
       res,
       { code: 'NOCLIP_FAILED', message: err.message },
+      500,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+});
+
+/**
+ * Unban a player and log the action.
+ *
+ * Route: POST /v1/admin/unban
+ * Body: { playerId: string, actorId: string, reason: string }
+ */
+router.post('/v1/admin/unban', async (req, res) => {
+  const { playerId, actorId, reason } = req.body || {};
+  if (!playerId || typeof playerId !== 'string') {
+    return sendError(res, { code: 'INVALID_INPUT', message: 'playerId is required' }, 400, res.locals.requestId, res.locals.traceId);
+  }
+  if (!actorId || typeof actorId !== 'string') {
+    return sendError(res, { code: 'INVALID_INPUT', message: 'actorId is required' }, 400, res.locals.requestId, res.locals.traceId);
+  }
+  if (!reason || typeof reason !== 'string') {
+    return sendError(res, { code: 'INVALID_INPUT', message: 'reason is required' }, 400, res.locals.requestId, res.locals.traceId);
+  }
+  try {
+    await unbanPlayer(playerId, actorId, reason);
+    if (websocket) websocket.broadcast('admin', 'ban.removed', { playerId, reason, actorId });
+    sendOk(res, { unbanned: true }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(
+      res,
+      { code: 'UNBAN_FAILED', message: err.message },
+      500,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+});
+
+/**
+ * Check if a player is currently banned.
+ *
+ * Route: GET /v1/admin/bans/{playerId}
+ */
+router.get('/v1/admin/bans/:playerId', async (req, res) => {
+  const { playerId } = req.params;
+  try {
+    const info = await isPlayerBanned(playerId);
+    sendOk(res, info, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(
+      res,
+      { code: 'BAN_STATUS_FAILED', message: err.message },
       500,
       res.locals.requestId,
       res.locals.traceId,


### PR DESCRIPTION
## Summary
- add unban audit trail with WebSocket `admin.ban.removed`
- expose ban status query and unban endpoint in admin API
- document and migrate `unban_events` table

## Testing
- `npm --prefix backend/srp-base test` (fails: Missing script)
- `npm --prefix backend/srp-base run migrate -- --dry` (fails: API_TOKEN environment variable must be provided)


------
https://chatgpt.com/codex/tasks/task_e_68b23ba231cc832d9cc855c2e7c02ac8