### PR TITLE
refactor: modernize example loadscreen

### DIFF
--- a/Example_Frameworks/cfx-server-data/resources/[test]/example-loadscreen/fxmanifest.lua
+++ b/Example_Frameworks/cfx-server-data/resources/[test]/example-loadscreen/fxmanifest.lua
@@ -1,19 +1,25 @@
--- This resource is part of the default Cfx.re asset pack (cfx-server-data)
--- Altering or recreating for local use only is strongly discouraged.
+--[[
+    -- Type: Resource Manifest
+    -- Name: example-loadscreen
+    -- Use: Provides a simple loading screen for the server
+    -- Created: 2024-02-14
+    -- By: VSSVSSN
+--]]
 
-version '1.0.0'
-author 'Cfx.re <root@cfx.re>'
+fx_version 'cerulean'
+game 'gta5'
+
+author 'Cfx.re <root@cfx.re> / Updated by VSSVSSN'
 description 'Example loading screen.'
+version '1.1.0'
 repository 'https://github.com/citizenfx/cfx-server-data'
 
 files {
     'index.html',
     'keks.css',
+    'loadscreen.js',
     'bankgothic.ttf',
     'loadscreen.jpg'
 }
 
 loadscreen 'index.html'
-
-fx_version 'bodacious'
-game 'gta5'

--- a/Example_Frameworks/cfx-server-data/resources/[test]/example-loadscreen/index.html
+++ b/Example_Frameworks/cfx-server-data/resources/[test]/example-loadscreen/index.html
@@ -1,77 +1,27 @@
-<html>
-    <head>
-        <link href="keks.css" rel="stylesheet" type="text/css" />
-    </head>
-    <body>
-        <div class="backdrop">
-            <div class="top">
-                <h1 title="Free Mode">Free Mode</h1>
-                <h2 title="Not Algonquin">Not Algonquin</h2>
-            </div>
-
-            <div class="letni">
-                <h2 title="INTEL">Intel</h2>
-                <h3></h3>
-                <div class="loadbar"><div class="thingy"></div></div>
-                <p>The Statue of Happiness has no heart. You do.</p>
-            </div>
-            <div class="bottom">
-                <div id="gradient">
-                </div>
-            </div>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Loading...</title>
+    <link rel="stylesheet" href="keks.css" type="text/css" />
+</head>
+<body>
+    <div class="backdrop">
+        <div class="top">
+            <h1 title="Free Mode">Free Mode</h1>
+            <h2 title="Not Algonquin">Not Algonquin</h2>
         </div>
 
-<script type="text/javascript">
-// this will actually restart the loading bar a lot, making multiple loading bars is an exercise to the reader... for now.
-// for a set of possible events, see https://github.com/citizenfx/fivem/blob/master/code/components/loading-screens-five/src/LoadingScreens.cpp
-var count = 0;
-var thisCount = 0;
-
-const emoji = {
-    INIT_BEFORE_MAP_LOADED: [ '🍉' ],
-    INIT_AFTER_MAP_LOADED: [ '🍋', '🍊' ],
-    INIT_SESSION: [ '🍐', '🍅', '🍆' ],
-};
-
-const handlers = {
-    startInitFunctionOrder(data)
-    {
-        count = data.count;
-
-        document.querySelector('.letni h3').innerHTML += emoji[data.type][data.order - 1] || '';
-    },
-
-    initFunctionInvoking(data)
-    {
-        document.querySelector('.thingy').style.left = '0%';
-        document.querySelector('.thingy').style.width = ((data.idx / count) * 100) + '%';
-    },
-
-    startDataFileEntries(data)
-    {
-        count = data.count;
-
-        document.querySelector('.letni h3').innerHTML += "\u{1f358}";
-    },
-
-    performMapLoadFunction(data)
-    {
-        ++thisCount;
-
-        document.querySelector('.thingy').style.left = '0%';
-        document.querySelector('.thingy').style.width = ((thisCount / count) * 100) + '%';
-    },
-
-    onLogLine(data)
-    {
-        document.querySelector('.letni p').innerHTML = data.message + "..!";
-    }
-};
-
-window.addEventListener('message', function(e)
-{
-    (handlers[e.data.eventName] || function() {})(e.data);
-});
-</script>
-    </body>
+        <div class="letni">
+            <h2 title="INTEL">Intel</h2>
+            <h3></h3>
+            <div class="loadbar"><div class="thingy"></div></div>
+            <p>The Statue of Happiness has no heart. You do.</p>
+        </div>
+        <div class="bottom">
+            <div id="gradient"></div>
+        </div>
+    </div>
+    <script src="loadscreen.js"></script>
+</body>
 </html>

--- a/Example_Frameworks/cfx-server-data/resources/[test]/example-loadscreen/keks.css
+++ b/Example_Frameworks/cfx-server-data/resources/[test]/example-loadscreen/keks.css
@@ -1,37 +1,29 @@
-body
-{
-    margin: 0px;
-    padding: 0px;
+html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
 }
 
-.backdrop
-{
+.backdrop {
     position: relative;
-    top: 0px;
-    left: 0px;
     width: 100%;
     height: 100%;
-
-    background-image: url(loadscreen.jpg);
-    background-size: 100% 100%;
+    background: url('loadscreen.jpg') no-repeat center center;
+    background-size: cover;
 }
 
-.bottom
-{
+.bottom {
     position: absolute;
-    bottom: 0px;
+    bottom: 0;
     width: 100%;
     height: 100%;
 }
 
-#gradient
-{
+#gradient {
     position: absolute;
-    bottom: 0px;
+    bottom: 0;
     width: 100%;
-
     height: 25%;
-
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 100%);
 }
 
@@ -43,109 +35,82 @@ body
 }
 
 h1, h2 {
-  position: relative;
-  background: transparent;
-  z-index: 0;
-}
-/* add a single stroke */
-h1:before, h2:before {
-  content: attr(title);
-  position: absolute;
-  -webkit-text-stroke: 0.1em #000;
-  left: 0;
-  z-index: -1;
+    position: relative;
+    background: transparent;
+    z-index: 0;
 }
 
+h1::before, h2::before {
+    content: attr(title);
+    position: absolute;
+    -webkit-text-stroke: 0.1em #000;
+    left: 0;
+    z-index: -1;
+}
 
-.letni
-{
+.letni {
     position: absolute;
     left: 5%;
     right: 5%;
     bottom: 10%;
-
     z-index: 5;
-
     color: #fff;
-
-    font-family: "Segoe UI";
+    font-family: 'Segoe UI', sans-serif;
 }
 
-.letni p
-{
+.letni p {
     font-size: 22px;
-
     margin-left: 3px;
-
-    margin-top: 0px;
+    margin-top: 0;
 }
 
-.letni h2, .letni h3
-{
-    font-family: BankGothic;
-
+.letni h2, .letni h3 {
+    font-family: 'BankGothic', sans-serif;
     text-transform: uppercase;
-
     font-size: 50px;
-
-    margin: 0px;
-
+    margin: 0;
     display: inline-block;
 }
 
-.top
-{
+.top {
     color: #fff;
-
     position: absolute;
     top: 7%;
     left: 5%;
     right: 5%;
 }
 
-.top h1
-{
-    font-family: BankGothic;
+.top h1 {
+    font-family: 'BankGothic', sans-serif;
     font-size: 60px;
-
-    margin: 0px;
+    margin: 0;
 }
 
-.top h2
-{
-    font-family: BankGothic;
+.top h2 {
+    font-family: 'BankGothic', sans-serif;
     font-size: 40px;
-
-    margin: 0px;
-
+    margin: 0;
     color: #ddd;
 }
 
-.loadbar
-{
+.loadbar {
     width: 100%;
     background-color: rgba(140, 140, 140, .9);
     height: 20px;
-
     margin-left: 2px;
     margin-right: 3px;
-
     margin-top: 5px;
     margin-bottom: 5px;
-
     overflow: hidden;
-
     position: relative;
-
     display: block;
 }
 
-.thingy
-{
+.thingy {
     width: 10%;
     background-color: #eee;
     height: 20px;
-
     position: absolute;
     left: 10%;
+    transition: width 0.3s ease;
 }

--- a/Example_Frameworks/cfx-server-data/resources/[test]/example-loadscreen/loadscreen.js
+++ b/Example_Frameworks/cfx-server-data/resources/[test]/example-loadscreen/loadscreen.js
@@ -1,0 +1,61 @@
+/**
+ * Type: Client Script
+ * Name: loadscreen.js
+ * Use: Handles loading screen events and progress bar updates.
+ * Created: 2024-02-14
+ * By: VSSVSSN
+ */
+
+(() => {
+    'use strict';
+
+    let count = 0;
+    let current = 0;
+
+    const emojis = {
+        INIT_BEFORE_MAP_LOADED: ['🍉'],
+        INIT_AFTER_MAP_LOADED: ['🍋', '🍊'],
+        INIT_SESSION: ['🍐', '🍅', '🍆']
+    };
+
+    const elements = {
+        progress: document.querySelector('.thingy'),
+        status: document.querySelector('.letni h3'),
+        message: document.querySelector('.letni p')
+    };
+
+    const handlers = {
+        startInitFunctionOrder: data => {
+            count = data.count;
+            const symbol = emojis[data.type]?.[data.order - 1] || '';
+            elements.status.textContent += symbol;
+        },
+
+        initFunctionInvoking: data => {
+            elements.progress.style.left = '0%';
+            elements.progress.style.width = `${(data.idx / count) * 100}%`;
+        },
+
+        startDataFileEntries: data => {
+            count = data.count;
+            elements.status.textContent += '🍘';
+        },
+
+        performMapLoadFunction: () => {
+            current++;
+            elements.progress.style.left = '0%';
+            elements.progress.style.width = `${(current / count) * 100}%`;
+        },
+
+        onLogLine: data => {
+            elements.message.textContent = `${data.message}..!`;
+        }
+    };
+
+    window.addEventListener('message', e => {
+        const handler = handlers[e.data.eventName];
+        if (handler) {
+            handler(e.data);
+        }
+    });
+})();


### PR DESCRIPTION
## Summary
- modernize loadscreen manifest and include new JS module
- refactor HTML/CSS and move script into `loadscreen.js`
- add safer event handlers with optional chaining and text updates

## Testing
- `node --check Example_Frameworks/cfx-server-data/resources/\[test\]/example-loadscreen/loadscreen.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1a8e6ca10832dacc833bc3051e95b