### PR TITLE
feat: add cancellable scheduler tasks

### DIFF
--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -42,3 +42,14 @@ scheduler.start();
 server.listen(port, () => {
   logger.info({ port }, 'srp-base listening');
 });
+
+function shutdown() {
+  scheduler.stop();
+  server.close(() => {
+    logger.info('srp-base shutting down');
+    process.exit(0);
+  });
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);


### PR DESCRIPTION
## Summary
- make scheduler tasks cancellable via `AbortController`
- expose `scheduler.stop` and stop tasks on process signals

## Testing
- `SRP_HMAC_SECRET=testing JWT_SECRET=secret npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba72fe10c0832d846952e3179cef05