### PR TITLE
srp-base(np-camera): photo metadata update endpoint with realtime push

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1946,3 +1946,17 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 
 * Drop `broadcast_messages` table and remove broadcast routes, config and scheduler registration.
+
+## 2025-08-30 (camera)
+
+### Added
+
+* Photo metadata update endpoint (`PATCH /v1/camera/photos/{id}`) with WebSocket/webhook push `camera.photo.updated`.
+
+### Risks
+
+* Clients not handling `camera.photo.updated` may show stale descriptions.
+
+### Rollback
+
+* Revert `PATCH /v1/camera/photos/{id}` route and remove associated repository function and documentation.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -12,6 +12,7 @@
 - Mechanic work orders backend with realtime push and scheduler.
 
 - Broadcast messages API with realtime push and purge scheduler.
+- Allow photo description updates with realtime push.
 
 | File | Action | Note |
 |---|---|---|
@@ -232,3 +233,16 @@
 | docs/run-docs.md | M | Summarize mechanic run |
 | CHANGELOG.md | M | Log mechanic module |
 | MANIFEST.md | M | Update manifest |
+| src/repositories/cameraRepository.js | M | Update photo metadata |
+| src/routes/camera.routes.js | M | Add PATCH endpoint |
+| openapi/api.yaml | M | Document photo update |
+| docs/modules/camera.md | M | Document photo update |
+| docs/index.md | M | Log camera metadata update |
+| docs/progress-ledger.md | M | Record camera extension |
+| docs/BASE_API_DOCUMENTATION.md | M | Add camera PATCH endpoint |
+| docs/events-and-rpcs.md | M | Map photo.updated event |
+| docs/naming-map.md | M | Map camera:Activate2 |
+| docs/research-log.md | M | Log np-camera research |
+| docs/run-docs.md | M | Summarize camera run |
+| MANIFEST.md | M | Update manifest |
+| CHANGELOG.md | M | Record camera metadata update |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -515,6 +515,7 @@ All routes require `X-API-Token` authentication. Idempotency keys are supported 
     - `GET /v1/camera/photos/{characterId}` – List photos for a character.
     - `POST /v1/camera/photos` – Save a photo with `characterId`, `imageUrl` and optional `description`; broadcasts `camera.photo.created` over WebSocket and webhooks.
     - `DELETE /v1/camera/photos/{id}` – Remove a photo record; broadcasts `camera.photo.deleted`.
+    - `PATCH /v1/camera/photos/{id}` – Update a photo description; broadcasts `camera.photo.updated`.
     - Scheduler purges photos older than `CAMERA_RETENTION_MS` at `CAMERA_CLEANUP_INTERVAL_MS`.
   - **srp-hud** – Stores per-character HUD settings.
 - `GET /v1/characters/{characterId}/hud` – Retrieve HUD preferences.

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -28,7 +28,7 @@
 | yuzler | No server events; clothing assets | N/A |
 | baseevents | Emits player join, drop and kill events | `POST /v1/base-events` logs events and broadcasts `base-events.logged`; `GET /v1/base-events` lists history |
 | boatshop | Resource sends purchase requests for boats | `GET /v1/boatshop`, `POST /v1/boatshop/purchase` → broadcasts `boatshop.catalog` (scheduled) and `boatshop.purchase` |
-| camera | Resource captures photos and uploads metadata | `GET /v1/camera/photos/{characterId}`, `POST /v1/camera/photos`, `DELETE /v1/camera/photos/{id}` → pushes `camera.photo.created`/`camera.photo.deleted` |
+| camera | Resource captures photos and uploads metadata | `GET /v1/camera/photos/{characterId}`, `POST /v1/camera/photos`, `DELETE /v1/camera/photos/{id}`, `PATCH /v1/camera/photos/{id}` → pushes `camera.photo.created`/`camera.photo.deleted`/`camera.photo.updated` |
 | carandplayerhud | Resource broadcasts HUD updates and vehicle state changes | `GET /v1/characters/{characterId}/hud`, `PUT /v1/characters/{characterId}/hud`, `GET /v1/characters/{characterId}/vehicle-state`, `PUT /v1/characters/{characterId}/vehicle-state` → WebSocket `hud.vehicleState` |
 | np-actionbar | Client manages quick action slots and holster events | `GET/PUT /v1/characters/{characterId}/action-bar` → WebSocket `hud.actionBar.updated` |
 | carwash | `carwash:checkmoney`, `carwash:success`, `notenoughmoney` | `POST /v1/carwash`, `GET /v1/carwash/history/{characterId}`, `GET/PATCH /v1/vehicles/{plate}/dirt`; dirt changes push `vehicles.dirt.update` |

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -144,3 +144,9 @@ Broadcast messages API with realtime push and hourly retention purge.
 * `POST /v1/broadcast/attempt` assigns broadcaster job.
 * `GET /v1/broadcast/messages` lists recent messages.
 * `POST /v1/broadcast/messages` creates a message and emits `broadcast.message` via WebSocket and webhooks.
+
+## Update – 2025-08-30 (camera metadata)
+
+Photo descriptions can now be updated with realtime notifications.
+
+* `PATCH /v1/camera/photos/{id}` updates description and emits `camera.photo.updated` via WebSocket and webhooks.

--- a/backend/srp-base/docs/modules/camera.md
+++ b/backend/srp-base/docs/modules/camera.md
@@ -15,6 +15,7 @@ There is no feature flag for camera; the module is always enabled.
 | **GET `/v1/camera/photos/{characterId}`** | List photos for a character. | 60/min per IP | Required | Yes | None | `{ ok, data: { photos: CameraPhoto[] }, requestId, traceId }` |
 | **POST `/v1/camera/photos`** | Create a new photo. Requires `characterId` and `imageUrl`. | 30/min per IP | Required | Yes | `CameraPhotoCreateRequest` | `{ ok, data: { photo: CameraPhoto }, requestId, traceId }` |
 | **DELETE `/v1/camera/photos/{id}`** | Delete a photo by ID. | 30/min per IP | Required | Yes | None | `{ ok, data: {}, requestId, traceId }` |
+| **PATCH `/v1/camera/photos/{id}`** | Update photo description. | 30/min per IP | Required | Yes | `CameraPhotoUpdateRequest` | `{ ok, data: { photo: CameraPhoto }, requestId, traceId }` |
 
 ### Real-time events
 
@@ -22,8 +23,9 @@ There is no feature flag for camera; the module is always enabled.
 |---|---|---|
 | `camera` | `photo.created` | `{ photo }` |
 | `camera` | `photo.deleted` | `{ id }` |
+| `camera` | `photo.updated` | `{ photo }` |
 
-Both events are also dispatched through the webhook dispatcher using event types `camera.photo.created` and `camera.photo.deleted`.
+All events are also dispatched through the webhook dispatcher using event types `camera.photo.created`, `camera.photo.deleted` and `camera.photo.updated`.
 
 ### Schemas
 

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -22,6 +22,7 @@ Upstream name → SRP name mapping for this run.
 | boatshop | boatshop |
 | bob74_ipl | ipl |
 | np-camera | camera |
+| camera:Activate2 | camera.photo.created |
 | carandplayerhud | hud |
 | carwash:checkmoney | POST /v1/carwash |
 | carwash:success | vehicles.dirt.update |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -117,6 +117,7 @@
 | 96 | np-barriers → barriers | Road barrier definitions and state | Create | Added barrier API with WS/webhook and auto-reset |
 | 97 | np-base → base-events | Base event filtering and indexing | Extend | Added `eventType` filter and composite index |
 | 98 | np-bennys → mechanic | Vehicle upgrade work orders with realtime push | Create | Added mechanic orders API and scheduler |
+| 99 | np-camera | Photo metadata updates with realtime push | Extend | Added PATCH endpoint and events |
 
 ## 2025-08-28 — koilWeatherSync
 
@@ -149,3 +150,7 @@
 ## 2025-08-30 — np-broadcaster
 
 - EXTEND: Broadcast messages API with WebSocket/webhook push and hourly purge scheduler.
+
+## 2025-08-30 — np-camera
+
+- EXTEND: Photo description update endpoint with WebSocket/webhook pushes.

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -477,3 +477,8 @@
 
 - Attempted to clone `https://github.com/h04X-2K/NoPixelServer` resource `np-broadcaster` but clone aborted due to repository size. Reference resources unavailable; proceeding with internal consistency only.
 - Reviewed chat and announcement flows in EssentialMode, ESX, ND Core, FSN, QB-Core, vRP and vORP for naming alignment.
+
+## Research Log – 2025-08-30 (np-camera)
+
+- Cloned `https://github.com/h04X-2K/NoPixelServer` with sparse checkout for `resources/np-camera` to examine camera activation flows.
+- Reviewed photo/gallery update patterns across EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP for naming consistency.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -42,3 +42,17 @@
 
 ## Outstanding Items
 - None
+
+## Update – 2025-08-30 (np-camera)
+
+- Added photo description update endpoint with realtime WebSocket/webhook events.
+
+### Updated Documentation
+- `docs/modules/camera.md`
+- `docs/index.md`
+- `docs/progress-ledger.md`
+- `docs/BASE_API_DOCUMENTATION.md`
+- `docs/events-and-rpcs.md`
+- `docs/naming-map.md`
+- `docs/research-log.md`
+- `openapi/api.yaml`

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -1416,6 +1416,13 @@ components:
         description:
           type: string
           nullable: true
+    CameraPhotoUpdateRequest:
+      type: object
+      required:
+        - description
+      properties:
+        description:
+          type: string
     HudPreferences:
       type: object
       properties:
@@ -6946,6 +6953,46 @@ paths:
                     type: string
         '400':
           $ref: '#/components/responses/BadRequest'
+    patch:
+      summary: Update a photo
+      operationId: updateCameraPhoto
+      x-websocket-event: camera.photo.updated
+      x-webhook-event: camera.photo.updated
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CameraPhotoUpdateRequest'
+      responses:
+        '200':
+          description: Photo updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      photo:
+                        $ref: '#/components/schemas/CameraPhoto'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
   /v1/characters/{characterId}/hud:
     get:
       summary: Get HUD preferences

--- a/backend/srp-base/src/repositories/cameraRepository.js
+++ b/backend/srp-base/src/repositories/cameraRepository.js
@@ -65,9 +65,30 @@ async function deletePhotosOlderThan(maxAgeMs) {
   return res.affectedRows || 0;
 }
 
+/**
+ * Update photo metadata such as description.
+ * @param {number} id
+ * @param {Object} params
+ * @param {string} params.description
+ * @returns {Promise<Object|null>} Updated photo or null if not found
+ */
+async function updatePhoto(id, { description }) {
+  const [res] = await db.query(
+    'UPDATE camera_photos SET description = ?, updated_at = NOW() WHERE id = ?',
+    [description, id],
+  );
+  if (!res.affectedRows) return null;
+  const [rows] = await db.query(
+    'SELECT id, character_id AS characterId, image_url AS imageUrl, description, created_at AS createdAt, updated_at AS updatedAt FROM camera_photos WHERE id = ?',
+    [id],
+  );
+  return rows[0] || null;
+}
+
 module.exports = {
   listPhotosByCharacter,
   createPhoto,
   deletePhoto,
   deletePhotosOlderThan,
+  updatePhoto,
 };

--- a/backend/srp-base/src/routes/camera.routes.js
+++ b/backend/srp-base/src/routes/camera.routes.js
@@ -4,6 +4,7 @@ const {
   listPhotosByCharacter,
   createPhoto,
   deletePhoto,
+  updatePhoto,
 } = require('../repositories/cameraRepository');
 const websocket = require('../realtime/websocket');
 const dispatcher = require('../hooks/dispatcher');
@@ -74,6 +75,39 @@ router.delete('/v1/camera/photos/:id', async (req, res) => {
     sendOk(res, {}, res.locals.requestId, res.locals.traceId);
   } catch (err) {
     sendError(res, { code: 'CAMERA_DELETE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+// Update a photo description
+router.patch('/v1/camera/photos/:id', async (req, res) => {
+  const { id } = req.params;
+  const idNum = parseInt(id, 10);
+  const { description } = req.body || {};
+  if (Number.isNaN(idNum) || typeof description !== 'string') {
+    return sendError(
+      res,
+      { code: 'VALIDATION_ERROR', message: 'id must be an integer and description required' },
+      400,
+      res.locals.requestId,
+      res.locals.traceId,
+    );
+  }
+  try {
+    const photo = await updatePhoto(idNum, { description });
+    if (!photo) {
+      return sendError(
+        res,
+        { code: 'NOT_FOUND', message: 'photo not found' },
+        404,
+        res.locals.requestId,
+        res.locals.traceId,
+      );
+    }
+    websocket.broadcast('camera', 'photo.updated', { photo });
+    dispatcher.dispatch('camera.photo.updated', photo);
+    sendOk(res, { photo }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'CAMERA_UPDATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
   }
 });
 


### PR DESCRIPTION
## Summary
- allow updating camera photo descriptions
- broadcast `camera.photo.updated` over websockets and webhooks
- document camera update in API and module docs

## Testing
- `API_TOKEN=dev node -e "require('./backend/srp-base/src/routes/camera.routes.js'); console.log('route-ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68b2504fabfc832dbe46e8113a622dcd