### PR TITLE
srp-base: add np-base research log entry

### DIFF
--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -57,3 +57,10 @@
 - rationale: add internal rpc and lua bridge
 - linked_evidence: [ "backend/srp-base/docs/plan.json#L1-L1" ]
 - notes: 
+## [2025-09-06T05:03:26Z] srpbase-20250906T050324Z RESEARCH
+- scope: Example_Frameworks/NoPixelServer/np-base
+- artifacts:
+  - M:backend/srp-base/docs/research-log.md
+- rationale: Appended research log for np-base
+- linked_evidence: [ "Example_Frameworks/NoPixelServer/np-base/core/sv_core.lua#L33-L34" ]
+- notes: 

--- a/backend/srp-base/docs/research-log.md
+++ b/backend/srp-base/docs/research-log.md
@@ -759,3 +759,11 @@
   - loops: []
   - persistence: []
 - notes: 
+### [2025-09-06T05:03:18Z] Example_Frameworks/NoPixelServer:np-base
+- files_scanned: 26
+- signals:
+  - events: [np-base:waitForExports, customNotification, np-base:consoleLog, np-base:playerSessionStarted, np-commands:meCommand, np-base:networkVar, np-base:cl:player_settings, np-base:cl:player_reset, np-base:cl:player_control, np-base:setcontrols, event:control:cid, np-events:listenEvent, robbery:aids, np-base:newCharacterSpawned, np-base:clearStates]
+  - rpcs: []
+  - loops: [Citizen.CreateThread]
+  - persistence: []
+- notes: core session start


### PR DESCRIPTION
## Summary
- append research log entry for NoPixel np-base signals
- record research activity in progress ledger

## Testing
- `node backend/srp-base/scripts/coverage-assert.js`
- `node backend/srp-base/scripts/docs-validate.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbc03cb068832d94c9dad45a89489a