### PR TITLE
docs: enhance fsn_activities documentation

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/docs.md
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/docs.md
@@ -1,100 +1,91 @@
 # fsn_activities Documentation
 
 ## Overview and Runtime Context
-`fsn_activities` bundles small leisure features for the FiveM server. Only the yoga mini-game is operational; fishing and hunting scripts exist as stubs. All logic in this resource executes on the client and relies on utilities provided by `fsn_main` and the `mythic_notify` notification system.
+`fsn_activities` bundles small client‑side leisure features for the FiveM server. At present only a yoga mini‑game is functional; fishing and hunting are placeholders awaiting future development. All logic executes on the client and relies on utilities provided by `fsn_main` along with notifications from `mythic_notify`.
 
 ## File Inventory
-| Path | Type |
-|------|------|
-| `fxmanifest.lua` | shared manifest |
-| `yoga/client.lua` | client script |
-| `fishing/client.lua` | client placeholder |
-| `hunting/client.lua` | client placeholder |
+| Path | Role | Classification |
+|------|------|----------------|
+| `fxmanifest.lua` | Resource manifest and dependency declarations | shared |
+| `yoga/client.lua` | Yoga activity implementation | client |
+| `fishing/client.lua` | Placeholder for fishing activity | client |
+| `hunting/client.lua` | Placeholder for hunting activity | client |
 
 ## Client
 
 ### yoga/client.lua
-*Role*: Implements the yoga activity that lowers player stress.
+*Responsibilities*
+- Maps three yoga spots near Del Perro and draws a "Yoga Bliss" blip at the area entrance.
+- Binds start (`E`) and cancel (`DELETE`) controls using utility helpers.
+- Hosts three perpetual threads: one to prompt starting yoga, one to handle cancellation, and one to spawn blips on load.
+- Provides helper functions `PositionCheck`, `DoYoga`, and `cancelledYoga` to manage activity flow.
 
-*Key Data*
-- Binds start (`E`) and cancel (`DELETE`) keys using helper utilities.
-- Defines three yoga spots near Del Perro, a blip configuration for "Yoga Bliss," and distance thresholds for prompts.
+*Control Flow*
+1. **Blip Setup** – When the resource starts, a thread iterates configured blips and places them on the map.
+2. **Start Prompt** – Each frame the main loop checks distance to the yoga zone; within range it shows 3D text and starts `DoYoga` if the start key is pressed.
+3. **Cancellation** – A parallel loop monitors the cancel key while `doingYoga` is true; pressing the key triggers `cancelledYoga`.
+4. **Yoga Sequence** – `DoYoga` displays a preparation message, plays the built‑in yoga scenario for 15 seconds, emits `fsn_yoga:checkStress`, then clears the animation.
+5. **Stress Handling** – The local handler for `fsn_yoga:checkStress` verifies the session and triggers `fsn_needs:stress:remove` with an amount of 10 to lower stress.
 
-*Runtime Flow*
-1. **Blip Creation** – On resource load, a thread iterates configured blips and places them on the map.
-2. **Start Prompt** – A continuous thread checks the player's proximity to the yoga area. When within range, it displays 3D text inviting the player to press the start key; pressing begins `DoYoga`.
-3. **Cancellation** – A parallel thread monitors for the cancel key while yoga is active and, if pressed, calls `cancelledYoga` to terminate the scenario early and notify the user.
-4. **Yoga Sequence** – `DoYoga` shows a short preparation message, plays the built‑in yoga scenario for 15 seconds, then triggers `fsn_yoga:checkStress` before clearing the animation.
-5. **Stress Adjustment** – The local event handler for `fsn_yoga:checkStress` checks the session state and emits `fsn_needs:stress:remove` with an amount of `10` to decrease stress.
-
-*Security & Performance*
-- Entirely client‑side; server does not verify participation or stress changes.
-- Both monitoring threads run each frame (`Citizen.Wait(0)`), which may be tuned if performance becomes an issue.
+*Security & Performance Notes*
+- Stress reduction is handled entirely client‑side; no server validation prevents spoofed events.
+- Both main loops run every frame (`Citizen.Wait(0)`), which may be tuned if performance is a concern.
 
 *Integration Points*
-- Uses `exports['mythic_notify']:DoCustomHudText` for HUD messages.
-- Calls `fsn_needs:stress:remove` to interact with the needs system.
-- Depends on utility functions (`Util.GetKeyNumber`, `Util.GetVecDist`, `Util.DrawText3D`) provided by `@fsn_main`.
+- Uses utility exports from `@fsn_main` such as `Util.GetKeyNumber`, `Util.GetVecDist`, and `Util.DrawText3D`.
+- Invokes `exports['mythic_notify']:DoCustomHudText` for on‑screen messages *(Inferred: High)*.
+- Emits `fsn_needs:stress:remove` to interact with the needs system *(Inferred: High)*.
 
 ### fishing/client.lua
-*Role*: Placeholder file reserved for a future fishing activity.
-
-*Status*: Contains only a TODO comment; no logic and not referenced in the manifest.
+*Status*: Contains only a TODO comment; no functional code and not referenced in the manifest.
 
 ### hunting/client.lua
-*Role*: Placeholder for a potential hunting feature, possibly migrated from another resource.
-
-*Status*: Contains only a TODO comment; no logic and not referenced in the manifest.
+*Status*: Contains only a TODO comment suggesting a possible move from `fsn_jobs`; no functional code and not referenced in the manifest.
 
 ## Shared Configuration
 
 ### fxmanifest.lua
-*Role*: Declares resource metadata and script lists.
-
 *Responsibilities*
-- Specifies `bodacious` FX version, author, description, and version information.
-- Loads client utilities and server utilities from `fsn_main`; server section also pulls `@mysql-async/lib/MySQL.lua` despite this resource having no server scripts.
+- Declares `bodacious` FX version, author, description, and version metadata.
+- Loads shared utility scripts from `fsn_main` for both client and server.
+- Includes `@mysql-async/lib/MySQL.lua` even though the resource currently has no server logic, implying planned database usage *(Inferred: Low).* 
 - Registers `yoga/client.lua` as the sole client script; fishing and hunting scripts are omitted.
-
-*Integration Points*
-- Depends on `fsn_main` for both client and server helpers.
-- Includes `mysql-async` for prospective database access though none is present in the current code.
 
 ## Cross-Indexes
 
 ### Events
 | Name | Direction | Arguments | Notes |
 |------|-----------|-----------|-------|
-| `fsn_yoga:checkStress` | Handles | none | Local event fired after yoga finishes.
-| `fsn_needs:stress:remove` | Emits | `amount:number` | Requests stress reduction from the needs system *(Inferred: High)*.
+| `fsn_yoga:checkStress` | handles (client) | none | Fired after yoga completes to adjust stress. |
+| `fsn_needs:stress:remove` | emits (client) | `amount:number` | Requests stress reduction from needs system *(Inferred: High).* |
+
+### ESX Callbacks
+- None.
 
 ### Exports
 | Name | Usage | Notes |
 |------|-------|-------|
-| `mythic_notify:DoCustomHudText` | Called | Displays custom HUD text *(Inferred: High)*.
+| `mythic_notify:DoCustomHudText` | called (client) | Displays custom HUD messages *(Inferred: High).* |
 
 ### Commands
-- None.
-
-### ESX Callbacks
 - None.
 
 ### NUI Channels
 - None.
 
 ### Database Calls
-- None, though `mysql-async` is loaded in the manifest.
+- None, though `mysql-async` is listed in the manifest *(Inferred: Low).* 
 
 ## Configuration & Integration Points
-- `@fsn_main/server_settings/sh_settings.lua` supplies shared configuration values.
-- `@mysql-async/lib/MySQL.lua` is included for future server-side persistence.
+- Relies on `@fsn_main/server_settings/sh_settings.lua` for shared settings.
+- Future server‑side features may use `@mysql-async/lib/MySQL.lua` for persistence *(Inferred: Low).* 
 
 ## Gaps & Inferences
-- Fishing and hunting modules are placeholders awaiting implementation. *TODO: add activities and register in manifest.*
-- Inclusion of `mysql-async` without server logic suggests planned database interactions *(Inferred: Low).*
-- `fsn_needs:stress:remove` and `mythic_notify:DoCustomHudText` behaviours are deduced from naming and context *(Inferred: High).*
+- Fishing and hunting modules are empty stubs awaiting implementation. **TODO:** add activities and register them in the manifest when ready.
+- Inclusion of `mysql-async` without server scripts suggests planned database features *(Inferred: Low).* 
+- Stress removal and notification behaviours are deduced from naming conventions *(Inferred: High).* 
 
 ## Conclusion
-Currently the resource provides only client-side yoga functionality. It registers activity locations, manages player prompts, and reduces stress through the needs system. Additional recreational features are scaffolded but inactive.
+The resource currently provides a single client‑side yoga mini‑game that reduces player stress. Additional activities are scaffolded but inactive. Future work may involve implementing fishing and hunting, adding server‑side verification, and utilising database support.
 
 DOCS COMPLETE


### PR DESCRIPTION
## Summary
- expand documentation for `fsn_activities` resource
- detail yoga flow, dependencies, and integration points
- record gaps for pending fishing and hunting features

## Testing
- `luacheck Example_Frameworks/FiveM-FSN-Framework/fsn_activities/yoga/client.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ee831d14832da6e65ec54f99ac41