### PR TITLE
docs: expand fsn_bennys resource docs

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_bennys/docs.md
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_bennys/docs.md
@@ -3,53 +3,72 @@
 ## Overview
 Benny's Motorworks customization interface for the FiveM FSN framework. The resource is entirely client-side and supplies a menu-driven garage that lets players preview and purchase vehicle upgrades.
 
+## Table of Contents
+- [Runtime Context](#runtime-context)
+- [Client Scripts](#client-scripts)
+  - [menu.lua](#menu.lua)
+  - [cl_config.lua](#cl_configlua)
+  - [cl_bennys.lua](#cl_bennyslua)
+- [Server Scripts](#server-scripts)
+- [Shared Files](#shared-files)
+- [Meta Files](#meta-files)
+  - [fxmanifest.lua](#fxmanifestlua)
+  - [agents.md](#agentsmd)
+- [Cross-Index](#cross-index)
+- [Configuration & Integration Points](#configuration--integration-points)
+- [Gaps & Inferences](#gaps--inferences)
+
 ## Runtime Context
 - Runs on the client; no in-resource server scripts.
 - Depends on `fsn_main` utilities for drawing prompts and checking player funds.
 - Uses `mythic_notify` to display HUD messages.
 - Declares MySQL and server-side utilities in the manifest but does not call them directly.
 
-## Client Files
-### fxmanifest.lua
-**Role:** Manifest
-
-Lists script files and external dependencies for both client and server runtime. Server script entries reference utilities and MySQL libraries from other resources but there are no local server scripts.
-
+## Client Scripts
 ### menu.lua
-**Role:** Client Library
+**Role:** Client library for building interactive menus.
 
-Implements a reusable menu system used to present modification options.
-- `Menu.new` builds a menu with configurable position, size, colors, and control bindings.
-- Rendering helpers draw text and info boxes with GTA natives.
-- Navigation functions (`Open`, `ChangeMenu`, `Close`, `draw`) manage menu visibility, selection state, and input handling.
-- Button constructors (`addButton`, `addPurchase`, `addList`, `addCheckbox`, `addSubMenu`) generate interactive entries.
-- `SetMenu` exposes the menu metatable so other scripts can instantiate menus.
+- `Menu.new` constructs menu instances with configurable position, size, colors, and control bindings.
+- Rendering helpers draw text and informational overlays using GTA natives.
+- Navigation helpers (`Open`, `ChangeMenu`, `Close`, `draw`) control visibility, selection, and input polling.
+- Button builders (`addButton`, `addPurchase`, `addList`, `addCheckbox`, `addSubMenu`) create interactive entries with optional prices and callbacks.
+- `SetMenu` exposes the menu metatable globally so other scripts can instantiate menus.
 
-**Security & Performance:** Menu drawing and input polling run every frame while the menu is open, which can consume CPU if misused.
+**Security & Performance:** The `draw` loop executes every frame while menus are open; excessive usage can impact client FPS.
 
 ### cl_config.lua
-**Role:** Client Configuration
+**Role:** Client configuration defining garage behavior and pricing.
 
-Provides data that defines garage behavior.
-- `Config.XYZ` specifies garage coordinates where interaction is allowed.
-- `Config.prices` contains pricing tables for window tint, resprays, neon options, plates, wheel accessories and colors, and a `mods` table mapping modification IDs to price schemes.
-- `Config.ModelBlacklist` lists vehicle models that cannot be customized.
-- `Config.lock` and `Config.oldenter` toggle garage access rules.
-- `Config.menu` configures control bindings, position, theme, button count, and menu size.
+- `Config.XYZ` specifies the world coordinates where interaction with the garage is allowed.
+- `Config.prices` provides pricing tables for tints, resprays, neon kits, plates, wheel accessories, colors, and a `mods` table mapping modification IDs to costs and increments.
+- `Config.ModelBlacklist` prevents specified vehicle models from being customized.
+- `Config.lock` and `Config.oldenter` toggle access restrictions and legacy interaction style.
+- `Config.menu` sets control bindings, layout, theme, button count, and menu size.
 
 ### cl_bennys.lua
-**Role:** Client Runtime Logic
+**Role:** Client runtime logic handling player interaction with the garage.
 
-Controls player interaction with the garage.
-- Establishes a `BennysMenu` instance from `menu.lua` and defines high‑level categories.
-- Thread monitors distance to `Config.XYZ`; when close and not already inside, it prompts via `Util.DrawText` and opens the menu on Enter.
-- `EnterGarage` verifies the player is driving, disables HUD and controls, and populates the menu with repair and modification options using `AddMod`.
-- `BennysMenu:onButtonSelected` uses `fsn_main:fsn_CanAfford` to verify funds and displays results with `mythic_notify:DoHudText`.
-- `AddMod` scans available vehicle mods and builds purchase buttons based on `Config.prices.mods`.
+- Initializes `BennysMenu` from `menu.lua` and defines high-level modification categories.
+- A `Citizen.CreateThread` constantly monitors distance to `Config.XYZ`. When a player approaches and isn't already inside, `Util.DrawText` prompts them to press Enter.
+- `EnterGarage` verifies the player is driving, disables radar and controls, sets up the menu, and populates it with repair and modification options via `AddMod`.
+- `BennysMenu:onButtonSelected` checks affordability through `fsn_main:fsn_CanAfford` and displays results using `mythic_notify:DoHudText`.
+- `AddMod` scans available vehicle mods and generates purchase buttons using `Config.prices.mods` for pricing.
 
-**Security & Performance:** Affordability checks are client-side only; final purchase enforcement must occur in another resource. The proximity thread uses a zero‑delay loop which may impact performance when many players are near the garage.
+**Security & Performance:** Affordability is verified only on the client; another resource must enforce payment and apply upgrades. The proximity thread uses a zero-delay loop that may affect performance when many players gather nearby.
+
+## Server Scripts
+None. The manifest lists server utilities from other resources, but this resource supplies no server-side logic.
+
+## Shared Files
+None.
 
 ## Meta Files
+### fxmanifest.lua
+**Role:** Resource manifest.
+
+- Declares `@fsn_main` utilities and `@mysql-async/lib/MySQL.lua` for compatibility with server-side systems.
+- Lists local client scripts (`menu.lua`, `cl_config.lua`, `cl_bennys.lua`) but no local server scripts.
+
 ### agents.md
 Documentation instructions for contributors.
 
@@ -67,11 +86,13 @@ Documentation instructions for contributors.
 ## Configuration & Integration Points
 - Coordinates and pricing are adjustable in `cl_config.lua`.
 - Menu appearance and control bindings are driven by `Config.menu`.
-- Monetary validation and notifications rely on exports from external resources.
+- Monetary validation and HUD messages rely on external exports from `fsn_main` and `mythic_notify`.
 
 ## Gaps & Inferences
-- `Util.DrawText` prompts players near the garage; function comes from `fsn_main` utilities. *Inferred (High).* 
-- Purchases only verify affordability on the client and do not deduct money or apply upgrades. Enforcement is presumed to occur elsewhere. *Inferred (Medium).* **TODO:** Identify server-side handler that finalizes transactions.
-- `@mysql-async/lib/MySQL.lua` is declared in the manifest despite no database calls. *Inferred (High).* Possibly a leftover dependency.
+- `Util.DrawText` used for interaction prompts appears in `fsn_main` utilities. *Inferred (High).* 
+- Purchases only check affordability on the client and do not deduct money or apply upgrades. Enforcement is presumed to occur in another resource. *Inferred (Medium).* **TODO:** Identify the server-side handler that finalizes transactions.
+- `@mysql-async/lib/MySQL.lua` is declared despite no database usage. *Inferred (High).* Likely a leftover dependency.
+- A trailing `SetPlayerControl(PlayerId(),true,256)` is marked as debug and may remain from testing. *Inferred (Low).* Removal is recommended for production.
 
 DOCS COMPLETE
+


### PR DESCRIPTION
## Summary
- add full table-of-contents and runtime context for fsn_bennys
- document client scripts, manifest, and integration points
- record gaps like missing server enforcement and unused mysql dep

## Testing
- `rg -n "RegisterNetEvent|TriggerEvent|AddEventHandler|RegisterCommand|ESX|exports\[" Example_Frameworks/FiveM-FSN-Framework/fsn_bennys`


------
https://chatgpt.com/codex/tasks/task_e_68c128e806e4832da92625c3d495c6b8