### PR TITLE
srp-base: add webhook dead-letter retry

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -89,3 +89,6 @@
 ## 2025-09-16
 - Refactor WebSocket gateway with per-domain namespaces, account and character validation, and broadcast rate limiting.
 
+## 2025-09-17
+- Parallelize webhook dispatch, persist failed deliveries, and schedule retries with exponential backoff.
+

--- a/backend/srp-base/MANIFEST.md
+++ b/backend/srp-base/MANIFEST.md
@@ -10,6 +10,7 @@
 - Added sessions whitelist and hardcap management with persistence, REST routes, WebSocket events, and tests.
 - Added coordinate saving, spawn logging, population metrics, broadcaster role management, and expanded notification endpoints.
 - Added infinity entity streaming with REST endpoints and scheduler purge, and enforced broadcast participation limits.
+- Added webhook dead-letter queue with parallel dispatch and retry scheduler.
 
 - Refactored WebSocket gateway with per-domain namespaces, handshake validation, and broadcast rate limiting.
 
@@ -145,3 +146,8 @@
 | docs/gap-closure-report.md | M | mark gateway gap closed |
 | docs/progress-ledger.md | M | record gateway work |
 | docs/testing.md | M | note gateway tests |
+| src/repositories/webhookDeadLetters.js | A | persist failed webhook deliveries |
+| src/webhooks/dispatcher.js | M | parallel dispatch with dead-letter logging |
+| src/migrations/0022_webhook_dead_letter.sql | A | webhook_dead_letter table |
+| src/server.js | M | retry dead-letter scheduler task |
+| test/webhook-dead-letter.test.js | A | dead-letter repository tests |

--- a/backend/srp-base/src/migrations/0022_webhook_dead_letter.sql
+++ b/backend/srp-base/src/migrations/0022_webhook_dead_letter.sql
@@ -1,0 +1,17 @@
+--[[
+-- Type: Migration
+-- Name: Create webhook_dead_letter table
+-- Created: 2025-09-05
+-- By: VSSVSSN
+--]]
+CREATE TABLE IF NOT EXISTS webhook_dead_letter (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  url VARCHAR(512) NOT NULL,
+  secret VARCHAR(255) NOT NULL,
+  payload JSON NOT NULL,
+  attempts INT NOT NULL DEFAULT 0,
+  next_attempt_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_webhook_dead_letter_next_attempt ON webhook_dead_letter (next_attempt_at);

--- a/backend/srp-base/src/repositories/webhookDeadLetters.js
+++ b/backend/srp-base/src/repositories/webhookDeadLetters.js
@@ -1,0 +1,67 @@
+import { query as dbQuery } from '../db/index.js';
+
+let queryFn = dbQuery;
+
+//[[
+// Type: Function
+// Name: setWebhookDeadLetterQuery
+// Use: Overrides query function, primarily for testing
+// Created: 2025-09-05
+// By: VSSVSSN
+//]]
+export function setWebhookDeadLetterQuery(fn) {
+  queryFn = fn;
+}
+
+//[[
+// Type: Function
+// Name: insertDeadLetter
+// Use: Stores failed webhook for later retry
+// Created: 2025-09-05
+// By: VSSVSSN
+//]]
+export async function insertDeadLetter({ url, secret, payload }) {
+  await queryFn(
+    'INSERT INTO webhook_dead_letter (url, secret, payload, attempts, next_attempt_at) VALUES (?, ?, ?, 0, DATE_ADD(NOW(), INTERVAL 60 SECOND))',
+    [url, secret, JSON.stringify(payload)]
+  );
+}
+
+//[[
+// Type: Function
+// Name: listDueDeadLetters
+// Use: Retrieves dead-lettered webhooks ready for retry
+// Created: 2025-09-05
+// By: VSSVSSN
+//]]
+export async function listDueDeadLetters(limit = 10) {
+  return queryFn(
+    'SELECT id, url, secret, payload, attempts FROM webhook_dead_letter WHERE next_attempt_at <= NOW() LIMIT ?',
+    [limit]
+  );
+}
+
+//[[
+// Type: Function
+// Name: deleteDeadLetter
+// Use: Removes successfully delivered dead-letter from queue
+// Created: 2025-09-05
+// By: VSSVSSN
+//]]
+export async function deleteDeadLetter(id) {
+  await queryFn('DELETE FROM webhook_dead_letter WHERE id = ?', [id]);
+}
+
+//[[
+// Type: Function
+// Name: rescheduleDeadLetter
+// Use: Updates retry schedule with exponential backoff
+// Created: 2025-09-05
+// By: VSSVSSN
+//]]
+export async function rescheduleDeadLetter(id, attempts, delaySeconds) {
+  await queryFn(
+    'UPDATE webhook_dead_letter SET attempts = ?, next_attempt_at = DATE_ADD(NOW(), INTERVAL ? SECOND) WHERE id = ?',
+    [attempts, delaySeconds, id]
+  );
+}

--- a/backend/srp-base/src/server.js
+++ b/backend/srp-base/src/server.js
@@ -8,7 +8,7 @@ import { purgeStalePlayers } from './repositories/scoreboard.js';
 import { purgeStaleQueue } from './repositories/queue.js';
 import { purgeStaleChannels } from './repositories/voice.js';
 import { purgeStaleEntities } from './repositories/world.js';
-import { refreshEndpoints } from './webhooks/dispatcher.js';
+import { refreshEndpoints, retryDeadLetters } from './webhooks/dispatcher.js';
 import { getCurrentTime } from './util/time.js';
 
 if (!process.env.SRP_HMAC_SECRET) {
@@ -35,6 +35,7 @@ const voiceStale = Number(process.env.VOICE_STALE_MS) || 300_000;
 registerTask('voice_purge', 60_000, () => purgeStaleChannels(voiceStale));
 const infinityStale = Number(process.env.INFINITY_STALE_MS) || 300_000;
 registerTask('infinity_entity_purge', 60_000, () => purgeStaleEntities(infinityStale));
+registerTask('webhook_dead_letter_retry', 60_000, retryDeadLetters);
 refreshEndpoints();
 initGateway(server, wsDomains);
 scheduler.start();

--- a/backend/srp-base/test/webhook-dead-letter.test.js
+++ b/backend/srp-base/test/webhook-dead-letter.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  setWebhookDeadLetterQuery,
+  insertDeadLetter,
+  listDueDeadLetters,
+  deleteDeadLetter,
+  rescheduleDeadLetter
+} from '../src/repositories/webhookDeadLetters.js';
+
+//[[
+// Type: Test
+// Name: Webhook dead-letter repository
+// Use: Ensures dead letters store, reschedule, and delete correctly
+// Created: 2025-09-05
+// By: VSSVSSN
+//]]
+test('webhook dead-letter round-trip', async () => {
+  const store = new Map();
+  let idSeq = 1;
+  setWebhookDeadLetterQuery(async (sql, params) => {
+    if (sql.startsWith('INSERT INTO webhook_dead_letter')) {
+      const [url, secret, payload] = params;
+      store.set(idSeq, { id: idSeq, url, secret, payload, attempts: 0 });
+      return { insertId: idSeq++ };
+    }
+    if (sql.startsWith('SELECT id, url, secret, payload, attempts FROM webhook_dead_letter')) {
+      return Array.from(store.values());
+    }
+    if (sql.startsWith('DELETE FROM webhook_dead_letter')) {
+      store.delete(params[0]);
+      return { affectedRows: 1 };
+    }
+    if (sql.startsWith('UPDATE webhook_dead_letter SET attempts')) {
+      const [attempts, , id] = params;
+      const row = store.get(id);
+      row.attempts = attempts;
+      return { affectedRows: 1 };
+    }
+    throw new Error('unexpected SQL');
+  });
+
+  await insertDeadLetter({ url: 'http://x', secret: 's', payload: { a: 1 } });
+  let due = await listDueDeadLetters();
+  assert.strictEqual(due.length, 1);
+  const id = due[0].id;
+  await rescheduleDeadLetter(id, 1, 120);
+  due = await listDueDeadLetters();
+  assert.strictEqual(due[0].attempts, 1);
+  await deleteDeadLetter(id);
+  due = await listDueDeadLetters();
+  assert.strictEqual(due.length, 0);
+});


### PR DESCRIPTION
## Summary
- dispatch webhooks concurrently and capture failures
- persist failed webhooks and retry with exponential backoff

## Testing
- `JWT_SECRET=secret SRP_HMAC_SECRET=secret npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba74941714832db0fa54658d1a94a4