### PR TITLE
srp-base: verify coverage and docs via scripts

### DIFF
--- a/backend/srp-base/docs/progress-ledger.md
+++ b/backend/srp-base/docs/progress-ledger.md
@@ -64,3 +64,10 @@
 - rationale: Appended research log for np-base
 - linked_evidence: [ "Example_Frameworks/NoPixelServer/np-base/core/sv_core.lua#L33-L34" ]
 - notes: 
+## [2025-09-06T05:06:10Z] srpbase-20250906T050556Z RESEARCH
+- scope: Example_Frameworks/NoPixelServer
+- artifacts:
+  - M:backend/srp-base/docs/progress-ledger.md
+- rationale: Verified coverage and docs via scripts
+- linked_evidence: [ "SunnyRP:backend/srp-base/docs/coverage-map.md#L1-L30" ]
+- notes: 


### PR DESCRIPTION
## Summary
- record verification of coverage map and docs

## Testing
- `node backend/srp-base/scripts/coverage-assert.js`
- `node backend/srp-base/scripts/docs-validate.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbc0fa8cbc832d9bc552b0bd0f7bc4