### PR TITLE
docs: expand fsn_admin resource documentation

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_admin/docs.md
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_admin/docs.md
@@ -1,7 +1,7 @@
 # fsn_admin Documentation
 
 ## Overview and Runtime Context
-`fsn_admin` supplies moderation utilities for FSN-based FiveM servers. It grants privileged chat, teleportation, player management, and punishment features while integrating with the FSN framework, MySQL, and other FSN resources.
+`fsn_admin` supplies moderation utilities for FSN-based FiveM servers. It grants privileged chat, teleportation, player management and punishment features while integrating with the FSN framework, MySQL and other FSN resources.
 
 ## File Inventory
 | Path | Type | Description |
@@ -14,6 +14,7 @@
 | server.lua | Server (legacy) | Earlier monolithic script containing command parsing and mixed logic. |
 | server_announce.lua | Server (legacy) | Commented example for timed restart broadcasts. |
 | oldresource.lua | Shared (legacy) | Historical manifest referencing legacy scripts. |
+| docs.md | Docs | This documentation file. |
 
 ## Client Files
 ### client/client.lua
@@ -24,33 +25,32 @@ Responsibilities:
 - Collects the player’s current coordinates when requested (`fsn_admin:requestXYZ`) and forwards them to the server through `fsn_admin:sendXYZ`.
 - Teleports the player when coordinates arrive from the server (`fsn_admin:recieveXYZ`).
 - Toggles local freeze status (`fsn_admin:FreezeMe`) and emits chat notifications reflecting the state change.
-- Utilizes an external `SpawnVehicle` utility (origin not in this resource).
+- Relies on an external `SpawnVehicle` utility to instantiate vehicles (Inferred Low).
 
 ### client.lua (legacy)
-Role: Prior client implementation; retains teleport and freeze handlers using basic `chatMessage` outputs. Not referenced by the manifest.
+Role: Earlier client implementation using basic `chatMessage` outputs; retains teleport and freeze handlers.
 
 ## Server Files
 ### server/server.lua
 Role: Main authority for privilege checks, command registration, and moderation flows.
 
 Responsibilities:
-- Retrieves the shared FSN object on startup to access player lookups.
-- Permission helpers `isModerator`/`isAdmin` and identifier fetchers `fsn_GetModeratorId`/`fsn_GetAdminId` validate players against `Config` lists.
-- **Command registration** through `registerModeratorCommands` and `registerAdminCommands`:
-  - Staff chat (`sc`) for moderators or admins.
-  - Placeholders for menus (`adminmenu`, `amenu`).
-  - Moderation actions (`freeze`, `announce`, `goto`, `bring`, `kick`, `ban`). Console invocations of `announce`, `kick`, and `ban` are supported.
-  - `registerModeratorCommands` re-registers `sc` each time it runs, which may conflict if multiple moderators connect (Inferred Medium).
-- **Suggestion registration** via `registerModeratorSuggestions`/`registerAdminSuggestions` so privileged players see guidance in the chat UI. These functions are duplicated later in the file (Inferred Low).
+- **FSN Object Retrieval**: A thread repeatedly triggers `fsn:getFsnObject` until the shared API is acquired; lack of delay in the loop may consume CPU (Inferred High).
+- **Permission Helpers**: `isModerator`/`isAdmin` validate players against `Config` lists. `fsn_GetModeratorId`/`fsn_GetAdminId` return player names for message templates.
+- **Command Registration**:
+  - `registerModeratorCommands` creates `/sc` for staff chat. Each moderator reconnect re-registers the command, possibly causing duplicates (Inferred Medium).
+  - `registerAdminCommands` establishes `/sc`, `/adminmenu`, `/amenu`, `/freeze`, `/announce`, `/goto`, `/bring`, `/kick`, and `/ban`. Console access is allowed for `announce`, `kick`, and `ban`.
+- **Suggestion Helpers**: `registerModeratorSuggestions` and `registerAdminSuggestions` add chat suggestions. Functions are duplicated later in file (Inferred Low).
 - **Events**:
-  - `fsn_admin:enableModeratorCommands` and `fsn_admin:enableAdminCommands` initialize suggestions and command sets when a player is recognized as privileged.
-  - `fsn:playerReady` fires on join, checking roles and triggering the above events.
-  - `onResourceStart` ensures admin commands exist even before any admin connects.
-- **Teleportation**: `goto` and `bring` request coordinates from targets via `fsn_admin:requestXYZ` but pass an extra unused argument (Inferred Medium). The client responds with `fsn_admin:sendXYZ`, yet no handler exists here (Inferred High).
-- **Database**: `ban` writes ban duration and reason to `fsn_users` using `MySQL.Async.execute`. The query includes an extra comma before `WHERE` (Inferred High).
+  - `fsn_admin:enableModeratorCommands` runs suggestions and command registration when a moderator joins.
+  - `fsn_admin:enableAdminCommands` adds admin suggestions. Admin commands are pre-registered on resource start.
+  - `fsn:playerReady` checks permissions after a player connects.
+  - `onResourceStart` ensures admin commands exist even if no admin is online.
+- **Teleportation**: `/goto` and `/bring` request coordinates via `fsn_admin:requestXYZ`, sending an extra unused target parameter (Inferred Medium). The server lacks a `fsn_admin:sendXYZ` handler, so returns are ignored (Inferred High).
+- **Punishment**: `/kick` and `/ban` remove players. `ban` writes to `fsn_users`, but the query includes an extra comma before `WHERE` (Inferred High). Duration table assigns `4d` to `354600` seconds and `2m` to roughly six days (Inferred High).
 
 ### server.lua (legacy)
-Role: Earlier monolithic script parsing `/admin` subcommands. Contains both server and client calls and implements handlers now absent from the current server logic.
+Role: Earlier monolithic script parsing chat commands. Implements handlers now absent from the current server logic.
 
 Key features:
 - Parses chat commands like `/ac`, `/am`, `/amenu`, `/admin freeze`, `/admin goto`, `/admin bring`, `/admin kick`, `/admin ban`, and `/admin announce`.
@@ -76,23 +76,23 @@ Historical manifest that loaded legacy scripts (`client.lua`, `server.lua`, `ser
 ### Events
 | Event | Direction | Payload | Notes |
 |---|---|---|---|
-| `fsn_admin:spawnVehicle` | Server → Client | `vehmodel` (string) | Creates a vehicle and notifies other resources. |
+| `fsn_admin:spawnVehicle` | Server → Client | `vehmodel` (string) | Creates a vehicle and notifies other resources; no server command triggers it (Inferred Low). |
 | `fsn_admin:requestXYZ` | Server → Client | `sendto` (number) | Server also sends an extra target ID ignored by the client (Inferred Medium). |
-| `fsn_admin:sendXYZ` | Client → Server | `sendto` (number), `{x,y,z}` | No handler in current server code; legacy server forwards coordinates (Inferred High). |
+| `fsn_admin:sendXYZ` | Client → Server (legacy) | `sendto` (number), `{x,y,z}` | No handler in current server code; legacy server forwards coordinates (Inferred High). |
 | `fsn_admin:recieveXYZ` | Server → Client | `{x,y,z}` | Teleports player. |
 | `fsn_admin:FreezeMe` | Server → Client | `adminName` (string) | Toggles freeze state. |
 | `fsn_admin:enableAdminCommands` | Server event | player ID | Registers admin suggestions. |
-| `fsn_admin:enableModeratorCommands` | Server event | player ID | Registers moderator suggestions and commands. |
+| `fsn_admin:enableModeratorCommands` | Server event | player ID | Registers moderator suggestions and `/sc` command; duplicates are possible (Inferred Medium). |
 | `fsn:playerReady` | Server event | none | Performs role check on join. |
 | `onResourceStart` | Server event | `resourceName` | Pre-registers admin commands. |
 | `chat:addMessage` | Server → Client | template, args | Sends staff chat and feedback messages. |
 | `chat:addSuggestion` | Server → Client | command, help, args | Populates chat suggestions. |
-| `fsn_admin:spawnCar` | Net event (legacy client) | `car` (model name) | Spawns vehicle locally; defined in legacy server.lua (Inferred High). |
-| `fsn_admin:fix` | Net event (legacy client) | none | Repairs current vehicle; legacy only (Inferred High). |
-| `fsn_admin:menu:toggle` | Client → NUI | none | Opens admin menu (legacy). |
-| `chatMessage` | Server event (legacy) | source, auth, msg | Parses chat-based commands. |
 | `fsn_cargarage:makeMine` | Client event | vehicle, model, plate | Claims spawned vehicle. |
 | `fsn_notify:displayNotification` | Client event | message, position, duration, type | Displays notifications. |
+| `fsn_admin:spawnCar` | Net event (legacy) | `car` (model name) | Spawns vehicle using client natives in server script (Inferred High). |
+| `fsn_admin:fix` | Net event (legacy) | none | Repairs vehicle; uses client natives in server script (Inferred High). |
+| `fsn_admin:menu:toggle` | Server → Client → NUI | none | Opens admin menu (legacy). |
+| `chatMessage` | Server event (legacy) | source, auth, msg | Parses chat-based commands. |
 
 ### Commands
 | Command | Permission | Function |
@@ -104,7 +104,7 @@ Historical manifest that loaded legacy scripts (`client.lua`, `server.lua`, `ser
 | `goto` | Admin | Teleport to target (requires `fsn_admin:sendXYZ`). |
 | `bring` | Admin | Bring target to admin (requires `fsn_admin:sendXYZ`). |
 | `kick` | Admin or console | Remove target with reason. |
-| `ban` | Admin or console | Ban target; durations: `1d`, `2d`, `3d`, `4d`, `5d`, `6d`, `1w`, `2w`, `3w`, `1m`, `2m`, `perm` (`2m` ≈ 6 days, Inferred Medium). |
+| `ban` | Admin or console | Ban target; durations: `1d`, `2d`, `3d`, `4d`, `5d`, `6d`, `1w`, `2w`, `3w`, `1m`, `2m`, `perm` (`4d` and `2m` miscalculated, Inferred High). |
 | `/ac` | Admin (legacy) | Staff chat via old command. |
 | `/am`, `/amenu` | Admin (legacy) | Toggle admin menu. |
 | `/admin freeze` | Admin (legacy) | Toggle frozen state via chat command. |
@@ -119,7 +119,7 @@ Historical manifest that loaded legacy scripts (`client.lua`, `server.lua`, `ser
 | File & Location | Query | Purpose | Notes |
 |---|---|---|---|
 | `server/server.lua` (`ban`) | `UPDATE fsn_users SET banned = @unban, banned_r = @reason, WHERE steamid = @steamId` | Stores ban data | Extra comma before `WHERE` breaks query (Inferred High). |
-| `server.lua` (`/admin ban`) | `UPDATE fsn_users SET banned = @unban, banned_r = @reason WHERE steamid = @steamid` | Legacy ban implementation | Uses MySQL Async. |
+| `server.lua` (`/admin ban`) | `UPDATE fsn_users SET banned = @unban, banned_r = @reason WHERE steamid = @steamid` | Legacy ban implementation | Times table contains typos for `4d` and `2m` (Inferred High). |
 
 ### NUI Channels
 | Channel | Purpose |
@@ -139,14 +139,18 @@ None; resource uses FSN framework.
 - Utilizes FiveM chat events for command suggestions and message display.
 
 ## Gaps & Inferences
-- **Absent `fsn_admin:sendXYZ` handler** – Needed for `goto` and `bring` to function (Inferred High).
+- **Missing `fsn_admin:sendXYZ` handler** – Needed for `goto` and `bring` to function (Inferred High).
 - **`fsn_admin:requestXYZ` parameter mismatch** – Server sends an unused extra argument (Inferred Medium).
 - **Duplicate suggestion helpers** – `registerModeratorSuggestions`/`registerAdminSuggestions` appear twice (Inferred Low).
 - **Repeated `sc` registration** – `registerModeratorCommands` registers a global command each time it runs (Inferred Medium).
-- **Ban duration for `2m`** – Value `529486` seconds equates to ~6 days rather than two months (Inferred Medium).
+- **Ban durations mis-specified** – `4d` uses 354600 seconds and `2m` equals ~6 days (Inferred High).
 - **Database query typo** – Extra comma before `WHERE` in `server/server.lua` `ban` query (Inferred High).
+- **Busy wait for FSN object** – Thread loops without delay until FSN object is available (Inferred High).
 - **Legacy server.lua mixes contexts** – Uses client natives in a server script (Inferred High).
 - **Vehicle spawn trigger source** – Client listens for `fsn_admin:spawnVehicle` without a corresponding server command; likely from an external admin menu (Inferred Low).
 - **`SpawnVehicle` utility missing** – Assumed provided by another resource (Inferred Low).
+
+TODO:
+- Determine origin of `fsn_admin:spawnVehicle` trigger and document its invocation once identified.
 
 DOCS COMPLETE


### PR DESCRIPTION
## Summary
- fully document fsn_admin moderation resource with file inventory and runtime context
- add detailed event, command, and database cross‑indexes
- note missing handlers, duplicate registrations, and database typos for follow‑up

## Testing
- no tests available

------
https://chatgpt.com/codex/tasks/task_e_68c10159f334832d9dbd3be850331ac3