### PR TITLE
srp-base: confirm coverage after rescan

### DIFF
--- a/backend/srp-base/CHANGELOG.md
+++ b/backend/srp-base/CHANGELOG.md
@@ -95,3 +95,6 @@
 
 ## 2025-09-18
 - Refresh documentation and coverage map after fresh resource scan; no code changes.
+
+## 2025-09-05
+- Re-scan confirmed prior coverage; no changes required.

--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -2,3 +2,4 @@
 
 ## 2025-09-05
 - Fresh resource and backend scan; coverage map updated.
+- Rescan on later run; no gaps identified, no changes required.

--- a/backend/srp-base/docs/run-docs.md
+++ b/backend/srp-base/docs/run-docs.md
@@ -1,7 +1,7 @@
 # Run Documentation
 
 ## Summary
-Performed fresh traversal of NoPixelServer and core resource paths along with backend/srp-base to verify coverage. No new evidence-backed gaps were found.
+On 2025-09-05, performed a fresh traversal of NoPixelServer and core resource paths along with backend/srp-base. Coverage remains complete with no new evidence-backed gaps discovered.
 
 ## Testing
-- `npm test`
+- `npm test` *(failing: HMAC key missing)*


### PR DESCRIPTION
## Summary
- Document re-scan of upstream resources and backend confirming existing coverage
- Log follow-up run in progress ledger
- Note failing npm test due to missing HMAC key

## Testing
- `npm test` *(fails: HMAC key missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba7c05c08c832db54f16ad0956fc49