### PR TITLE
Enforce required security secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ Configure the service with environment variables or a `.env` file.
 | -------- | ------- |
 | `PORT` | HTTP listen port (default `3000`). |
 | `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASS` | MySQL connection settings. |
-| `SRP_HMAC_SECRET` | Shared secret used to validate the `X-SRP-Signature` header. |
-| `JWT_SECRET` | Secret for signing access tokens. |
+| `SRP_HMAC_SECRET` | **Required** secret used to validate the `X-SRP-Signature` header. |
+| `JWT_SECRET` | **Required** secret for signing access tokens. |
 | `TIME_BROADCAST_INTERVAL_MS` | Frequency for system time WebSocket broadcasts. |
 | `SCOREBOARD_STALE_MS` | Age threshold for purging stale scoreboard entries. |
+
+`SRP_HMAC_SECRET` and `JWT_SECRET` must be defined; the service exits on startup if either is missing.
 
 #### Running Locally
 

--- a/backend/srp-base/src/middleware/auth.js
+++ b/backend/srp-base/src/middleware/auth.js
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 export function verifySignature(req, res, next) {
   const signature = req.get('x-srp-signature');
   if (!signature) return res.status(401).json({ error: 'Missing signature' });
-  const secret = process.env.SRP_HMAC_SECRET || 'changeme';
+  const secret = process.env.SRP_HMAC_SECRET;
   const payload = req.rawBody || '';
   const hmac = crypto.createHmac('sha256', secret).update(payload).digest('hex');
   if (hmac !== signature) return res.status(401).json({ error: 'Invalid signature' });

--- a/backend/srp-base/src/middleware/tokenAuth.js
+++ b/backend/srp-base/src/middleware/tokenAuth.js
@@ -10,7 +10,7 @@ export async function authToken(req, res, next) {
     return res.status(401).json({ error: 'Malformed Authorization header' });
   }
   try {
-    const secret = process.env.JWT_SECRET || 'changeme';
+    const secret = process.env.JWT_SECRET;
     const payload = jwt.verify(token, secret);
     const [dbScopes, dbRoles] = await Promise.all([
       getAccountScopes(payload.accountId),

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -11,6 +11,13 @@ import { purgeStaleEntities } from './repositories/world.js';
 import { refreshEndpoints } from './webhooks/dispatcher.js';
 import { getCurrentTime } from './util/time.js';
 
+if (!process.env.SRP_HMAC_SECRET) {
+  throw new Error('SRP_HMAC_SECRET environment variable is required');
+}
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
+
 const port = process.env.PORT || 3000;
 const server = http.createServer(app);
 


### PR DESCRIPTION
## Summary
- Remove insecure default secrets from authentication middlewares
- Fail fast on startup when JWT or HMAC secrets are missing
- Document mandatory JWT and HMAC secrets in configuration guide

## Testing
- `JWT_SECRET=secret SRP_HMAC_SECRET=secret npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba70a53500832d858efb1e1fb25a90