### PR TITLE
docs: expand es_extended documentation

### DIFF
--- a/Example_Frameworks/es_extended/es_extended_Documentation.md
+++ b/Example_Frameworks/es_extended/es_extended_Documentation.md
@@ -1,7 +1,7 @@
 # es_extended Documentation
 
 ## Overview
-`es_extended` is the core of the ESX Legacy framework. It manages player data, inventory, jobs, accounts and exposes APIs used by other resources. Logic is split between client scripts, server scripts, shared utilities, a NUI interface, and locale files.
+`es_extended` provides the core systems of the ESX Legacy framework for SunnyRP. It manages player data, inventories, jobs, accounts, and exposes APIs consumed by other resources. Logic is divided into client scripts, server scripts, shared utilities, UI assets, and locale files.
 
 ## Table of Contents
 - [Top-Level Files](#top-level-files)
@@ -64,160 +64,187 @@
 
 ## Top-Level Files
 ### README.md
-Introduction to ESX Legacy, its purpose, and references to companion resources such as `esx_identity`, `esx_society`, and `esx_billing`.
+Introduces ESX Legacy and references related resources such as identity or society modules.
 
 ### LICENSE
-GPL license granting rights to redistribute and modify the project.
+GPL license granting rights to redistribute and modify the resource.
 
 ### agents.md
-Instructions for generating comprehensive documentation for the resource.
+Instructions directing contributors to generate comprehensive documentation for this resource.
 
 ### fxmanifest.lua
-Resource manifest defining shared, client, and server scripts; NUI files; exports for `getSharedObject`; and dependencies on `mysql-async`, `async`, and `spawnmanager`.
+Resource manifest declaring:
+- Shared scripts (locale handlers, configuration files).
+- Server scripts including database loader, player class, command handlers, and shared modules.
+- Client scripts like HUD/UI managers, NUI wrapper, and streaming utilities.
+- UI files and exported `getSharedObject` function for both client and server.
+- Dependencies on `mysql-async`, `async`, and `spawnmanager`.
 
 ### config.lua
-Global configuration:
+Central configuration toggles:
 - Locale selection and account labels.
-- Gameplay toggles for HUD display, PvP, identity and multicharacter support.
-- Inventory weight limit and paycheck interval.
+- Initial bankroll per account.
+- Feature switches (society payouts, HUD, default inventory, wanted level, PVP).
+- Gameplay limits such as inventory weight and paycheck interval.
+- Multicharacter and identity flags that alter player loading logic.
 
 ### config.weapons.lua
-Large table describing every weapon: label, components, available tints, and default tint names used by weapon APIs.
+Large table of weapon definitions. Each entry lists label, available components, supported tint options, and default tint names. Used by weapon handling APIs and UI labels.
 
 ### es_extended.sql
-Database schema creating `users`, `items`, `jobs`, and `job_grades` tables with default entries and field defaults.
+Database schema establishing persistent storage:
+- `users` table for player state, accounts, job, inventory, loadout, and coordinates.
+- `items` table describing weight and rarity of inventory items.
+- `job_grades` and `jobs` tables with default unemployed entries.
 
 ### imports.lua
-Exports the ESX shared object. On the client it listens for `esx:setPlayerData` to update cached player data when the event originates from this resource.
+Exports the ESX shared object for other resources. On the client it listens for `esx:setPlayerData` events and updates cached fields when they originate from this resource.
 
 ### locale.lua
-Lua helpers `_` and `_U` resolve translated strings based on `Config.Locale`, returning placeholders when a key or locale is missing.
+Provides translation helpers `_` and `_U` to resolve locale strings based on `Config.Locale` and capitalize them when needed.
 
 ### locale.js
-JavaScript translation utilities mirroring the Lua helpers. `_U` fetches and optionally formats strings from the loaded locale data and capitalizes the first letter.
+Browser-side translation utilities mirroring the Lua helpers. It exposes `_U` to fetch or format strings inside NUI pages and includes string formatting and capitalization helpers.
 
 ### version.json
-Metadata describing the legacy version and commit hash.
+Metadata identifying the legacy version and commit hash.
 
 ## Client Scripts
 ### client/common.lua
-Shares the ESX object with other client resources through the `esx:getSharedObject` event and a `getSharedObject` function.
+- Registers the `esx:getSharedObject` event to supply the global `ESX` table to other client resources.
+- Exposes `getSharedObject()` as an export for direct access.
 
 ### client/entityiter.lua
-Provides entity enumeration helpers. `EnumerateEntities` yields entities using native find functions, while `EnumerateEntitiesWithinDistance` filters entities within a specified range. Convenience wrappers enumerate objects, peds, vehicles, and pickups.
+- Implements coroutine-based enumerators for objects, peds, vehicles, and pickups via native find functions.
+- `EnumerateEntitiesWithinDistance` filters entities near a position; used by higher-level helpers in `ESX.Game`.
 
 ### client/functions.lua
-Defines the global `ESX` client API:
-- Data and timeout management (`SetTimeout`, `ClearTimeout`, `SetPlayerData`).
-- Notification helpers (`ShowNotification`, `ShowAdvancedNotification`, `ShowHelpNotification`, `ShowFloatingHelpNotification`).
-- RPC via `TriggerServerCallback` with response handling through `esx:serverCallback`.
-- HUD management (`ESX.UI.HUD` functions to register, update, delete, and reset elements).
-- Game utilities (`ESX.Game`): teleporting entities, spawning or deleting vehicles and objects, enumeration helpers, vehicle property getters/setters, and 3D text drawing.
-- Event handlers for server callbacks and display events: `esx:serverCallback`, `esx:showNotification`, `esx:showAdvancedNotification`, and `esx:showHelpNotification`.
+Defines the bulk of the client API and event handlers:
+- **Timeouts**: `ESX.SetTimeout` and `ESX.ClearTimeout` manage delayed callbacks using the game timer.
+- **Data Access**: `IsPlayerLoaded`, `GetPlayerData`, and `SetPlayerData` emit `esx:setPlayerData` when fields change.
+- **Notifications**: functions to show standard, advanced, help, and floating help notifications.
+- **Server Callbacks**: `TriggerServerCallback` sends `esx:triggerServerCallback` and awaits `esx:serverCallback` responses.
+- **HUD Management**: `ESX.UI.HUD` functions register, remove, reset, and update HUD elements through NUI messages.
+- **Menu System**: `ESX.UI.Menu` registers menu types and provides open, close, update, and query helpers for interactive menus.
+- **Game Utilities** (`ESX.Game`): teleport entities, spawn or delete objects/vehicles, enumerate nearby entities, draw 3D text, and derive vehicle properties (mods, colors, extras, etc.).
+- **Player Interactions**: opens the inventory interface, manages weapon tint/components, and draws notifications when items are added or removed.
+- **Event Handlers**: reacts to `esx:serverCallback`, `esx:setAccountMoney`, `esx:addInventoryItem`, `esx:removeInventoryItem`, `esx:useItem`, `esx:onPickup`, `esx:onPlayerDeath`, and scheduled restart events to keep the client state synchronized.
 
 ### client/main.lua
-Player lifecycle controller:
-- On join, disables auto-spawn and requests initialization from the server.
-- Handles `esx:playerLoaded` to spawn the player, enable HUD elements, restore loadout, and start sync loops that periodically update coordinates and weapon ammo.
-- Responds to events altering player state: logout (`esx:onPlayerLogout`), inventory (`esx:addInventoryItem`, `esx:removeInventoryItem`), accounts (`esx:setAccountMoney`), weapons (`esx:addWeapon`, `esx:setWeaponAmmo`, `esx:removeWeapon`, etc.), job changes (`esx:setJob`), teleports (`esx:teleport`), vehicle spawning/deletion, pickup creation, chat suggestions, and admin utilities (`esx:tpm`, `esx:noclip`, `esx:killPlayer`, `esx:freezePlayer`).
+Manages player lifecycle on the client:
+- On startup disables auto-spawn and requests the server to run `esx:onPlayerJoined`.
+- Handles `esx:playerLoaded` to spawn the player, load skin, enable PVP, initialize HUD, and start periodic sync loops.
+- Responds to logout and death events to update internal state and HUD.
+- Exposes player data to other scripts and synchronizes weapons, accounts, and inventory through events like `esx:setAccountMoney`, `esx:addInventoryItem`, `esx:removeInventoryItem`, `esx:restoreLoadout`, and `esx:setMaxWeight`.
 
 ### client/wrapper.lua
-Reassembles chunked NUI messages. When `__chunk` callbacks complete, it decodes the accumulated data and emits `<resource>:message:<type>` events.
+Receives chunked NUI messages via `__chunk`, reconstructs the original JSON payload, and triggers resource-specific events named `resource:message:type` once the final chunk arrives.
 
 ### client/modules/death.lua
-Monitors player death. When the player dies, gathers killer information and distance, then triggers `esx:onPlayerDeath` locally and on the server. Resets state on respawn.
+Continuously monitors the player ped for fatal injuries. When death occurs:
+- Determines killer information and distance if killed by another player.
+- Triggers local and server events `esx:onPlayerDeath` with contextual data.
 
 ### client/modules/scaleform.lua
-Convenience wrappers for displaying scaleform movies: freemode messages, breaking news tickers, popup warnings, and traffic camera clips. A utility function requests and caches scaleform movies.
+Utility for displaying Rockstar scaleform movies:
+- `ShowFreemodeMessage`, `ShowBreakingNews`, `ShowPopupWarning`, and `ShowTrafficMovie` request the appropriate movie and draw it for the specified duration.
 
 ### client/modules/streaming.lua
-Asset loading helpers ensuring models, textures, particle assets, animation sets/dicts, and weapon assets are requested and loaded before invoking callbacks.
+Provides helpers to load assets on demand:
+- `RequestModel`, `RequestStreamedTextureDict`, `RequestNamedPtfxAsset`, `RequestAnimSet`, `RequestAnimDict`, and `RequestWeaponAsset` wrap native requests and invoke an optional callback once the asset is loaded.
 
 ## Server Scripts
 ### server/common.lua
-Initializes the server-side ESX object. On database readiness it loads item and job data, prints status, and starts periodic player saving (`StartDBSync`) and paychecks (`StartPayCheck`). Provides events `esx:clientLog` for debug traces and `esx:triggerServerCallback` to dispatch registered server callbacks.
+Initializes the server-side `ESX` object:
+- Populates item and job definitions from the database when MySQL is ready.
+- Starts periodic database synchronization and paychecks (`StartDBSync`, `StartPayCheck`).
+- Registers `esx:getSharedObject`, `esx:clientLog`, and `esx:triggerServerCallback` events so other resources can access ESX, log debug messages, or request callbacks.
 
 ### server/functions.lua
-Core server utilities:
-- Debug tracing and timeout scheduling.
-- `ESX.RegisterCommand` with argument validation, chat suggestions, and ACE permission setup.
-- RPC registration (`RegisterServerCallback`) and invocation (`TriggerServerCallback`).
-- Persistence helpers `SavePlayer` and `SavePlayers` using prepared statements.
-- Player lookup (`GetPlayers`, `GetExtendedPlayers`, `GetPlayerFromId`, `GetPlayerFromIdentifier`, `GetIdentifier`).
-- Item and weapon helpers (`RegisterUsableItem`, `UseItem`, `GetItemLabel`, `CreatePickup`).
-- Employment check `DoesJobExist`.
+Server utilities and persistence:
+- Logging via `ESX.Trace` and timeout helpers `SetTimeout`/`ClearTimeout`.
+- `ESX.RegisterCommand` creates administrative and gameplay commands with ACE-based permissions and optional chat suggestions.
+- Callback framework: `RegisterServerCallback` and `TriggerServerCallback` allow RPC-style server/client communication.
+- Persistence routines: `SavePlayer` and `SavePlayers` serialize player accounts, job, inventory, loadout, and coordinates to the database.
+- Player management helpers (`GetPlayers`, `GetExtendedPlayers`, `GetPlayerFromId`, `GetIdentifier`, etc.).
+- Item interfaces: registering usable items, creating world pickups, verifying jobs, and retrieving item labels.
 
 ### server/main.lua
-Manages connection flow and gameplay events:
-- Sets map/game type on startup and prepares SQL statements for player creation and loading.
-- Handles player join via `esx:onPlayerJoined` or `playerConnecting`, creating or loading accounts (`createESXPlayer`, `loadESXPlayer`).
-- Cleans up on `playerDropped` and `esx:playerLogout` while saving data.
-- Updates server state on `esx:updateCoords` and `esx:updateWeaponAmmo`.
-- Item interactions: `esx:giveInventoryItem`, `esx:removeInventoryItem`, `esx:useItem`, `esx:onPickup`.
-- Provides callbacks `esx:getPlayerData`, `esx:getOtherPlayerData`, and `esx:getPlayerNames`.
-- Saves all players shortly before a scheduled txAdmin restart.
+Core player connect/disconnect flow:
+- Prepares SQL statements for inserting or loading users and sets map metadata on resource start.
+- Handles `playerConnecting` to guard against duplicate identifiers.
+- Functions `onPlayerJoined`, `createESXPlayer`, and `loadESXPlayer` insert new records or retrieve existing data, assemble accounts/inventory/loadout, and instantiate `ExtendedPlayer` objects.
+- Emits `esx:playerLoaded` to both server and client, registers command suggestions, and logs connections.
+- On `playerDropped` or `esx:playerLogout`, triggers `esx:playerDropped`, saves character data, and cleans up cached players.
+- Sync events: `esx:updateCoords` and `esx:updateWeaponAmmo` update stored data; `esx:giveInventoryItem`, `esx:useItem`, and `esx:onPickup` handle item transfer and pickups between players.
+- Server callbacks `esx:getPlayerData`, `esx:getOtherPlayerData`, and `esx:getPlayerNames` expose player information to clients.
+- Responds to `txAdmin` restart warnings by saving all players 10 seconds before restart.
 
 ### server/paycheck.lua
-`StartPayCheck` credits salaries at `Config.PaycheckInterval`. It can deduct funds from society accounts when configured and sends HUD notifications to players.
+`StartPayCheck` thread runs at `Config.PaycheckInterval` to credit salaries:
+- Deposits payment into player bank accounts.
+- Optionally deducts funds from society accounts when `Config.EnableSocietyPayouts` is enabled.
+- Sends HUD notifications using the bank icon.
 
 ### server/commands.lua
-Registers administrative and utility commands through `ESX.RegisterCommand`, including:
-- Teleport and job tools (`setcoords`, `setjob`, `car`, `cardel/dv`).
-- Economy controls (`setaccountmoney`, `giveaccountmoney`, `giveitem`, `giveweapon`, `giveweaponcomponent`).
-- Chat and data management (`clear`, `clearall`, `clearinventory`, `clearloadout`, `setgroup`, `save`, `saveall`).
-- Player info utilities (`group`, `job`, `info`, `coords`, `tpm`, `goto`, `bring`, `kill`, `freeze`, `unfreeze`, `reviveall`, `noclip`, `players`).
-Each command validates arguments and invokes the relevant player methods or events.
+Registers administrative and utility commands via `ESX.RegisterCommand`. Categories include:
+- **Teleport/Job Tools:** `setcoords`, `setjob`, `car`, `cardel`/`dv`, `tpm`, `goto`, `bring`.
+- **Economy Controls:** `setaccountmoney`, `giveaccountmoney`, `giveitem`, `giveweapon`, `giveweaponcomponent`.
+- **Player Management:** `clear`, `clearall`, `clearinventory`, `clearloadout`, `setgroup`, `save`, `saveall`, `kill`, `freeze`, `unfreeze`, `reviveall`, `noclip`.
+- **Information:** `group`, `job`, `info`, `coords`, `players`.
+Each command validates inputs, checks permissions, and triggers the appropriate player methods or notifications.
 
 ### server/classes/player.lua
-Defines the extended player object instantiated for each connection. Major method groups:
-- **Core**: `triggerEvent`, `setCoords`, `updateCoords`, `getCoords`, `kick`.
-- **Accounts**: `setMoney`, `addMoney`, `removeMoney`, `setAccountMoney`, `addAccountMoney`, `removeAccountMoney`, `getAccounts`, `getAccount`; these fire events like `esx:setAccountMoney`.
-- **Inventory**: `getInventory`, `getInventoryItem`, `addInventoryItem`, `removeInventoryItem`, `setInventoryItem`, weight checks (`getWeight`, `getMaxWeight`, `canCarryItem`, `canSwapItem`, `setMaxWeight`).
-- **Jobs and groups**: `setJob`, `getJob`, `setGroup`, `getGroup` with ACE permission bindings.
-- **Weapons**: `addWeapon`, `addWeaponComponent`, `addWeaponAmmo`, `updateWeaponAmmo`, `setWeaponTint`, `getWeaponTint`, `removeWeapon`, `removeWeaponComponent`, `removeWeaponAmmo`, `hasWeaponComponent`, `hasWeapon`, `getWeapon`.
-- **Messaging**: `showNotification` and `showHelpNotification` to push client prompts.
-Most mutators trigger matching client events so the HUD and inventory stay in sync.
+Defines the `ExtendedPlayer` class representing connected players. Major method groups include:
+- **Core:** event triggering, coordinate management, kicking, and ACE group synchronization.
+- **Accounts:** balance getters/setters for cash and custom accounts; fires `esx:setAccountMoney` when balances change.
+- **Inventory:** item getters/setters, add/remove operations, weight calculations, and capacity checks.
+- **Jobs & Groups:** assigns jobs or groups and binds ACE permissions accordingly.
+- **Weapons:** add/remove weapons, ammo, components, and tint management with server-to-client sync (`esx:setWeaponTint`, `esx:updateWeaponAmmo`).
+- **Messaging:** `showNotification` and `showHelpNotification` send HUD prompts to the client.
 
 ## Shared Modules
 ### common/functions.lua
-Utility functions shared across client and server:
-- Random string generation (`GetRandomString`).
-- Configuration and weapon accessors (`GetConfig`, `GetWeapon`, `GetWeaponFromHash`, `GetWeaponList`, `GetWeaponLabel`, `GetWeaponComponent`).
-- Debug table dump (`DumpTable`) and rounding proxy (`Round`).
+Cross-environment utilities:
+- Random string generation.
+- Accessors for configuration and weapon metadata (`GetConfig`, `GetWeapon`, `GetWeaponLabel`, `GetWeaponComponent`, etc.).
+- Debug table dumping and rounding helpers.
 
 ### common/modules/math.lua
-Math helpers including `Round`, digit grouping (`GroupDigits`) that respects locale symbols, and whitespace trimming (`Trim`).
+Math helpers such as rounding, digit grouping respecting locale separators, and string trimming.
 
 ### common/modules/table.lua
-Table helpers: size calculation, set conversion, search (`IndexOf`, `LastIndexOf`, `Find`, `FindIndex`), filter/map/clone utilities, concatenation (`Concat`), joining (`Join`), reversing (`Reverse`), deep cloning, and key-sorted iteration with `Sort`.
+Table utilities used across client and server: size calculation, set conversion, search helpers (`IndexOf`, `Find`), mapping/filtering, cloning, concatenation, joining, reversing, deep copying, and key-sorted iteration.
 
 ## UI and Assets
 ### html/ui.html
-NUI entry point embedding HUD and inventory notification containers, loading styles and scripts.
+NUI entry point that loads CSS and JavaScript, defines HUD containers, and hosts inventory notifications.
 
 ### html/css/app.css
-Defines fonts, layout, colors, and animations for HUD widgets and inventory notifications.
+Stylesheet controlling fonts, layout, colors, and animations for HUD elements and notifications.
 
 ### html/js/app.js
-Client-side HUD controller that registers, updates, and deletes elements, shows inventory notifications, and routes messages from Lua via the `onData` listener.
+Browser-side controller:
+- Registers, updates, and removes HUD elements via messages from Lua.
+- Displays inventory notifications and processes incoming NUI messages in `onData`.
 
 ### html/js/wrapper.js
-Breaks large JSON messages into fixed-size chunks and posts them back to Lua through `SendMessage`.
+Splits large JSON messages into fixed-size chunks and posts them to Lua via `SendMessage`, enabling transmission of large payloads.
 
 ### html/js/mustache.min.js
-Minified Mustache templating engine used to render HUD elements.
+Minified Mustache templating library used to render HUD templates.
 
 ### html/fonts/pdown.ttf
 ### html/fonts/bankgothic.ttf
-Custom fonts referenced by the UI stylesheet.
+Custom fonts referenced by the stylesheet.
 
 ### html/img/accounts/bank.png
 ### html/img/accounts/black_money.png
 ### html/img/accounts/money.png
-Icons displayed next to bank, illicit, and cash balances on the HUD.
+Account icons displayed next to bank, illicit, and cash balances on the HUD.
 
 ## Locale Files
-Each file registers translations for notifications, commands, weapons, and UI text in a specific language. Scripts select a locale via `Config.Locale`.
+Each file registers translations for notifications, commands, weapons, and UI text in the respective language. Scripts select one via `Config.Locale`.
 
 ### locales/br.lua
 Brazilian Portuguese translations.
@@ -253,9 +280,10 @@ Swedish translations.
 Traditional Chinese translations.
 
 ## Documentation Gaps
-- `config.weapons.lua` defines extensive weapon and component data not individually described here; consult the file for the full list.
-- External dependencies such as `esx_society`, `skinchanger`, and others provide events referenced in this resource but are documented elsewhere.
-- `server/commands.lua` contains many administrative commands; while major categories are summarized, individual argument details may require reviewing the source.
+- `config.weapons.lua` contains an extensive list of weapons and components; individual weapon attributes are not detailed here.
+- `client/functions.lua` and `server/functions.lua` expose numerous utility methods and events; only major categories are summarized.
+- `server/commands.lua` lists many commands; argument specifics and edge-case behaviors require reading the source.
+- External dependencies such as `esx_society` and `skinchanger` provide events referenced in this resource but are documented elsewhere.
 
 ## Conclusion
-`es_extended` supplies the foundational systems for SunnyRP’s ESX-based gameplay. Server scripts manage persistence, commands, and player state; client scripts provide interaction and HUD logic; shared modules offer utilities; UI assets display information; and locale files enable multilingual support.
+`es_extended` supplies the foundational systems for SunnyRP's ESX-based gameplay. Server scripts manage persistence, commands, and player state; client scripts handle interface and gameplay logic; shared modules offer utilities; UI assets display information; and locale files enable multilingual support.


### PR DESCRIPTION
## Summary
- expand `es_extended` resource documentation with per-file explanations and event references
- note coverage gaps for complex configs and external dependencies

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb739161c832dbea346e00d04057e