### PR TITLE
refactor: modernize money-fountain example

### DIFF
--- a/Example_Frameworks/cfx-server-data/resources/[gameplay]/[examples]/money-fountain/client.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[gameplay]/[examples]/money-fountain/client.lua
@@ -10,92 +10,98 @@ local Wait = Wait
 local GetEntityCoords = GetEntityCoords
 local PlayerPedId = PlayerPedId
 
+-- controls
+local INPUT_PICKUP <const> = 38
+local INPUT_DETONATE <const> = 47
+
 -- timer, don't tick as frequently if we're far from any money fountain
 local relevanceTimer = 500
 
-CreateThread(function()
-    local pressing = false
+--[[
+    -- Type: Function
+    -- Name: handleControls
+    -- Use: Sends server events based on player input
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
+local function handleControls(id)
+    if IsControlJustReleased(0, INPUT_PICKUP) then
+        TriggerServerEvent('money_fountain:tryPickup', id)
+    elseif IsControlJustReleased(0, INPUT_DETONATE) then
+        TriggerServerEvent('money_fountain:tryPlace', id)
+    end
+end
 
+--[[
+    -- Type: Function
+    -- Name: showHelp
+    -- Use: Displays contextual help for the fountain
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
+local function showHelp(data, youCanSpend, fountainCanSpend)
+    local helpName
+
+    if youCanSpend and fountainCanSpend then
+        helpName = 'FOUNTAIN_HELP'
+    elseif youCanSpend and not fountainCanSpend then
+        helpName = 'FOUNTAIN_HELP_DRAINED'
+    elseif not youCanSpend and fountainCanSpend then
+        helpName = 'FOUNTAIN_HELP_BROKE'
+    else
+        helpName = 'FOUNTAIN_HELP_BROKE_N_DRAINED'
+    end
+
+    BeginTextCommandDisplayHelp(helpName)
+    AddTextComponentInteger(GlobalState['fountain_' .. data.id])
+
+    if fountainCanSpend then
+        AddTextComponentInteger(data.amount)
+    end
+
+    if youCanSpend then
+        AddTextComponentInteger(data.amount)
+    end
+
+    EndTextCommandDisplayHelp(0, false, false, 1000)
+end
+
+CreateThread(function()
     while true do
         Wait(relevanceTimer)
 
         local coords = GetEntityCoords(PlayerPedId())
+        local near = false
 
         for _, data in pairs(moneyFountains) do
-            -- if we're near this fountain
             local dist = #(coords - data.coords)
 
-            -- near enough to draw
-            if dist < 40 then
-                -- ensure per-frame tick
-                relevanceTimer = 0
-
+            if dist < 40.0 then
+                near = true
                 DrawMarker(29, data.coords.x, data.coords.y, data.coords.z, 0, 0, 0, 0.0, 0, 0, 1.0, 1.0, 1.0, 0, 150, 0, 120, false, true, 2, false, nil, nil, false)
-            else
-                -- put the relevance timer back to the way it was
-                relevanceTimer = 500
-            end
 
-            -- near enough to use
-            if dist < 1 then
-                -- are we able to use it? if not, display appropriate help
-                local player = LocalPlayer
-                local nextUse = player.state['fountain_nextUse']
+                if dist < 1.0 then
+                    local player = LocalPlayer
+                    local nextUse = player.state['fountain_nextUse']
 
-                -- GetNetworkTime is synced for everyone
-                if nextUse and nextUse >= GetNetworkTime() then
-                    BeginTextCommandDisplayHelp('FOUNTAIN_HELP_INUSE')
-                    AddTextComponentInteger(GlobalState['fountain_' .. data.id])
-                    AddTextComponentSubstringTime(math.tointeger(nextUse - GetNetworkTime()), 2 | 4) -- seconds (2), minutes (4)
-                    EndTextCommandDisplayHelp(0, false, false, 1000)
-                else
-                    -- handle inputs for pickup/place
-                    if not pressing then
-                        if IsControlPressed(0, 38 --[[ INPUT_PICKUP ]]) then
-                            TriggerServerEvent('money_fountain:tryPickup', data.id)
-                            pressing = true
-                        elseif IsControlPressed(0, 47 --[[ INPUT_DETONATE ]]) then
-                            TriggerServerEvent('money_fountain:tryPlace', data.id)
-                            pressing = true
-                        end
+                    if nextUse and nextUse >= GetNetworkTime() then
+                        BeginTextCommandDisplayHelp('FOUNTAIN_HELP_INUSE')
+                        AddTextComponentInteger(GlobalState['fountain_' .. data.id])
+                        AddTextComponentSubstringTime(math.tointeger(nextUse - GetNetworkTime()), 2 | 4)
+                        EndTextCommandDisplayHelp(0, false, false, 1000)
                     else
-                        if not IsControlPressed(0, 38 --[[ INPUT_PICKUP ]]) and 
-                           not IsControlPressed(0, 47 --[[ INPUT_DETONATE ]]) then
-                            pressing = false
-                        end
+                        handleControls(data.id)
+
+                        local youCanSpend = (player.state['money_cash'] or 0) >= data.amount
+                        local fountainCanSpend = GlobalState['fountain_' .. data.id] >= data.amount
+
+                        showHelp(data, youCanSpend, fountainCanSpend)
                     end
-
-                    -- decide the appropriate help message
-                    local youCanSpend = (player.state['money_cash'] or 0) >= data.amount
-                    local fountainCanSpend = GlobalState['fountain_' .. data.id] >= data.amount
-
-                    local helpName
-
-                    if youCanSpend and fountainCanSpend then
-                        helpName = 'FOUNTAIN_HELP'
-                    elseif youCanSpend and not fountainCanSpend then
-                        helpName = 'FOUNTAIN_HELP_DRAINED'
-                    elseif not youCanSpend and fountainCanSpend then
-                        helpName = 'FOUNTAIN_HELP_BROKE'
-                    else
-                        helpName = 'FOUNTAIN_HELP_BROKE_N_DRAINED'
-                    end
-
-                    -- and print it
-                    BeginTextCommandDisplayHelp(helpName)
-                    AddTextComponentInteger(GlobalState['fountain_' .. data.id])
-
-                    if fountainCanSpend then
-                        AddTextComponentInteger(data.amount)
-                    end
-
-                    if youCanSpend then
-                        AddTextComponentInteger(data.amount)
-                    end
-
-                    EndTextCommandDisplayHelp(0, false, false, 1000)
                 end
             end
         end
+
+        relevanceTimer = near and 0 or 500
     end
 end)
+

--- a/Example_Frameworks/cfx-server-data/resources/[gameplay]/[examples]/money-fountain/fxmanifest.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[gameplay]/[examples]/money-fountain/fxmanifest.lua
@@ -6,7 +6,7 @@ description 'An example money system client containing a money fountain.'
 repository 'https://github.com/citizenfx/cfx-server-data'
 author 'Cfx.re <root@cfx.re>'
 
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'gta5'
 
 client_script 'client.lua'

--- a/Example_Frameworks/cfx-server-data/resources/[gameplay]/[examples]/money-fountain/mapdata.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[gameplay]/[examples]/money-fountain/mapdata.lua
@@ -4,15 +4,21 @@ moneyFountains = {}
 -- index to know what to remove
 local fountainIdx = 1
 
+--[[
+    -- Type: Function
+    -- Name: getMapDirectives
+    -- Use: Registers money fountain directive for map parsing
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
 AddEventHandler('getMapDirectives', function(add)
-    -- add a 'money_fountain' map directive
     add('money_fountain', function(state, name)
         return function(data)
             local coords = data[1]
             local amount = data.amount or 100
 
             local idx = fountainIdx
-            fountainIdx += 1
+            fountainIdx = fountainIdx + 1
 
             moneyFountains[idx] = {
                 id = name,

--- a/Example_Frameworks/cfx-server-data/resources/[gameplay]/[examples]/money-fountain/server.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[gameplay]/[examples]/money-fountain/server.lua
@@ -4,91 +4,99 @@ local sentState = {}
 -- money system
 local ms = exports['money']
 
--- get the fountain content from storage
+--[[
+    -- Type: Function
+    -- Name: getMoneyForId
+    -- Use: Retrieve stored money amount for a fountain
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
 local function getMoneyForId(fountainId)
     return GetResourceKvpInt(('money:%s'):format(fountainId)) / 100.0
 end
 
--- set the fountain content in storage + state
+--[[
+    -- Type: Function
+    -- Name: setMoneyForId
+    -- Use: Persist fountain money and update global state
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
 local function setMoneyForId(fountainId, money)
     GlobalState['fountain_' .. fountainId] = math.tointeger(money)
-
     return SetResourceKvpInt(('money:%s'):format(fountainId), math.tointeger(money * 100.0))
 end
 
--- get the nearest fountain to the player + ID
+--[[
+    -- Type: Function
+    -- Name: getMoneyFountain
+    -- Use: Returns fountain data when player is within range
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
 local function getMoneyFountain(id, source)
     local coords = GetEntityCoords(GetPlayerPed(source))
 
     for _, v in pairs(moneyFountains) do
-        if v.id == id then
-            if #(v.coords - coords) < 2.5 then
-                return v
-            end
+        if v.id == id and #(v.coords - coords) < 2.5 then
+            return v
         end
     end
 
     return nil
 end
 
--- generic function for events
-local function handleFountainStuff(source, id, pickup)
-    -- if near the fountain we specify
+--[[
+    -- Type: Function
+    -- Name: handleFountain
+    -- Use: Handles pickup/place logic for the fountain
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
+local function handleFountain(source, id, pickup)
     local fountain = getMoneyFountain(id, source)
+    if not fountain then
+        return
+    end
 
-    if fountain then
-        -- and we can actually use the fountain already
-        local player = Player(source)
+    local player = Player(source)
+    local nextUse = player.state['fountain_nextUse'] or 0
 
-        local nextUse = player.state['fountain_nextUse']
-        if not nextUse then
-            nextUse = 0
+    if nextUse > GetGameTimer() then
+        return
+    end
+
+    local success = false
+    local money = getMoneyForId(fountain.id)
+
+    if pickup then
+        if money >= fountain.amount and ms:addMoney(source, 'cash', fountain.amount) then
+            money = money - fountain.amount
+            success = true
         end
-
-        -- GetGameTimer ~ GetNetworkTime on client
-        if nextUse <= GetGameTimer() then
-            -- not rate limited
-            local success = false
-            local money = getMoneyForId(fountain.id)
-
-            -- decide the op
-            if pickup then
-                -- if the fountain is rich enough to get the per-use amount
-                if money >= fountain.amount then
-                    -- give the player money
-                    if ms:addMoney(source, 'cash', fountain.amount) then
-                        money -= fountain.amount
-                        success = true
-                    end
-                end
-            else
-                -- if the player is rich enough
-                if ms:removeMoney(source, 'cash', fountain.amount) then
-                    -- add to the fountain
-                    money += fountain.amount
-                    success = true
-                end
-            end
-
-            -- save it and set the player's cooldown
-            if success then
-                setMoneyForId(fountain.id, money)
-                player.state['fountain_nextUse'] = GetGameTimer() + GetConvarInt('moneyFountain_cooldown', 5000)
-            end
+    else
+        if ms:removeMoney(source, 'cash', fountain.amount) then
+            money = money + fountain.amount
+            success = true
         end
+    end
+
+    if success then
+        setMoneyForId(fountain.id, money)
+        player.state['fountain_nextUse'] = GetGameTimer() + GetConvarInt('moneyFountain_cooldown', 5000)
     end
 end
 
 -- event for picking up fountain->player
 RegisterNetEvent('money_fountain:tryPickup')
 AddEventHandler('money_fountain:tryPickup', function(id)
-    handleFountainStuff(source, id, true)
+    handleFountain(source, id, true)
 end)
 
 -- event for donating player->fountain
 RegisterNetEvent('money_fountain:tryPlace')
 AddEventHandler('money_fountain:tryPlace', function(id)
-    handleFountainStuff(source, id, false)
+    handleFountain(source, id, false)
 end)
 
 -- listener: if a new fountain is added, set its current money in state
@@ -99,7 +107,6 @@ CreateThread(function()
         for _, fountain in pairs(moneyFountains) do
             if not sentState[fountain.id] then
                 GlobalState['fountain_' .. fountain.id] = math.tointeger(getMoneyForId(fountain.id))
-
                 sentState[fountain.id] = true
             end
         end


### PR DESCRIPTION
## Summary
- modernize client interaction handling for money fountains
- streamline server-side fountain logic with documented helpers
- document map directives and update manifest to cerulean

## Testing
- `luac -p Example_Frameworks/cfx-server-data/resources/'[gameplay]'/'[examples]'/money-fountain/*.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1a55ffdb0832db5be1d25933e455d