### PR TITLE
refactor yarn build task and update manifest

### DIFF
--- a/Example_Frameworks/cfx-server-data/resources/[system]/[builders]/yarn/fxmanifest.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[system]/[builders]/yarn/fxmanifest.lua
@@ -3,10 +3,10 @@
 
 version '1.0.0'
 author 'Cfx.re <root@cfx.re>'
-description 'Builds resources with yarn. To learn more: https://classic.yarnpkg.com'
+description 'Builds resources with Yarn. Learn more at https://yarnpkg.com'
 repository 'https://github.com/citizenfx/cfx-server-data'
 
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'common'
 
 server_script 'yarn_builder.js'

--- a/Example_Frameworks/cfx-server-data/resources/[system]/[builders]/yarn/yarn_builder.js
+++ b/Example_Frameworks/cfx-server-data/resources/[system]/[builders]/yarn/yarn_builder.js
@@ -1,81 +1,94 @@
 const path = require('path');
 const fs = require('fs');
 const child_process = require('child_process');
-let buildingInProgress = false;
-let currentBuildingModule = '';
 
 const initCwd = process.cwd();
-const trimOutput = (data) => {
-	return `[yarn]\t` + data.toString().replace(/\s+$/, '');
+const trimOutput = (data) => `[yarn]\t${data.toString().trimEnd()}`;
+
+let buildingInProgress = false;
+let currentBuildingModule = '';
+const buildQueue = [];
+
+function runQueue() {
+        if (buildingInProgress || buildQueue.length === 0) {
+                return;
+        }
+
+        const { resourceName, cb } = buildQueue.shift();
+        buildingInProgress = true;
+        currentBuildingModule = resourceName;
+
+        runYarn(resourceName)
+                .then(() => cb(true))
+                .catch((err) => cb(false, err.message || 'yarn failed!'))
+                .finally(() => {
+                        buildingInProgress = false;
+                        currentBuildingModule = '';
+                        runQueue();
+                });
+}
+
+function runYarn(resourceName) {
+        return new Promise((resolve, reject) => {
+                const proc = child_process.fork(
+                        require.resolve('./yarn_cli.js'),
+                        ['install', '--ignore-scripts', '--cache-folder', path.join(initCwd, 'cache', 'yarn-cache'), '--mutex', 'file:' + path.join(initCwd, 'cache', 'yarn-mutex')],
+                        {
+                                cwd: path.resolve(GetResourcePath(resourceName)),
+                                stdio: 'pipe',
+                        }
+                );
+
+                proc.stdout.on('data', (data) => console.log(trimOutput(data)));
+                proc.stderr.on('data', (data) => console.error(trimOutput(data)));
+                proc.on('error', reject);
+                proc.on('exit', (code, signal) => {
+                        if (code !== 0 || signal) {
+                                return reject(new Error('yarn failed'));
+                        }
+
+                        const resourcePath = GetResourcePath(resourceName);
+                        const yarnLock = path.resolve(resourcePath, '.yarn.installed');
+                        fs.writeFile(yarnLock, '', (err) => {
+                                if (err) {
+                                        return reject(err);
+                                }
+                                resolve();
+                        });
+                });
+        });
 }
 
 const yarnBuildTask = {
-	shouldBuild(resourceName) {
-		try {
-			const resourcePath = GetResourcePath(resourceName);
-			
-			const packageJson = path.resolve(resourcePath, 'package.json');
-			const yarnLock = path.resolve(resourcePath, '.yarn.installed');
-			
-			const packageStat = fs.statSync(packageJson);
-			
-			try {
-				const yarnStat = fs.statSync(yarnLock);
-				
-				if (packageStat.mtimeMs > yarnStat.mtimeMs) {
-					return true;
-				}
-			} catch (e) {
-				// no yarn.installed, but package.json - install time!
-				return true;
-			}
-		} catch (e) {
-			
-		}
-		
-		return false;
-	},
-	
-	build(resourceName, cb) {
-		(async () => {
-			while (buildingInProgress && currentBuildingModule !== resourceName) {
-				console.log(`yarn is currently busy: we are waiting to compile ${resourceName}`);
-				await sleep(3000);
-			}
-			buildingInProgress = true;
-			currentBuildingModule = resourceName;
-			const proc = child_process.fork(
-				require.resolve('./yarn_cli.js'),
-				['install', '--ignore-scripts', '--cache-folder', path.join(initCwd, 'cache', 'yarn-cache'), '--mutex', 'file:' + path.join(initCwd, 'cache', 'yarn-mutex')],
-				{
-					cwd: path.resolve(GetResourcePath(resourceName)),
-					stdio: 'pipe',
-				});
-			proc.stdout.on('data', (data) => console.log(trimOutput(data)));
-			proc.stderr.on('data', (data) => console.error(trimOutput(data)));
-			proc.on('exit', (code, signal) => {
-				setImmediate(() => {
-					if (code != 0 || signal) {
-						buildingInProgress = false;
-						currentBuildingModule = '';
-						cb(false, 'yarn failed!');
-						return;
-					}
+        shouldBuild(resourceName) {
+                try {
+                        const resourcePath = GetResourcePath(resourceName);
+                        const packageJson = path.resolve(resourcePath, 'package.json');
+                        if (!fs.existsSync(packageJson)) {
+                                return false;
+                        }
 
-					const resourcePath = GetResourcePath(resourceName);
-					const yarnLock = path.resolve(resourcePath, '.yarn.installed');
-					fs.writeFileSync(yarnLock, '');
+                        const yarnLock = path.resolve(resourcePath, '.yarn.installed');
+                        const packageStat = fs.statSync(packageJson);
 
-					buildingInProgress = false;
-					currentBuildingModule = '';
-					cb(true);
-				});
-			});
-		})();
-	}
+                        try {
+                                const yarnStat = fs.statSync(yarnLock);
+                                return packageStat.mtimeMs > yarnStat.mtimeMs;
+                        } catch (e) {
+                                // yarn not yet installed
+                                return true;
+                        }
+                } catch (e) {
+                        console.error(`[yarn]\tfailed to determine build status for ${resourceName}:`, e);
+                }
+
+                return false;
+        },
+
+        build(resourceName, cb) {
+                buildQueue.push({ resourceName, cb });
+                runQueue();
+        },
 };
 
-function sleep(ms) {
-	return new Promise(resolve => setTimeout(resolve, ms));
-}
 RegisterResourceBuildTaskFactory('yarn', () => yarnBuildTask);


### PR DESCRIPTION
## Summary
- update fxmanifest to modern cerulean version and refreshed description
- refactor yarn builder to use a queue and promise-based execution with improved logging

## Testing
- `node --check Example_Frameworks/cfx-server-data/resources/[system]/[builders]/yarn/yarn_builder.js`
- `luac -p Example_Frameworks/cfx-server-data/resources/[system]/[builders]/yarn/fxmanifest.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1a8452b68832dba8a341fd751d4bc