### PR TITLE
refactor: modernize rconlog and chat resources

### DIFF
--- a/Example_Frameworks/cfx-server-data/resources/[gameplay]/chat/sv_chat.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[gameplay]/chat/sv_chat.lua
@@ -26,7 +26,7 @@ local hookIdx = 1
 
 exports('registerMessageHook', function(hook)
     local resource = GetInvokingResource()
-    hooks[hookIdx + 1] = {
+    hooks[hookIdx] = {
         fn = hook,
         resource = resource
     }

--- a/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/fxmanifest.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/fxmanifest.lua
@@ -9,7 +9,8 @@ repository 'https://github.com/citizenfx/cfx-server-data'
 client_script 'rconlog_client.lua'
 server_script 'rconlog_server.lua'
 
-fx_version 'adamant'
+fx_version 'cerulean'
+lua54 'yes'
 games { 'gta5', 'rdr3' }
 
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'

--- a/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_client.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_client.lua
@@ -3,23 +3,21 @@ RegisterNetEvent('rlUpdateNames')
 AddEventHandler('rlUpdateNames', function()
     local names = {}
 
-    for i = 0, 31 do
-        if NetworkIsPlayerActive(i) then
-            names[GetPlayerServerId(i)] = { id = i, name = GetPlayerName(i) }
-        end
+    for _, player in ipairs(GetActivePlayers()) do
+        names[GetPlayerServerId(player)] = { id = player, name = GetPlayerName(player) }
     end
 
     TriggerServerEvent('rlUpdateNamesResult', names)
 end)
 
-Citizen.CreateThread(function()
-	while true do
-		Wait(0)
+CreateThread(function()
+    while true do
+        Wait(0)
 
-		if NetworkIsSessionStarted() then
-			TriggerServerEvent('rlPlayerActivated')
+        if NetworkIsSessionStarted() then
+            TriggerServerEvent('rlPlayerActivated')
 
-			return
-		end
-	end
+            return
+        end
+    end
 end)

--- a/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_server.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_server.lua
@@ -1,11 +1,21 @@
-RconLog({ msgType = 'serverStart', hostname = 'lovely', maxplayers = 32 })
+RconLog({
+    msgType = 'serverStart',
+    hostname = GetConvar('sv_hostname', 'unknown'),
+    maxplayers = GetConvarInt('sv_maxclients', 32)
+})
 
-RegisterServerEvent('rlPlayerActivated')
+RegisterNetEvent('rlPlayerActivated')
 
 local names = {}
 
 AddEventHandler('rlPlayerActivated', function()
-    RconLog({ msgType = 'playerActivated', netID = source, name = GetPlayerName(source), guid = GetPlayerIdentifiers(source)[1], ip = GetPlayerEP(source) })
+    RconLog({
+        msgType = 'playerActivated',
+        netID = source,
+        name = GetPlayerName(source),
+        guid = GetPlayerIdentifiers(source)[1],
+        ip = GetPlayerEndpoint(source)
+    })
 
     names[source] = { name = GetPlayerName(source), id = source }
 
@@ -14,7 +24,7 @@ AddEventHandler('rlPlayerActivated', function()
 	end
 end)
 
-RegisterServerEvent('rlUpdateNamesResult')
+RegisterNetEvent('rlUpdateNamesResult')
 
 AddEventHandler('rlUpdateNamesResult', function(res)
     if source ~= tonumber(GetHostId()) then
@@ -61,7 +71,7 @@ AddEventHandler('rconCommand', function(commandName, args)
             if guid and guid[1] and data then
                 local ping = GetPlayerPing(netid)
 
-                RconPrint(netid .. ' ' .. guid[1] .. ' ' .. data.name .. ' ' .. GetPlayerEP(netid) .. ' ' .. ping .. "\n")
+                RconPrint(netid .. ' ' .. guid[1] .. ' ' .. data.name .. ' ' .. GetPlayerEndpoint(netid) .. ' ' .. ping .. "\n")
             end
         end
 


### PR DESCRIPTION
## Summary
- modernize rconlog's native usage and manifest
- simplify player name sync client loop
- fix message hook registration in chat server

## Testing
- `luac -p Example_Frameworks/cfx-server-data/resources/'[gameplay]'/chat/sv_chat.lua`
- `luac -p Example_Frameworks/cfx-server-data/resources/'[system]'/rconlog/rconlog_client.lua`
- `luac -p Example_Frameworks/cfx-server-data/resources/'[system]'/rconlog/rconlog_server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1a24516ac832dad03fc96568e51b6