### PR TITLE
srp-base: replace locale time formatting with ISO strings

### DIFF
--- a/backend/srp-base/docs/admin-ops.md
+++ b/backend/srp-base/docs/admin-ops.md
@@ -16,7 +16,7 @@
 
 ## System Time
 - Configure timezone and broadcast interval via environment:
-  - `TIMEZONE` (default `UTC`)
+  - `TIMEZONE` (IANA zone or `+HH:MM` offset, default `UTC`)
   - `TIME_BROADCAST_INTERVAL_MS` (default `60000`)
 
 ## Scoreboard

--- a/backend/srp-base/docs/events-and-rpcs.md
+++ b/backend/srp-base/docs/events-and-rpcs.md
@@ -4,7 +4,7 @@
 - Namespaces: `/ws/<domain>`
 - Envelope fields: `id`, `type`, `source`, `subject`, `time`, `specversion`, `data`
 - Built-in: `ping` -> `pong`
-- `srp.system.time` -> server time tick honoring `TIMEZONE`
+- `srp.system.time` -> server time tick in ISO 8601 format honoring `TIMEZONE`
 - `srp.scoreboard.update` -> player ping, name, or job update
 - `srp.scoreboard.remove` -> player removed/timeout
 - `srp.telemetry.error` -> error log created

--- a/backend/srp-base/src/util/time.js
+++ b/backend/srp-base/src/util/time.js
@@ -1,4 +1,28 @@
 export function getCurrentTime() {
   const tz = process.env.TIMEZONE || 'UTC';
-  return new Date().toLocaleString('sv-SE', { timeZone: tz, hour12: false }).replace(' ', 'T');
+  const now = new Date();
+
+  const offsetPattern = /^([+-])(\d{2}):?(\d{2})$/;
+
+  if (tz === 'UTC') {
+    return now.toISOString();
+  }
+
+  let offsetMinutes;
+
+  if (offsetPattern.test(tz)) {
+    const [, sign, hh, mm] = tz.match(offsetPattern);
+    offsetMinutes = (sign === '+' ? 1 : -1) * (parseInt(hh, 10) * 60 + parseInt(mm, 10));
+  } else {
+    const tzDate = new Date(now.toLocaleString('en-US', { timeZone: tz }));
+    offsetMinutes = (tzDate.getTime() - now.getTime()) / 60000;
+  }
+
+  const sign = offsetMinutes >= 0 ? '+' : '-';
+  const abs = Math.abs(offsetMinutes);
+  const hours = String(Math.floor(abs / 60)).padStart(2, '0');
+  const minutes = String(abs % 60).padStart(2, '0');
+  const adjusted = new Date(now.getTime() + offsetMinutes * 60000);
+  const iso = adjusted.toISOString().replace('Z', '');
+  return `${iso}${sign}${hours}:${minutes}`;
 }

--- a/backend/srp-base/test/time.test.js
+++ b/backend/srp-base/test/time.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getCurrentTime } from '../src/util/time.js';
+
+test('getCurrentTime returns ISO string in UTC by default', (t) => {
+  const original = process.env.TIMEZONE;
+  process.env.TIMEZONE = '';
+  t.after(() => {
+    process.env.TIMEZONE = original;
+  });
+
+  const time = getCurrentTime();
+  assert.match(time, /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
+});
+
+test('getCurrentTime appends timezone offset when specified', (t) => {
+  const original = process.env.TIMEZONE;
+  process.env.TIMEZONE = '+02:00';
+  t.after(() => {
+    process.env.TIMEZONE = original;
+  });
+
+  const time = getCurrentTime();
+  assert.ok(time.endsWith('+02:00'));
+});
+


### PR DESCRIPTION
## Summary
- switch server time utility to ISO 8601 formatting with optional timezone offsets
- document TIMEZONE environment variable usage and event format
- add tests covering default and custom timezone offsets

## Testing
- `npm test` *(fails: AssertionError expected 401 actual 500)*

------
https://chatgpt.com/codex/tasks/task_e_68ba75880784832d8f7e5dbe9698de90