### PR TITLE
refactor: modernize skater map resource

### DIFF
--- a/Example_Frameworks/cfx-server-data/resources/[gamemodes]/[maps]/fivem-map-skater/fxmanifest.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[gamemodes]/[maps]/fivem-map-skater/fxmanifest.lua
@@ -1,14 +1,21 @@
--- This resource is part of the default Cfx.re asset pack (cfx-server-data)
--- Altering or recreating for local use only is strongly discouraged.
+--[[
+    -- Type: Manifest
+    -- Name: fivem-map-skater
+    -- Use: Defines metadata for the skater spawn map
+    -- Updated: 2024-05-31
+    -- By: VSSVSSN
+--]]
 
-version '1.0.0'
+fx_version 'cerulean'
+lua54 'yes'
+game 'gta5'
+
+version '1.1.0'
 author 'Cfx.re <root@cfx.re>'
 description 'Example spawn points for FiveM with a "skater" model.'
 repository 'https://github.com/citizenfx/cfx-server-data'
 
+this_is_a_map 'yes'
 resource_type 'map' { gameTypes = { ['basic-gamemode'] = true } }
 
 map 'map.lua'
-
-fx_version 'adamant'
-game 'gta5'

--- a/Example_Frameworks/cfx-server-data/resources/[gamemodes]/[maps]/fivem-map-skater/map.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[gamemodes]/[maps]/fivem-map-skater/map.lua
@@ -1,62 +1,75 @@
-spawnpoint 'a_m_y_skater_01' { x = -802.311, y = 175.056, z = 72.8446 }
-spawnpoint 'a_m_y_skater_02' { x = -9.96562, y = -1438.54, z = 31.1015 }
-spawnpoint 'a_m_y_skater_01' { x = 0.916756, y = 528.485, z = 174.628 }
-spawnpoint 'a_m_y_skater_02' { x = 1975.86, y = 3821.03, z = 33.4501 }
-spawnpoint 'a_m_y_skater_01' { x = -181.615, y = 852.8, z = 232.701 }
-spawnpoint 'a_m_y_skater_02' { x = 657.723, y = 457.342, z = 144.641 }
-spawnpoint 'a_m_y_skater_01' { x = 134.387, y = 1150.31, z = 231.594 }
-spawnpoint 'a_m_y_skater_02' { x = 726.14, y = 1196.91, z = 326.262 }
-spawnpoint 'a_m_y_skater_01' { x = 740.792, y = 1283.62, z = 360.297 }
-spawnpoint 'a_m_y_skater_02' { x = -437.009, y = 1059.59, z = 327.331 }
-spawnpoint 'a_m_y_skater_01' { x = -428.771, y = 1596.8, z = 356.338 }
-spawnpoint 'a_m_y_skater_02' { x = -1348.78, y = 723.87, z = 186.45 }
-spawnpoint 'a_m_y_skater_01' { x = -1543.24, y = 830.069, z = 182.132 }
-spawnpoint 'a_m_y_skater_02' { x = -2150.48, y = 222.019, z = 184.602 }
-spawnpoint 'a_m_y_skater_01' { x = -3032.13, y = 22.2157, z = 10.1184 }
-spawnpoint 'a_m_y_skater_02' { x = 3063.97, y = 5608.88, z = 209.245 }
-spawnpoint 'a_m_y_skater_01' { x = -2614.35, y = 1872.49, z = 167.32 }
-spawnpoint 'a_m_y_skater_02' { x = -1873.94, y = 2088.73, z = 140.994 }
-spawnpoint 'a_m_y_skater_01' { x = -597.177, y = 2092.16, z = 131.413 }
-spawnpoint 'a_m_y_skater_02' { x = 967.126, y = 2226.99, z = 54.0588 }
-spawnpoint 'a_m_y_skater_01' { x = -338.043, y = 2829, z = 56.0871 }
-spawnpoint 'a_m_y_skater_02' { x = 1082.25, y = -696.921, z = 58.0099 }
-spawnpoint 'a_m_y_skater_01' { x = 1658.31, y = -13.9234, z = 169.992 }
-spawnpoint 'a_m_y_skater_02' { x = 2522.98, y = -384.436, z = 92.9928 }
-spawnpoint 'a_m_y_skater_01' { x = 2826.27, y = -656.489, z = 1.87841 }
-spawnpoint 'a_m_y_skater_02' { x = 2851.12, y = 1467.5, z = 24.5554 }
-spawnpoint 'a_m_y_skater_01' { x = 2336.33, y = 2535.39, z = 46.5177 }
-spawnpoint 'a_m_y_skater_02' { x = 2410.46, y = 3077.88, z = 48.1529 }
-spawnpoint 'a_m_y_skater_01' { x = 2451.15, y = 3768.37, z = 41.3477 }
-spawnpoint 'a_m_y_skater_02' { x = 3337.78, y = 5174.8, z = 18.2108 }
-spawnpoint 'a_m_y_skater_01' { x = -1119.33, y = 4978.52, z = 186.26 }
-spawnpoint 'a_m_y_skater_02' { x = 2877.3, y = 5911.57, z = 369.618 }
-spawnpoint 'a_m_y_skater_01' { x = 2942.1, y = 5306.73, z = 101.52 }
-spawnpoint 'a_m_y_skater_02' { x = 2211.29, y = 5577.94, z = 53.872 }
-spawnpoint 'a_m_y_skater_01' { x = 1602.39, y = 6623.02, z = 15.8417 }
-spawnpoint 'a_m_y_skater_02' { x = 66.0113, y = 7203.58, z = 3.16 }
-spawnpoint 'a_m_y_skater_01' { x = -219.201, y = 6562.82, z = 10.9706 }
-spawnpoint 'a_m_y_skater_02' { x = -45.1562, y = 6301.64, z = 31.6114 }
-spawnpoint 'a_m_y_skater_01' { x = -1004.77, y = 4854.32, z = 274.606 }
-spawnpoint 'a_m_y_skater_02' { x = -1580.01, y = 5173.3, z = 19.5813 }
-spawnpoint 'a_m_y_skater_01' { x = -1467.95, y = 5416.2, z = 23.5959 }
-spawnpoint 'a_m_y_skater_02' { x = -2359.31, y = 3243.83, z = 92.9037 }
-spawnpoint 'a_m_y_skater_01' { x = -2612.96, y = 3555.03, z = 4.85649 }
-spawnpoint 'a_m_y_skater_02' { x = -2083.27, y = 2616.94, z = 3.08396 }
-spawnpoint 'a_m_y_skater_01' { x = -524.471, y = 4195, z = 193.731 }
-spawnpoint 'a_m_y_skater_02' { x = -840.713, y = 4183.18, z = 215.29 }
-spawnpoint 'a_m_y_skater_01' { x = -1576.24, y = 2103.87, z = 67.576 }
-spawnpoint 'a_m_y_skater_02' { x = -1634.37, y = 209.816, z = 60.6413 }
-spawnpoint 'a_m_y_skater_01' { x = -1495.07, y = 142.697, z = 55.6527 }
-spawnpoint 'a_m_y_skater_02' { x = -1715.41, y = -197.722, z = 57.698 }
-spawnpoint 'a_m_y_skater_01' { x = -1181.07, y = -505.544, z = 35.5661 }
-spawnpoint 'a_m_y_skater_02' { x = -1712.37, y = -1082.91, z = 13.0801 }
-spawnpoint 'a_m_y_skater_01' { x = -1352.43, y = -1542.75, z = 4.42268 }
-spawnpoint 'a_m_y_skater_02' { x = -1756.89, y = 427.531, z = 127.685 }
-spawnpoint 'a_m_y_skater_01' { x = 3060.2, y = 2113.2, z = 1.6613 }
-spawnpoint 'a_m_y_skater_02' { x = 501.646, y = 5604.53, z = 797.91 }
-spawnpoint 'a_m_y_skater_01' { x = 714.109, y = 4151.15, z = 35.7792 }
-spawnpoint 'a_m_y_skater_02' { x = -103.651, y = -967.93, z = 296.52 }
-spawnpoint 'a_m_y_skater_01' { x = -265.333, y = -2419.35, z = 122.366 }
-spawnpoint 'a_m_y_skater_02' { x = 1788.25, y = 3890.34, z = 34.3849 }
+--[[
+    -- Type: Configuration
+    -- Name: Skater Spawn Points
+    -- Use: Registers ped spawn locations for the skater map
+    -- Updated: 2024-05-31
+    -- By: VSSVSSN
+--]]
 
---
+local spawnPoints = {
+    { model = 'a_m_y_skater_01', x = -802.311, y = 175.056, z = 72.8446 },
+    { model = 'a_m_y_skater_02', x = -9.96562, y = -1438.54, z = 31.1015 },
+    { model = 'a_m_y_skater_01', x = 0.916756, y = 528.485, z = 174.628 },
+    { model = 'a_m_y_skater_02', x = 1975.86, y = 3821.03, z = 33.4501 },
+    { model = 'a_m_y_skater_01', x = -181.615, y = 852.8, z = 232.701 },
+    { model = 'a_m_y_skater_02', x = 657.723, y = 457.342, z = 144.641 },
+    { model = 'a_m_y_skater_01', x = 134.387, y = 1150.31, z = 231.594 },
+    { model = 'a_m_y_skater_02', x = 726.14, y = 1196.91, z = 326.262 },
+    { model = 'a_m_y_skater_01', x = 740.792, y = 1283.62, z = 360.297 },
+    { model = 'a_m_y_skater_02', x = -437.009, y = 1059.59, z = 327.331 },
+    { model = 'a_m_y_skater_01', x = -428.771, y = 1596.8, z = 356.338 },
+    { model = 'a_m_y_skater_02', x = -1348.78, y = 723.87, z = 186.45 },
+    { model = 'a_m_y_skater_01', x = -1543.24, y = 830.069, z = 182.132 },
+    { model = 'a_m_y_skater_02', x = -2150.48, y = 222.019, z = 184.602 },
+    { model = 'a_m_y_skater_01', x = -3032.13, y = 22.2157, z = 10.1184 },
+    { model = 'a_m_y_skater_02', x = 3063.97, y = 5608.88, z = 209.245 },
+    { model = 'a_m_y_skater_01', x = -2614.35, y = 1872.49, z = 167.32 },
+    { model = 'a_m_y_skater_02', x = -1873.94, y = 2088.73, z = 140.994 },
+    { model = 'a_m_y_skater_01', x = -597.177, y = 2092.16, z = 131.413 },
+    { model = 'a_m_y_skater_02', x = 967.126, y = 2226.99, z = 54.0588 },
+    { model = 'a_m_y_skater_01', x = -338.043, y = 2829, z = 56.0871 },
+    { model = 'a_m_y_skater_02', x = 1082.25, y = -696.921, z = 58.0099 },
+    { model = 'a_m_y_skater_01', x = 1658.31, y = -13.9234, z = 169.992 },
+    { model = 'a_m_y_skater_02', x = 2522.98, y = -384.436, z = 92.9928 },
+    { model = 'a_m_y_skater_01', x = 2826.27, y = -656.489, z = 1.87841 },
+    { model = 'a_m_y_skater_02', x = 2851.12, y = 1467.5, z = 24.5554 },
+    { model = 'a_m_y_skater_01', x = 2336.33, y = 2535.39, z = 46.5177 },
+    { model = 'a_m_y_skater_02', x = 2410.46, y = 3077.88, z = 48.1529 },
+    { model = 'a_m_y_skater_01', x = 2451.15, y = 3768.37, z = 41.3477 },
+    { model = 'a_m_y_skater_02', x = 3337.78, y = 5174.8, z = 18.2108 },
+    { model = 'a_m_y_skater_01', x = -1119.33, y = 4978.52, z = 186.26 },
+    { model = 'a_m_y_skater_02', x = 2877.3, y = 5911.57, z = 369.618 },
+    { model = 'a_m_y_skater_01', x = 2942.1, y = 5306.73, z = 101.52 },
+    { model = 'a_m_y_skater_02', x = 2211.29, y = 5577.94, z = 53.872 },
+    { model = 'a_m_y_skater_01', x = 1602.39, y = 6623.02, z = 15.8417 },
+    { model = 'a_m_y_skater_02', x = 66.0113, y = 7203.58, z = 3.16 },
+    { model = 'a_m_y_skater_01', x = -219.201, y = 6562.82, z = 10.9706 },
+    { model = 'a_m_y_skater_02', x = -45.1562, y = 6301.64, z = 31.6114 },
+    { model = 'a_m_y_skater_01', x = -1004.77, y = 4854.32, z = 274.606 },
+    { model = 'a_m_y_skater_02', x = -1580.01, y = 5173.3, z = 19.5813 },
+    { model = 'a_m_y_skater_01', x = -1467.95, y = 5416.2, z = 23.5959 },
+    { model = 'a_m_y_skater_02', x = -2359.31, y = 3243.83, z = 92.9037 },
+    { model = 'a_m_y_skater_01', x = -2612.96, y = 3555.03, z = 4.85649 },
+    { model = 'a_m_y_skater_02', x = -2083.27, y = 2616.94, z = 3.08396 },
+    { model = 'a_m_y_skater_01', x = -524.471, y = 4195, z = 193.731 },
+    { model = 'a_m_y_skater_02', x = -840.713, y = 4183.18, z = 215.29 },
+    { model = 'a_m_y_skater_01', x = -1576.24, y = 2103.87, z = 67.576 },
+    { model = 'a_m_y_skater_02', x = -1634.37, y = 209.816, z = 60.6413 },
+    { model = 'a_m_y_skater_01', x = -1495.07, y = 142.697, z = 55.6527 },
+    { model = 'a_m_y_skater_02', x = -1715.41, y = -197.722, z = 57.698 },
+    { model = 'a_m_y_skater_01', x = -1181.07, y = -505.544, z = 35.5661 },
+    { model = 'a_m_y_skater_02', x = -1712.37, y = -1082.91, z = 13.0801 },
+    { model = 'a_m_y_skater_01', x = -1352.43, y = -1542.75, z = 4.42268 },
+    { model = 'a_m_y_skater_02', x = -1756.89, y = 427.531, z = 127.685 },
+    { model = 'a_m_y_skater_01', x = 3060.2, y = 2113.2, z = 1.6613 },
+    { model = 'a_m_y_skater_02', x = 501.646, y = 5604.53, z = 797.91 },
+    { model = 'a_m_y_skater_01', x = 714.109, y = 4151.15, z = 35.7792 },
+    { model = 'a_m_y_skater_02', x = -103.651, y = -967.93, z = 296.52 },
+    { model = 'a_m_y_skater_01', x = -265.333, y = -2419.35, z = 122.366 },
+    { model = 'a_m_y_skater_02', x = 1788.25, y = 3890.34, z = 34.3849 }
+}
+
+for _, sp in ipairs(spawnPoints) do
+    spawnpoint(sp.model, { x = sp.x, y = sp.y, z = sp.z, heading = sp.h or 0.0 })
+end
+


### PR DESCRIPTION
## Summary
- update manifest to cerulean with Lua 5.4 and map flag
- refactor skater map spawnpoints into table-driven configuration

## Testing
- `luac -p Example_Frameworks/cfx-server-data/resources/[gamemodes]/[maps]/fivem-map-skater/map.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1a4600960832d8cb290ef55ee3941