### PR TITLE
srp-base: command definition backend with realtime push

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -1960,3 +1960,17 @@ Documentation cleanup to ensure OpenAPI validation passes. No runtime behaviour 
 ### Rollback
 
 * Revert `PATCH /v1/camera/photos/{id}` route and remove associated repository function and documentation.
+
+## 2025-08-30 (np-commands)
+
+### Added
+
+* Command definition endpoints (`GET/POST /v1/commands`, `DELETE /v1/commands/{id}`) with WebSocket/webhook `commands.*` events.
+
+### Risks
+
+* Misconfigured role flags may expose admin-only commands.
+
+### Rollback
+
+* Drop `commands` table and remove command routes and repository.

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -13,6 +13,7 @@
 
 - Broadcast messages API with realtime push and purge scheduler.
 - Allow photo description updates with realtime push.
+- Command definitions API with realtime push.
 
 | File | Action | Note |
 |---|---|---|
@@ -246,3 +247,19 @@
 | docs/run-docs.md | M | Summarize camera run |
 | MANIFEST.md | M | Update manifest |
 | CHANGELOG.md | M | Record camera metadata update |
+| src/routes/commands.routes.js | A | Command definition routes |
+| src/repositories/commandsRepository.js | A | Command persistence |
+| src/migrations/093_add_commands.sql | A | Command definitions table |
+| docs/modules/commands.md | A | Document commands module |
+| docs/index.md | M | Log commands update |
+| docs/progress-ledger.md | M | Record np-commands entry |
+| docs/framework-compliance.md | M | Add commands module compliance |
+| docs/events-and-rpcs.md | M | Map np-commands resource |
+| docs/admin-ops.md | M | Add commands table note |
+| docs/naming-map.md | M | Map np-commands |
+| docs/research-log.md | M | Log np-commands research |
+| docs/db-schema.md | M | Document commands table |
+| docs/migrations.md | M | List migration 093 |
+| docs/run-docs.md | M | Summarize commands run |
+| openapi/api.yaml | M | Document command endpoints |
+| docs/BASE_API_DOCUMENTATION.md | M | Document commands API |

--- a/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
+++ b/backend/srp-base/docs/BASE_API_DOCUMENTATION.md
@@ -763,3 +763,11 @@ Broadcast job assignment and message endpoints.
 - `POST /v1/broadcast/messages` – requires `X-Idempotency-Key`
 
 WebSocket namespace `broadcast` emits `broadcast.message`. Scheduler `broadcast-purge` removes old messages.
+
+### Commands
+
+| Method | Path | Description |
+|---|---|---|
+| GET | /v1/commands | List command definitions |
+| POST | /v1/commands | Create a command (idempotent via X-Idempotency-Key) |
+| DELETE | /v1/commands/{id} | Delete a command |

--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -74,3 +74,4 @@
 - Ensure the `bans` and `unban_events` tables exist; WebSocket namespace `admin` emits `ban.added` and `ban.removed` for moderation actions.
 - Ensure the `mechanic_orders` table exists for vehicle work orders; scheduler `mechanic-process` completes pending orders.
 - Ensure the `broadcast_messages` table exists; set `BROADCAST_RETENTION_MS` to control message retention. Scheduler `broadcast-purge` prunes old entries.
+- Ensure the `commands` table exists for command definitions.

--- a/backend/srp-base/docs/db-schema.md
+++ b/backend/srp-base/docs/db-schema.md
@@ -2,6 +2,20 @@
 Added `world_forecast` table for weather scheduling. K9 migration renamed to 057_add_k9_units.sql.
 
 
+## commands
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INT AUTO_INCREMENT | Primary key |
+| name | VARCHAR(64) | Unique command name |
+| description | TEXT | Optional description |
+| restricted_police | TINYINT(1) | 1 if police-only |
+| restricted_ems | TINYINT(1) | 1 if EMS-only |
+| restricted_judge | TINYINT(1) | 1 if judge-only |
+| created_at | TIMESTAMP | Creation time |
+| updated_at | TIMESTAMP | Update time |
+| INDEX idx_commands_name | (name) |
+
 ## bans
 
 | Column | Type | Notes |

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -31,6 +31,7 @@
 | camera | Resource captures photos and uploads metadata | `GET /v1/camera/photos/{characterId}`, `POST /v1/camera/photos`, `DELETE /v1/camera/photos/{id}`, `PATCH /v1/camera/photos/{id}` → pushes `camera.photo.created`/`camera.photo.deleted`/`camera.photo.updated` |
 | carandplayerhud | Resource broadcasts HUD updates and vehicle state changes | `GET /v1/characters/{characterId}/hud`, `PUT /v1/characters/{characterId}/hud`, `GET /v1/characters/{characterId}/vehicle-state`, `PUT /v1/characters/{characterId}/vehicle-state` → WebSocket `hud.vehicleState` |
 | np-actionbar | Client manages quick action slots and holster events | `GET/PUT /v1/characters/{characterId}/action-bar` → WebSocket `hud.actionBar.updated` |
+| np-commands | Resource rebuilds allowed chat commands based on job/whitelist | `GET/POST/DELETE /v1/commands` → WS `commands.*` |
 | carwash | `carwash:checkmoney`, `carwash:success`, `notenoughmoney` | `POST /v1/carwash`, `GET /v1/carwash/history/{characterId}`, `GET/PATCH /v1/vehicles/{plate}/dirt`; dirt changes push `vehicles.dirt.update` |
 | chat | Resource broadcasts chat messages | `POST /v1/chat/messages` logs and pushes `chat.message`; history via `GET /v1/chat/messages/{characterId}`; scheduler `chat-purge` removes old logs |
 | connectqueue | Resource uses exports `AddPriority` and `RemovePriority` with account identifiers and now pushes `priority.upserted`, `priority.removed` and `priority.expired` over WebSocket and webhooks | `GET/POST/DELETE /v1/connectqueue/priorities` manage backend priority records |

--- a/backend/srp-base/docs/framework-compliance.md
+++ b/backend/srp-base/docs/framework-compliance.md
@@ -115,6 +115,8 @@ practice is supported by citations.
 | **action bar module** | Quick slot endpoints use repository pattern and realtime dispatch. |
 | **barriers module** | Barrier endpoints follow the established layered pattern with authentication, idempotency, WebSocket/webhook broadcasts and auto-reset scheduler. |
 
+| **commands module** | Command definition endpoints follow the layered pattern with authentication, idempotency, WebSocket/webhook events. |
+
 ## Outstanding Items
 
 - Integrate OpenAPI validation middleware for all routes.

--- a/backend/srp-base/docs/index.md
+++ b/backend/srp-base/docs/index.md
@@ -150,3 +150,9 @@ Broadcast messages API with realtime push and hourly retention purge.
 Photo descriptions can now be updated with realtime notifications.
 
 * `PATCH /v1/camera/photos/{id}` updates description and emits `camera.photo.updated` via WebSocket and webhooks.
+
+## Update – 2025-08-30 (commands)
+
+Managed server command definitions with realtime push.
+
+* `GET /v1/commands`, `POST /v1/commands`, `DELETE /v1/commands/{id}` emit `commands.*` over WebSocket and webhooks.

--- a/backend/srp-base/docs/migrations.md
+++ b/backend/srp-base/docs/migrations.md
@@ -90,3 +90,4 @@
 | 090_add_base_event_logs_type_index.sql | Index base_event_logs on event_type and created_at |
 | 091_add_mechanic_orders.sql | Mechanic work orders table |
 | 092_add_broadcast_messages.sql | Broadcast message log table |
+| 093_add_commands.sql | Command definitions table |

--- a/backend/srp-base/docs/modules/commands.md
+++ b/backend/srp-base/docs/modules/commands.md
@@ -1,0 +1,17 @@
+# Commands Module
+
+Provides CRUD for server command definitions used by gameplay roles.
+
+## Routes
+- `GET /v1/commands` – list available commands.
+- `POST /v1/commands` – create a command.
+- `DELETE /v1/commands/{id}` – remove a command.
+
+## Repository Contract
+- `list(limit, offset)` → array of commands.
+- `create({ name, description, police, ems, judge })` → created command.
+- `remove(id)` → delete command.
+
+## Edge Cases
+- Duplicate `name` yields database constraint error.
+- All boolean flags default to `false` when omitted.

--- a/backend/srp-base/docs/naming-map.md
+++ b/backend/srp-base/docs/naming-map.md
@@ -65,3 +65,4 @@ Upstream name → SRP name mapping for this run.
 | np-barriers | barriers |
 | np-bennys | mechanic |
 | np-broadcaster | broadcast |
+| np-commands | commands |

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -154,3 +154,7 @@
 ## 2025-08-30 — np-camera
 
 - EXTEND: Photo description update endpoint with WebSocket/webhook pushes.
+
+## 2025-08-30 — np-commands
+
+- CREATE: Command definition API with WebSocket/webhook pushes.

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -482,3 +482,8 @@
 
 - Cloned `https://github.com/h04X-2K/NoPixelServer` with sparse checkout for `resources/np-camera` to examine camera activation flows.
 - Reviewed photo/gallery update patterns across EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP for naming consistency.
+
+## Research Log – 2025-08-30 (np-commands)
+
+- Cloned `https://github.com/h04X-2K/NoPixelServer` and inspected `resources/np-commands` for command whitelist flows.
+- Reviewed command handling in EssentialMode, ESX, ND Core, FSN Framework, QB-Core, vRP and vORP for naming parity.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -56,3 +56,23 @@
 - `docs/naming-map.md`
 - `docs/research-log.md`
 - `openapi/api.yaml`
+
+## Update – 2025-08-30 (np-commands)
+
+- Added command definition backend with realtime WebSocket/webhook events.
+
+### Updated Documentation
+- `docs/modules/commands.md`
+- `docs/db-schema.md`
+- `docs/migrations.md`
+- `docs/index.md`
+- `docs/progress-ledger.md`
+- `docs/framework-compliance.md`
+- `docs/events-and-rpcs.md`
+- `docs/admin-ops.md`
+- `docs/naming-map.md`
+- `docs/research-log.md`
+- `openapi/api.yaml`
+- `CHANGELOG.md`
+- `MANIFEST.md`
+- `docs/BASE_API_DOCUMENTATION.md`

--- a/backend/srp-base/openapi/api.yaml
+++ b/backend/srp-base/openapi/api.yaml
@@ -2342,6 +2342,43 @@ components:
           type: string
           format: date-time
           nullable: true
+    Command:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        police:
+          type: boolean
+        ems:
+          type: boolean
+        judge:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    CommandCreateRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
+        police:
+          type: boolean
+        ems:
+          type: boolean
+        judge:
+          type: boolean
 security:
   - ApiToken: []
 paths:
@@ -5414,6 +5451,93 @@ paths:
                     properties:
                       note:
                         $ref: '#/components/schemas/Note'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+  /v1/commands:
+    get:
+      summary: List registered commands
+      parameters:
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 50
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            default: 0
+      responses:
+        '200':
+          description: List of commands
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      commands:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/Command'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+    post:
+      summary: Create a command
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CommandCreateRequest'
+      responses:
+        '200':
+          description: Command created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      command:
+                        $ref: '#/components/schemas/Command'
+                  requestId:
+                    type: string
+                  traceId:
+                    type: string
+  /v1/commands/{id}:
+    delete:
+      summary: Delete a command
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Command deleted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  data:
+                    type: object
                   requestId:
                     type: string
                   traceId:

--- a/backend/srp-base/src/app.js
+++ b/backend/srp-base/src/app.js
@@ -84,6 +84,8 @@ const baseEventsRoutes = require('./routes/baseEvents.routes');
 const cronRoutes = require('./routes/cron.routes');
 // coordinates domain route (formerly coordsaver)
 const coordinatesRoutes = require('./routes/coordinates.routes');
+// commands domain route
+const commandsRoutes = require('./routes/commands.routes');
 
 // phone domain route
 const phoneRoutes = require('./routes/phone.routes');
@@ -256,6 +258,8 @@ app.use(clothesRoutes);
 
 // mount notes routes
 app.use(notesRoutes);
+// mount commands routes
+app.use(commandsRoutes);
 // mount furniture routes
 app.use(furnitureRoutes);
 // mount coordinates routes

--- a/backend/srp-base/src/migrations/093_add_commands.sql
+++ b/backend/srp-base/src/migrations/093_add_commands.sql
@@ -1,0 +1,13 @@
+-- Adds commands table
+CREATE TABLE IF NOT EXISTS commands (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(64) NOT NULL UNIQUE,
+  description TEXT,
+  restricted_police TINYINT(1) NOT NULL DEFAULT 0,
+  restricted_ems TINYINT(1) NOT NULL DEFAULT 0,
+  restricted_judge TINYINT(1) NOT NULL DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_commands_name ON commands (name);

--- a/backend/srp-base/src/repositories/commandsRepository.js
+++ b/backend/srp-base/src/repositories/commandsRepository.js
@@ -1,0 +1,26 @@
+const db = require('./db');
+
+async function list(limit = 50, offset = 0) {
+  return db.query(
+    'SELECT id, name, description, restricted_police AS police, restricted_ems AS ems, restricted_judge AS judge FROM commands ORDER BY id LIMIT ? OFFSET ?',
+    [limit, offset]
+  );
+}
+
+async function create({ name, description = '', police = false, ems = false, judge = false }) {
+  const result = await db.query(
+    'INSERT INTO commands (name, description, restricted_police, restricted_ems, restricted_judge) VALUES (?, ?, ?, ?, ?)',
+    [name, description, police ? 1 : 0, ems ? 1 : 0, judge ? 1 : 0]
+  );
+  return { id: result.insertId, name, description, police, ems, judge };
+}
+
+async function remove(id) {
+  await db.query('DELETE FROM commands WHERE id = ?', [id]);
+}
+
+module.exports = {
+  list,
+  create,
+  remove,
+};

--- a/backend/srp-base/src/routes/commands.routes.js
+++ b/backend/srp-base/src/routes/commands.routes.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const { sendOk, sendError } = require('../utils/respond');
+const repo = require('../repositories/commandsRepository');
+const websocket = require('../realtime/websocket');
+const hooks = require('../hooks/dispatcher');
+
+const router = express.Router();
+
+router.get('/v1/commands', async (req, res) => {
+  const limit = Math.min(parseInt(req.query.limit, 10) || 50, 100);
+  const offset = parseInt(req.query.offset, 10) || 0;
+  try {
+    const commands = await repo.list(limit, offset);
+    sendOk(res, { commands }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'COMMAND_LIST_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+router.post('/v1/commands', async (req, res) => {
+  const { name, description, police, ems, judge } = req.body;
+  if (!name || typeof name !== 'string') {
+    return sendError(res, { code: 'VALIDATION_ERROR', message: 'name required' }, 400, res.locals.requestId, res.locals.traceId);
+  }
+  try {
+    const command = await repo.create({ name, description, police: !!police, ems: !!ems, judge: !!judge });
+    websocket.broadcast('commands', 'created', command);
+    hooks.dispatch('commands.created', command);
+    sendOk(res, { command }, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'COMMAND_CREATE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+router.delete('/v1/commands/:id', async (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  if (Number.isNaN(id)) {
+    return sendError(res, { code: 'VALIDATION_ERROR', message: 'id must be integer' }, 400, res.locals.requestId, res.locals.traceId);
+  }
+  try {
+    await repo.remove(id);
+    websocket.broadcast('commands', 'removed', { id });
+    hooks.dispatch('commands.removed', { id });
+    sendOk(res, {}, res.locals.requestId, res.locals.traceId);
+  } catch (err) {
+    sendError(res, { code: 'COMMAND_DELETE_FAILED', message: err.message }, 500, res.locals.requestId, res.locals.traceId);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add command definition API with role flags
- broadcast command changes over WebSocket and webhooks
- document new commands table and endpoints

## Testing
- `node src/bootstrap/migrate.js` *(fails: API_TOKEN environment variable must be provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b255dc9240832daf2b9a95ef8c8fbb