### PR TITLE
refactor: modernize rconlog resource

### DIFF
--- a/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/fxmanifest.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/fxmanifest.lua
@@ -1,9 +1,9 @@
 -- This resource is part of the default Cfx.re asset pack (cfx-server-data)
 -- Altering or recreating for local use only is strongly discouraged.
 
-version '1.0.0'
-author 'Cfx.re <root@cfx.re>'
-description 'Handles old-style server player management commands.'
+version '1.1.0'
+author 'Cfx.re <root@cfx.re> & VSSVSSN'
+description 'Modernized RCON logging and player management commands.'
 repository 'https://github.com/citizenfx/cfx-server-data'
 
 client_script 'rconlog_client.lua'

--- a/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_client.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_client.lua
@@ -1,6 +1,21 @@
+--[[
+    -- Type: Client Script
+    -- Name: rconlog_client.lua
+    -- Use: Sends player activation and name data to the server for RCON logging
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+
 RegisterNetEvent('rlUpdateNames')
 
-AddEventHandler('rlUpdateNames', function()
+--[[
+    -- Type: Function
+    -- Name: onUpdateNames
+    -- Use: Collects all active player names and forwards them to the server
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function onUpdateNames()
     local names = {}
 
     for _, player in ipairs(GetActivePlayers()) do
@@ -8,16 +23,21 @@ AddEventHandler('rlUpdateNames', function()
     end
 
     TriggerServerEvent('rlUpdateNamesResult', names)
-end)
+end
+AddEventHandler('rlUpdateNames', onUpdateNames)
 
+--[[
+    -- Type: Thread
+    -- Name: activationThread
+    -- Use: Waits for the network session and notifies the server once ready
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
 CreateThread(function()
-    while true do
-        Wait(0)
-
-        if NetworkIsSessionStarted() then
-            TriggerServerEvent('rlPlayerActivated')
-
-            return
-        end
+    while not NetworkIsSessionStarted() do
+        Wait(500)
     end
+
+    TriggerServerEvent('rlPlayerActivated')
 end)
+

--- a/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_server.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_server.lua
@@ -1,94 +1,182 @@
-RconLog({
-    msgType = 'serverStart',
-    hostname = GetConvar('sv_hostname', 'unknown'),
-    maxplayers = GetConvarInt('sv_maxclients', 32)
-})
-
-RegisterNetEvent('rlPlayerActivated')
+--[[
+    -- Type: Resource Script
+    -- Name: rconlog_server.lua
+    -- Use: Handles logging of server events to the RCON console and implements basic RCON commands
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
 
 local names = {}
 
-AddEventHandler('rlPlayerActivated', function()
-    RconLog({
+--[[
+    -- Type: Function
+    -- Name: log
+    -- Use: Wrapper for the RconLog native to keep calls consistent
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function log(payload)
+    RconLog(payload)
+end
+
+--[[
+    -- Type: Function
+    -- Name: broadcastNames
+    -- Use: Requests the host to send the latest player name table
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function broadcastNames()
+    local host = GetHostId()
+    if host then
+        TriggerClientEvent('rlUpdateNames', host)
+    end
+end
+
+--[[
+    -- Type: Function
+    -- Name: handlePlayerActivated
+    -- Use: Logs when a player joins and updates the name cache
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function handlePlayerActivated()
+    local src = source
+    local playerName = GetPlayerName(src)
+
+    log({
         msgType = 'playerActivated',
-        netID = source,
-        name = GetPlayerName(source),
-        guid = GetPlayerIdentifiers(source)[1],
-        ip = GetPlayerEndpoint(source)
+        netID = src,
+        name = playerName,
+        guid = GetPlayerIdentifier(src, 0),
+        ip = GetPlayerEndpoint(src)
     })
 
-    names[source] = { name = GetPlayerName(source), id = source }
+    names[src] = { name = playerName, id = src }
+    broadcastNames()
+end
+RegisterNetEvent('rlPlayerActivated')
+AddEventHandler('rlPlayerActivated', handlePlayerActivated)
 
-	if GetHostId() then
-		TriggerClientEvent('rlUpdateNames', GetHostId())
-	end
-end)
-
-RegisterNetEvent('rlUpdateNamesResult')
-
-AddEventHandler('rlUpdateNamesResult', function(res)
+--[[
+    -- Type: Function
+    -- Name: handleNamesResult
+    -- Use: Receives updated name information from the host client
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function handleNamesResult(res)
     if source ~= tonumber(GetHostId()) then
-        print('bad guy')
+        print('Unauthorized rlUpdateNamesResult from', source)
         return
     end
 
     for id, data in pairs(res) do
         if data then
-            if data.name then
-                if not names[id] then
-                    names[id] = data
-                end
-
-                if names[id].name ~= data.name or names[id].id ~= data.id then
-                    names[id] = data
-
-                    RconLog({ msgType = 'playerRenamed', netID = id, name = data.name })
-                end
+            if not names[id] or names[id].name ~= data.name or names[id].id ~= data.id then
+                names[id] = data
+                log({ msgType = 'playerRenamed', netID = id, name = data.name })
             end
         else
             names[id] = nil
         end
     end
-end)
+end
+RegisterNetEvent('rlUpdateNamesResult')
+AddEventHandler('rlUpdateNamesResult', handleNamesResult)
 
-AddEventHandler('playerDropped', function()
-    RconLog({ msgType = 'playerDropped', netID = source, name = GetPlayerName(source) })
+--[[
+    -- Type: Function
+    -- Name: handlePlayerDropped
+    -- Use: Logs when a player disconnects from the server
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function handlePlayerDropped()
+    local src = source
+    log({ msgType = 'playerDropped', netID = src, name = GetPlayerName(src) })
+    names[src] = nil
+end
+AddEventHandler('playerDropped', handlePlayerDropped)
 
-    names[source] = nil
-end)
-
+--[[
+    -- Type: Event Handler
+    -- Name: chatMessage
+    -- Use: Logs chat messages to the RCON console
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
 AddEventHandler('chatMessage', function(netID, name, message)
-    RconLog({ msgType = 'chatMessage', netID = netID, name = name, message = message, guid = GetPlayerIdentifiers(netID)[1] })
+    log({
+        msgType = 'chatMessage',
+        netID = netID,
+        name = name,
+        message = message,
+        guid = GetPlayerIdentifier(netID, 0)
+    })
 end)
 
--- NOTE: DO NOT USE THIS METHOD FOR HANDLING COMMANDS
--- This resource has not been updated to use newer methods such as RegisterCommand.
-AddEventHandler('rconCommand', function(commandName, args)
-    if commandName == 'status' then
-        for netid, data in pairs(names) do
-            local guid = GetPlayerIdentifiers(netid)
+--[[
+    -- Type: Function
+    -- Name: commandStatus
+    -- Use: Outputs the current player list to the RCON console
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function commandStatus(source, args)
+    if source ~= 0 then return end
 
-            if guid and guid[1] and data then
-                local ping = GetPlayerPing(netid)
+    for netid, data in pairs(names) do
+        local guid = GetPlayerIdentifier(netid, 0) or 'unknown'
+        local endpoint = GetPlayerEndpoint(netid) or 'unknown'
+        local ping = GetPlayerPing(netid) or -1
 
-                RconPrint(netid .. ' ' .. guid[1] .. ' ' .. data.name .. ' ' .. GetPlayerEndpoint(netid) .. ' ' .. ping .. "\n")
-            end
-        end
-
-        CancelEvent()
-    elseif commandName:lower() == 'clientkick' then
-        local playerId = table.remove(args, 1)
-        local msg = table.concat(args, ' ')
-
-        DropPlayer(playerId, msg)
-
-        CancelEvent()
-    elseif commandName:lower() == 'tempbanclient' then
-        local playerId = table.remove(args, 1)
-        local msg = table.concat(args, ' ')
-
-        TempBanPlayer(playerId, msg)
-
-        CancelEvent()
+        RconPrint(('%s %s %s %s %s\n'):format(netid, guid, data.name, endpoint, ping))
     end
-end)
+end
+RegisterCommand('status', commandStatus, true)
+
+--[[
+    -- Type: Function
+    -- Name: commandClientKick
+    -- Use: Kicks a player from the server via RCON command
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function commandClientKick(source, args)
+    if source ~= 0 then return end
+
+    local playerId = table.remove(args, 1)
+    local msg = table.concat(args, ' ')
+
+    if playerId then
+        DropPlayer(playerId, msg or '')
+    end
+end
+RegisterCommand('clientkick', commandClientKick, true)
+
+--[[
+    -- Type: Function
+    -- Name: commandTempBanClient
+    -- Use: Temporarily bans a player via RCON command
+    -- Created: 2024-05-23
+    -- By: VSSVSSN
+--]]
+local function commandTempBanClient(source, args)
+    if source ~= 0 then return end
+
+    local playerId = table.remove(args, 1)
+    local msg = table.concat(args, ' ')
+
+    if playerId then
+        TempBanPlayer(playerId, msg or '')
+    end
+end
+RegisterCommand('tempbanclient', commandTempBanClient, true)
+
+log({
+    msgType = 'serverStart',
+    hostname = GetConvar('sv_hostname', 'unknown'),
+    maxplayers = GetConvarInt('sv_maxclients', 32)
+})
+


### PR DESCRIPTION
## Summary
- refactor rcon logging server/client scripts with modular functions and modern command registration
- add detailed documentation comments and improved fxmanifest metadata
- replace legacy rconCommand handling with secure RegisterCommand implementations

## Testing
- `luac -p Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_server.lua`
- `luac -p Example_Frameworks/cfx-server-data/resources/[system]/rconlog/rconlog_client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1a889ff6c832d84ddc498ae320105