### PR TITLE
docs: expand fsn_admin event index

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_admin/docs.md
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_admin/docs.md
@@ -87,6 +87,7 @@ Historical manifest that loaded legacy scripts (`client.lua`, `server.lua`, `ser
 | `onResourceStart` | Server event | `resourceName` | Pre-registers admin commands. |
 | `chat:addMessage` | Server → Client | template, args | Sends staff chat and feedback messages. |
 | `chat:addSuggestion` | Server → Client | command, help, args | Populates chat suggestions. |
+| `fsn:getFsnObject` | Server event | callback | Retrieves shared FSN API; loop lacks wait (Inferred High). |
 | `fsn_cargarage:makeMine` | Client event | vehicle, model, plate | Claims spawned vehicle. |
 | `fsn_notify:displayNotification` | Client event | message, position, duration, type | Displays notifications. |
 | `fsn_admin:spawnCar` | Net event (legacy) | `car` (model name) | Spawns vehicle using client natives in server script (Inferred High). |


### PR DESCRIPTION
## Summary
- document `fsn:getFsnObject` retrieval event in fsn_admin cross-index

## Testing
- `/usr/bin/npm test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c102d81f48832dbaaf5199f2748122