### PR TITLE
feat: broadcast message backend

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1927,3 +1927,22 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 
 * Drop `mechanic_orders` table and remove mechanic routes and scheduler registration.
+
+## 2025-08-30 (broadcast)
+
+### Added
+
+* Broadcast message API (`GET /v1/broadcast/messages`, `POST /v1/broadcast/messages`, `POST /v1/broadcast/attempt`) with WebSocket/webhook push.
+* Scheduler `broadcast-purge` removes expired messages.
+
+### Migrations
+
+* `092_add_broadcast_messages.sql` – table for broadcast messages.
+
+### Risks
+
+* Misconfigured retention may allow unbounded growth or premature deletion of messages.
+
+### Rollback
+
+* Drop `broadcast_messages` table and remove broadcast routes, config and scheduler registration.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -11,8 +11,34 @@
 - Base event filter and composite index for targeted analytics.
 - Mechanic work orders backend with realtime push and scheduler.
 
+- Broadcast messages API with realtime push and purge scheduler.
+
 | File | Action | Note |
 |---|---|---|
+| src/routes/broadcast.routes.js | R | Rename broadcaster to broadcast with message endpoints |
+| src/repositories/broadcastRepository.js | A | Store and list broadcast messages |
+| src/tasks/broadcast.js | A | Purge old broadcast messages |
+| src/server.js | M | Register broadcast purge task |
+| src/app.js | M | Mount broadcast routes |
+| src/config/env.js | M | Add broadcast retention config |
+| src/migrations/092_add_broadcast_messages.sql | A | Broadcast messages table |
+| openapi/api.yaml | M | Document broadcast endpoints |
+| docs/modules/broadcast.md | R | Document broadcast module |
+| docs/index.md | M | Log broadcast update |
+| docs/progress-ledger.md | M | Record np-broadcaster entry |
+| docs/framework-compliance.md | M | Rename broadcast module compliance |
+| docs/BASE_API_DOCUMENTATION.md | M | Add broadcast API mapping |
+| docs/events-and-rpcs.md | M | Map broadcast events |
+| docs/admin-ops.md | M | Broadcast operations note |
+| docs/security.md | M | Update broadcast auth note |
+| docs/testing.md | M | Broadcast endpoint tests |
+| docs/research-log.md | M | Log broadcast research |
+| docs/naming-map.md | M | Map np-broadcaster |
+| docs/db-schema.md | M | Document broadcast_messages table |
+| docs/migrations.md | M | List migration 092 |
+| docs/run-docs.md | M | Summarize broadcast run |
+| MANIFEST.md | M | Update manifest |
+| CHANGELOG.md | M | Log broadcast feature |
 | src/repositories/jobsRepository.js | M | Added on-duty roster query |
 | src/routes/jobs.routes.js | M | Broadcast/dispatch `jobs.assigned` and `jobs.duty` |
 | src/tasks/jobs.js | A | Scheduler broadcasting `jobs.roster` |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -750,3 +750,15 @@ Vehicle upgrade and repair work orders backed by mechanic service.
 - `GET /v1/mechanic/orders/{id}`
 
 WebSocket namespace `mechanic` broadcasts `orders.created` and `orders.completed`. Scheduler `mechanic-process` finalises pending orders.
+
+## Update – 2025-08-30 (broadcast)
+
+Broadcast job assignment and message endpoints.
+
+### Endpoints
+
+- `POST /v1/broadcast/attempt`
+- `GET /v1/broadcast/messages`
+- `POST /v1/broadcast/messages` – requires `X-Idempotency-Key`
+
+WebSocket namespace `broadcast` emits `broadcast.message`. Scheduler `broadcast-purge` removes old messages.

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -73,3 +73,4 @@
 - Ensure the `noclip_events` table exists for auditing admin/dev noclip usage.
 - Ensure the `bans` and `unban_events` tables exist; WebSocket namespace `admin` emits `ban.added` and `ban.removed` for moderation actions.
 - Ensure the `mechanic_orders` table exists for vehicle work orders; scheduler `mechanic-process` completes pending orders.
+- Ensure the `broadcast_messages` table exists; set `BROADCAST_RETENTION_MS` to control message retention. Scheduler `broadcast-purge` prunes old entries.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -765,3 +765,13 @@ Indexes:
 | completed_at | TIMESTAMP NULL | Completion time |
 | INDEX idx_mechanic_orders_plate | (vehicle_plate) |
 | INDEX idx_mechanic_orders_status | (status) |
+
+## broadcast_messages
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INT AUTO_INCREMENT | Primary key |
+| character_id | INT | FK to characters.id |
+| message | VARCHAR(255) | Message text |
+| created_at | TIMESTAMP | Creation time |
+| INDEX idx_broadcast_messages_created_at | (created_at) |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -52,7 +52,7 @@
 | heli | Resource logs helicopter flight start and end events | `POST /v1/heli/flights`, `POST /v1/heli/flights/{id}/end`, `GET /v1/characters/{characterId}/heli/flights` → `heli.flightStarted`, `heli.flightEnded`, `heli.flightExpired` |
 | jailbreak | Resource triggers jailbreak start/completion and auto-expiry events with character and prison info | `POST /v1/jailbreaks`, `POST /v1/jailbreaks/{id}/complete`, `GET /v1/jailbreaks/active` → WS `jailbreaks.attempt`, `jailbreaks.completed`, `jailbreaks.expired`; webhooks mirror `jailbreak.*` |
 | jobsystem | Resource manages job definitions and assignments | `GET /v1/jobs`, `POST /v1/jobs`, `GET /v1/jobs/{id}`, `POST /v1/jobs/assign`, `POST /v1/jobs/duty`, `GET /v1/jobs/{characterId}/assignments`; WS `jobs.assigned`, `jobs.duty`, `jobs.roster` |
-| broadcaster | Event to attempt joining the broadcaster job | `POST /v1/broadcast/attempt` |
+| broadcast | Assign broadcaster job and push messages | `POST /v1/broadcast/attempt`, `POST /v1/broadcast/messages` → WS `broadcast.message` |
 | srp-debug | Developer requests for runtime diagnostics | `GET /v1/debug/status` returns server metrics |
 | srp-weathersync | Resource broadcasts weather and time updates; proxies api.weather.gov | `GET/POST /v1/weathersync/forecast`, `GET /v1/weathersync/weather.gov`, legacy `/v1/world/forecast` (deprecated) |
 | climate-overrides | Resource applies custom timecycle XMLs; emits `world.timecycle.set`/`world.timecycle.clear` | `/v1/world/timecycle` to set or clear presets; scheduler auto-clears expired |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -92,7 +92,8 @@ practice is supported by citations.
 | **jailbreak module** | Jailbreak endpoints follow the layered pattern with auth/idempotency and now emit WebSocket/webhook events with an expiry scheduler. |
 | **k9 module** | K9 unit endpoints follow the layered pattern with auth/idempotency; active roster broadcasts via WebSocket, webhooks and scheduler. |
 | **jobs module** | Job CRUD and assignment endpoints follow the layered pattern with authentication, idempotency, WebSocket/webhook events and roster scheduler. |
-| **broadcaster module** | Broadcaster assignment uses character-scoped job logic and follows the established layered pattern. || **debug module** | Debug status endpoint follows the established layered pattern with authentication and rate limiting. |
+| **broadcast module** | Broadcast job assignment and message endpoints follow the layered pattern with auth, idempotency, WebSocket/webhook events and retention scheduler. |
+| **debug module** | Debug status endpoint follows the established layered pattern with authentication and rate limiting. |
 | **world module** | World state and forecast endpoints follow the established layered pattern with authentication and idempotency. |
 | **diamondCasino module** | Casino game endpoints follow the established layered pattern with authentication and idempotency. |
 | **WebSocket gateway** | Provides authenticated connections with heartbeat and at-least-once broadcast semantics. |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -136,3 +136,11 @@ Mechanic orders API with realtime completion events.
 * `POST /v1/mechanic/orders` creates work orders.
 * `GET /v1/mechanic/orders/{id}` retrieves status.
 * Scheduler `mechanic-process` marks orders complete and broadcasts `mechanic.orders.completed`.
+
+## Update – 2025-08-30 (broadcast)
+
+Broadcast messages API with realtime push and hourly retention purge.
+
+* `POST /v1/broadcast/attempt` assigns broadcaster job.
+* `GET /v1/broadcast/messages` lists recent messages.
+* `POST /v1/broadcast/messages` creates a message and emits `broadcast.message` via WebSocket and webhooks.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -89,3 +89,4 @@
 | 089_add_barriers.sql | Create barriers table for world barrier definitions |
 | 090_add_base_event_logs_type_index.sql | Index base_event_logs on event_type and created_at |
 | 091_add_mechanic_orders.sql | Mechanic work orders table |
+| 092_add_broadcast_messages.sql | Broadcast message log table |

--- a/backend/srp-base/docs/modules/broadcast.md
+++ b/backend/srp-base/docs/modules/broadcast.md
@@ -1,11 +1,13 @@
-# Broadcaster Module
+# Broadcast Module
 
-The broadcaster module implements the server‑side logic of the
-legacy `np-broadcaster` resource in the unified `srp‑base`
-backend.  In the original Lua resource, characters trigger an
-`attemptBroadcast` event to become a broadcaster.  The server
-counts how many broadcasters are currently active and, if below a
-hard-coded limit, assigns the broadcaster job using the job manager.
+The broadcast module implements the server-side logic of the legacy
+`np-broadcaster` resource in the unified `srp-base` backend.  In the
+original Lua resource, characters triggered an `attemptBroadcast`
+event to become a broadcaster.  The server counts how many
+broadcasters are currently active and, if below a hard-coded limit,
+assigns the broadcaster job using the job manager.  The module also
+stores free-form broadcast messages and pushes them to connected
+clients via WebSocket and configured webhook sinks.
 
 ## Endpoints
 
@@ -73,3 +75,16 @@ change the limit without code changes.
   duty status.
 * Rate limiting, authentication and idempotency policies are
   inherited from the global middleware in `src/app.js`.
+
+### `GET /v1/broadcast/messages`
+
+Returns recent broadcast messages ordered from newest to oldest.
+Optional query parameter `limit` caps results (default 50, max 100).
+
+### `POST /v1/broadcast/messages`
+
+Creates a new broadcast message.  Body requires `characterId` and
+`message` fields.  The stored record is broadcast via WebSocket
+namespace `broadcast` using event type `broadcast.message` and also
+dispatched to registered webhooks.  Scheduler `broadcast-purge`
+removes messages older than `BROADCAST_RETENTION_MS`.

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -63,3 +63,4 @@ Upstream name → SRP name mapping for this run.
 | np-admin:IsPlayerBanned | admin.ban.status |
 | np-barriers | barriers |
 | np-bennys | mechanic |
+| np-broadcaster | broadcast |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -145,3 +145,7 @@
 ## 2025-08-30 — np-base
 
 - EXTEND: Base event listing supports `eventType` filter and adds `(event_type, created_at)` index.
+
+## 2025-08-30 — np-broadcaster
+
+- EXTEND: Broadcast messages API with WebSocket/webhook push and hourly purge scheduler.

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -472,3 +472,8 @@
 - Attempted to clone `https://github.com/h04X-2K/NoPixelServer` resource `np-bennys` but clone aborted due to repository size. Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed mechanic and vehicle upgrade flows conceptually across EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP to align naming.
 - Reviewed public NoPixel 4.0 and ProdigyRP 4.0 notes on mechanic shops and vehicle customization for feature parity (names/flows only).
+
+## Research Log – 2025-08-30 (np-broadcaster)
+
+- Attempted to clone `https://github.com/h04X-2K/NoPixelServer` resource `np-broadcaster` but clone aborted due to repository size. Reference resources unavailable; proceeding with internal consistency only.
+- Reviewed chat and announcement flows in EssentialMode, ESX, ND Core, FSN, QB-Core, vRP and vORP for naming alignment.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -19,5 +19,26 @@
 - `CHANGELOG.md`
 - `MANIFEST.md`
 
+## Update – 2025-08-30 (broadcast)
+
+- Added broadcast messages backend with WebSocket/webhook push and hourly purge scheduler.
+
+### Updated Documentation
+- `docs/modules/broadcast.md`
+- `docs/db-schema.md`
+- `docs/migrations.md`
+- `docs/index.md`
+- `docs/progress-ledger.md`
+- `docs/framework-compliance.md`
+- `docs/BASE_API_DOCUMENTATION.md`
+- `docs/events-and-rpcs.md`
+- `docs/admin-ops.md`
+- `docs/security.md`
+- `docs/testing.md`
+- `docs/research-log.md`
+- `docs/naming-map.md`
+- `CHANGELOG.md`
+- `MANIFEST.md`
+
 ## Outstanding Items
 - None

--- a/backend/srp-base/docs/security.md
+++ b/backend/srp-base/docs/security.md
@@ -43,7 +43,7 @@
 - Police routes inherit the same authentication and idempotency requirements.
 - WebSocket connections require a `token` query parameter matching the `X-API-Token` and drop clients missing heartbeats.
 - Webhook dispatcher signs payloads with HMAC and retries failed deliveries.
-- Broadcaster routes inherit the same authentication and idempotency requirements.
+- Broadcast routes inherit the same authentication and idempotency requirements.
 - Debug routes inherit the same authentication and rate limiting requirements.
 - World routes (state, forecast and timecycle) inherit the same authentication and idempotency requirements.
 - Minimap routes inherit the same authentication and idempotency requirements.

--- a/backend/srp-base/docs/testing.md
+++ b/backend/srp-base/docs/testing.md
@@ -479,3 +479,13 @@ curl -H 'X-API-Token: <token>' http://localhost:3010/v1/characters/1/action-bar
 curl -H 'X-API-Token: <token>' -H 'Content-Type: application/json' -H 'X-Idempotency-Key: ab1' \
   -d '{"slots":[{"slot":1,"item":"WEAPON_PISTOL"}]}' http://localhost:3010/v1/characters/1/action-bar
 ```
+
+Manually verify broadcast message endpoints:
+
+```sh
+curl -H 'X-API-Token: <token>' http://localhost:3010/v1/broadcast/messages
+curl -H 'X-API-Token: <token>' -H 'Content-Type: application/json' -H 'X-Idempotency-Key: bc1' \
+  -d '{"characterId":1,"message":"Hello"}' http://localhost:3010/v1/broadcast/messages
+```
+
+Connect a WebSocket client to `ws://localhost:3010/ws?token=<token>&ns=broadcast` to receive `broadcast.message` events.

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -665,6 +665,18 @@ components:
         hiredAt:
           type: string
           format: date-time
+    BroadcastMessage:
+      type: object
+      properties:
+        id:
+          type: integer
+        characterId:
+          type: integer
+        message:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
     Tweet:
       type: object
       properties:
@@ -4109,6 +4121,76 @@ paths:
           description: Broadcaster limit reached
         '429':
           description: Rate limit exceeded
+  /v1/broadcast/messages:
+    get:
+      summary: List recent broadcast messages
+      operationId: listBroadcastMessages
+      security:
+        - ApiToken: []
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+      responses:
+        '200':
+          description: List of messages
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      messages:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/BroadcastMessage'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+    post:
+      summary: Create broadcast message
+      operationId: createBroadcastMessage
+      security:
+        - ApiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - characterId
+                - message
+              properties:
+                characterId:
+                  type: integer
+                message:
+                  type: string
+      responses:
+        '200':
+          description: Broadcast message created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    $ref: '#/components/schemas/BroadcastMessage'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+      description: Stores a message and broadcasts `broadcast.message` via WebSocket and webhooks.
   /v1/jobs:
     get:
       summary: List jobs

--- a/backend/srp-base/src/app.js
+++ b/backend/srp-base/src/app.js
@@ -58,8 +58,8 @@ const driftSchoolRoutes = require('./routes/driftschool.routes');
 // boatshop domain route
 const boatshopRoutes = require('./routes/boatshop.routes');
 
-// broadcaster domain route
-const broadcasterRoutes = require('./routes/broadcaster.routes');
+// broadcast domain routes
+const broadcastRoutes = require('./routes/broadcast.routes');
 
 // new domain routes for gangs, garages, apartments, police
 const gangsRoutes = require('./routes/gangs.routes');
@@ -236,8 +236,8 @@ app.use(drivingTestsRoutes);
 app.use(driftSchoolRoutes);
 app.use(boatshopRoutes);
 
-// mount broadcaster route
-app.use(broadcasterRoutes);
+// mount broadcast routes
+app.use('/v1/broadcast', broadcastRoutes);
 
 // mount gang, garage, apartment and police routes
 app.use(gangsRoutes);

--- a/backend/srp-base/src/config/env.js
+++ b/backend/srp-base/src/config/env.js
@@ -76,6 +76,7 @@ const config = {
   baseEvents: { retentionMs: parseInt(process.env.BASE_EVENT_RETENTION_MS || '2592000000', 10) },
   assets: { retentionMs: parseInt(process.env.ASSET_RETENTION_MS || '2592000000', 10) },
   chat: { retentionMs: parseInt(process.env.CHAT_RETENTION_MS || '604800000', 10) },
+  broadcast: { retentionMs: parseInt(process.env.BROADCAST_RETENTION_MS || '86400000', 10) },
   recycling: { retentionMs: parseInt(process.env.RECYCLING_RETENTION_MS || '2592000000', 10) },
   camera: {
     retentionMs: parseInt(process.env.CAMERA_RETENTION_MS || '2592000000', 10),

--- a/backend/srp-base/src/migrations/092_add_broadcast_messages.sql
+++ b/backend/srp-base/src/migrations/092_add_broadcast_messages.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS broadcast_messages (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  character_id INT NOT NULL,
+  message VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_broadcast_messages_created_at (created_at),
+  FOREIGN KEY (character_id) REFERENCES characters(id)
+);

--- a/backend/srp-base/src/repositories/broadcastRepository.js
+++ b/backend/srp-base/src/repositories/broadcastRepository.js
@@ -1,0 +1,24 @@
+const db = require('./db');
+
+async function createMessage({ characterId, message }) {
+  await db.query('INSERT INTO broadcast_messages (character_id, message) VALUES (?, ?)', [characterId, message]);
+  const [row] = await db.query(
+    'SELECT id, character_id AS characterId, message, created_at AS createdAt FROM broadcast_messages ORDER BY id DESC LIMIT 1',
+  );
+  return row;
+}
+
+async function getRecentMessages(limit) {
+  const rows = await db.query(
+    'SELECT id, character_id AS characterId, message, created_at AS createdAt FROM broadcast_messages ORDER BY id DESC LIMIT ?',
+    [limit],
+  );
+  return rows;
+}
+
+async function deleteOlderThan(cutoff) {
+  const result = await db.query('DELETE FROM broadcast_messages WHERE created_at < ?', [cutoff]);
+  return result.affectedRows || 0;
+}
+
+module.exports = { createMessage, getRecentMessages, deleteOlderThan };

--- a/backend/srp-base/src/routes/broadcast.routes.js
+++ b/backend/srp-base/src/routes/broadcast.routes.js
@@ -1,5 +1,8 @@
 const express = require('express');
 const jobsRepo = require('../repositories/jobsRepository');
+const broadcastRepo = require('../repositories/broadcastRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
 const { sendOk, sendError } = require('../utils/respond');
 
 // Maximum number of characters allowed to hold the broadcaster job at the
@@ -27,7 +30,7 @@ const router = express.Router();
  * the maximum number of broadcasters has been reached, an error is
  * returned.  On success the assigned job record is returned.
  */
-router.post('/v1/broadcast/attempt', express.json(), async (req, res, next) => {
+router.post('/attempt', async (req, res, next) => {
   try {
     const { characterId } = req.body || {};
     if (characterId === undefined) {
@@ -65,6 +68,57 @@ router.post('/v1/broadcast/attempt', express.json(), async (req, res, next) => {
     // assignment already exists it will update the record.
     const assignment = await jobsRepo.assignJob(parseInt(characterId, 10), job.id);
     sendOk(res, assignment, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * GET /v1/broadcast/messages
+ *
+ * Query: ?limit=50
+ *
+ * Lists recent broadcast messages ordered from newest to oldest.  The
+ * limit parameter caps the number of returned records (default 50,
+ * maximum 100).
+ */
+router.get('/messages', async (req, res, next) => {
+  try {
+    const limit = Math.max(1, Math.min(100, parseInt(req.query.limit, 10) || 50));
+    const messages = await broadcastRepo.getRecentMessages(limit);
+    sendOk(res, { messages }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    next(err);
+  }
+});
+
+/**
+ * POST /v1/broadcast/messages
+ *
+ * Body: { characterId: number, message: string }
+ *
+ * Persists a broadcast message and pushes it via WebSocket and webhook
+ * sinks.  Clients must supply an idempotency key.
+ */
+router.post('/messages', async (req, res, next) => {
+  try {
+    const { characterId, message } = req.body || {};
+    if (characterId === undefined || typeof message !== 'string' || message.length === 0) {
+      return sendError(
+        res,
+        { code: 'INVALID_INPUT', message: 'characterId and message are required' },
+        400,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    const record = await broadcastRepo.createMessage({
+    characterId: parseInt(characterId, 10),
+    message: message.slice(0, 255),
+    });
+    websocket.broadcast('broadcast', 'message', record);
+    hooks.dispatch('broadcast.message', record);
+    sendOk(res, record, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     next(err);
   }

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -46,6 +46,7 @@ const emsVehicleTasks = require('./tasks/emsVehicles');
 const vehicleControlTasks = require('./tasks/vehicleControl');
 const hackingTasks = require('./tasks/hacking');
 const mechanicTasks = require('./tasks/mechanic');
+const broadcastTasks = require('./tasks/broadcast');
 
 // Register Prometheus metrics if enabled.  This must be done before
 // the server starts so that middleware can increment counters.
@@ -292,6 +293,13 @@ scheduler.register(
   () => emsVehicleTasks.purgeOld(),
   emsVehicleTasks.INTERVAL_MS,
   { jitter: 60000, persistName: emsVehicleTasks.JOB_NAME },
+);
+
+scheduler.register(
+  broadcastTasks.JOB_NAME,
+  () => broadcastTasks.purgeOld(),
+  broadcastTasks.INTERVAL_MS,
+  { jitter: 60000, persistName: broadcastTasks.JOB_NAME },
 );
 
 scheduler.register(

--- a/backend/srp-base/src/tasks/broadcast.js
+++ b/backend/srp-base/src/tasks/broadcast.js
@@ -1,0 +1,18 @@
+const config = require('../config/env');
+const repo = require('../repositories/broadcastRepository');
+const logger = require('../utils/logger');
+
+const JOB_NAME = 'broadcast-purge';
+const INTERVAL_MS = 3600000; // hourly
+
+async function purgeOld() {
+  try {
+    const cutoff = new Date(Date.now() - config.broadcast.retentionMs);
+    const removed = await repo.deleteOlderThan(cutoff.toISOString().slice(0, 19).replace('T', ' '));
+    if (removed) logger.info({ removed }, 'Pruned stale broadcast messages');
+  } catch (err) {
+    logger.error({ err }, 'Failed to prune broadcast messages');
+  }
+}
+
+module.exports = { purgeOld, JOB_NAME, INTERVAL_MS };


### PR DESCRIPTION
## Summary
- add broadcast messages API with websocket and webhook push
- rename broadcaster routes to broadcast and add retention scheduler

## Testing
- `node --check backend/srp-base/src/routes/broadcast.routes.js`
- `node --check backend/srp-base/src/repositories/broadcastRepository.js`
- `node --check backend/srp-base/src/tasks/broadcast.js`
- `node --check backend/srp-base/src/app.js`
- `node --check backend/srp-base/src/server.js`
- `node --check backend/srp-base/src/config/env.js`


------
https://chatgpt.com/codex/tasks/task_e_68b24dc09298832d839465cb3519d269