### PR TITLE
Modernize es_extended threads and manifest

### DIFF
--- a/Example_Frameworks/es_extended/client/functions.lua
+++ b/Example_Frameworks/es_extended/client/functions.lua
@@ -311,7 +311,7 @@ ESX.Game.GetPedMugshot = function(ped, transparent)
 		end
 
 		while not IsPedheadshotReady(mugshot) do
-			Citizen.Wait(0)
+			Wait(0)
 		end
 
 		return mugshot, GetPedheadshotTxdString(mugshot)
@@ -326,7 +326,7 @@ ESX.Game.Teleport = function(entity, coords, cb)
 	if DoesEntityExist(entity) then
 		RequestCollisionAtCoord(vector.xyz)
 		while not HasCollisionLoadedAroundEntity(entity) do
-			Citizen.Wait(0)
+			Wait(0)
 		end
 
 		SetEntityCoords(entity, vector.xyz, false, false, false, false)
@@ -343,7 +343,7 @@ ESX.Game.SpawnObject = function(object, coords, cb, networked)
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
 	networked = networked == nil and true or networked
 
-	Citizen.CreateThread(function()
+	CreateThread(function()
 		ESX.Streaming.RequestModel(model)
 
 		local obj = CreateObject(model, vector.xyz, networked, false, true)
@@ -371,7 +371,7 @@ ESX.Game.SpawnVehicle = function(vehicle, coords, heading, cb, networked)
 	local model = (type(vehicle) == 'number' and vehicle or GetHashKey(vehicle))
 	local vector = type(coords) == "vector3" and coords or vec(coords.x, coords.y, coords.z)
 	networked = networked == nil and true or networked
-	Citizen.CreateThread(function()
+	CreateThread(function()
 		ESX.Streaming.RequestModel(model)
 
 		local vehicle = CreateVehicle(model, vector.xyz, heading, networked, false)
@@ -388,7 +388,7 @@ ESX.Game.SpawnVehicle = function(vehicle, coords, heading, cb, networked)
 
 		RequestCollisionAtCoord(vector.xyz)
 		while not HasCollisionLoadedAroundEntity(vehicle) do
-			Citizen.Wait(0)
+			Wait(0)
 		end
 
 		if cb then
@@ -914,7 +914,7 @@ ESX.ShowInventory = function()
 					if type == 'item_weapon' then
 						menu1.close()
 						TaskPlayAnim(playerPed, dict, anim, 8.0, 1.0, 1000, 16, 0.0, false, false, false)
-						Citizen.Wait(1000)
+						Wait(1000)
 						TriggerServerEvent('esx:removeInventoryItem', type, item)
 					else
 						ESX.UI.Menu.Open('dialog', GetCurrentResourceName(), 'inventory_item_count_remove', {
@@ -926,7 +926,7 @@ ESX.ShowInventory = function()
 								menu2.close()
 								menu1.close()
 								TaskPlayAnim(playerPed, dict, anim, 8.0, 1.0, 1000, 16, 0.0, false, false, false)
-								Citizen.Wait(1000)
+								Wait(1000)
 								TriggerServerEvent('esx:removeInventoryItem', type, item, quantity)
 							else
 								ESX.ShowNotification(_U('amount_invalid'))
@@ -1009,7 +1009,7 @@ AddEventHandler('esx:showHelpNotification', function(msg, thisFrame, beep, durat
 end)
 
 -- SetTimeout
-Citizen.CreateThread(function()
+CreateThread(function()
 	while true do
 		local sleep = 100
 		if #ESX.TimeoutCallbacks > 0 then
@@ -1022,6 +1022,6 @@ Citizen.CreateThread(function()
 				end
 			end
 		end
-		Citizen.Wait(sleep)
+		Wait(sleep)
 	end
 end)

--- a/Example_Frameworks/es_extended/client/main.lua
+++ b/Example_Frameworks/es_extended/client/main.lua
@@ -1,8 +1,8 @@
 local pickups = {}
 
-Citizen.CreateThread(function()
+CreateThread(function()
 	while not Config.Multichar do
-		Citizen.Wait(0)
+		Wait(0)
 		if NetworkIsPlayerActive(PlayerId()) then
 			exports.spawnmanager:setAutoSpawn(false)
 			DoScreenFadeOut(0)
@@ -20,7 +20,7 @@ AddEventHandler('esx:playerLoaded', function(xPlayer, isNew, skin)
 	FreezeEntityPosition(PlayerPedId(), true)
 
 	if Config.Multichar then
-		Citizen.Wait(3000)
+		Wait(3000)
 	else
 		exports.spawnmanager:spawnPlayer({
 			x = ESX.PlayerData.coords.x,
@@ -48,7 +48,7 @@ AddEventHandler('esx:playerLoaded', function(xPlayer, isNew, skin)
 		end)
 	end
 
-	while ESX.PlayerData.ped == nil do Citizen.Wait(20) end
+	while ESX.PlayerData.ped == nil do Wait(20) end
 	-- enable PVP
 	if Config.EnablePVP then
 		SetCanAttackFriendly(ESX.PlayerData.ped, true, false)
@@ -97,7 +97,7 @@ end)
 
 AddEventHandler('skinchanger:modelLoaded', function()
 	while not ESX.PlayerLoaded do
-		Citizen.Wait(100)
+		Wait(100)
 	end
 	TriggerEvent('esx:restoreLoadout')
 end)
@@ -317,7 +317,7 @@ AddEventHandler('esx:deleteVehicle', function(radius)
 			local attempt = 0
 
 			while not NetworkHasControlOfEntity(entity) and attempt < 100 and DoesEntityExist(entity) do
-				Citizen.Wait(100)
+				Wait(100)
 				NetworkRequestControlOfEntity(entity)
 				attempt = attempt + 1
 			end
@@ -334,7 +334,7 @@ AddEventHandler('esx:deleteVehicle', function(radius)
 		end
 
 		while not NetworkHasControlOfEntity(vehicle) and attempt < 100 and DoesEntityExist(vehicle) do
-			Citizen.Wait(100)
+			Wait(100)
 			NetworkRequestControlOfEntity(vehicle)
 			attempt = attempt + 1
 		end
@@ -347,10 +347,10 @@ end)
 
 -- Pause menu disables HUD display
 if Config.EnableHud then
-	Citizen.CreateThread(function()
+	CreateThread(function()
 		local isPaused = false
 		while true do
-			Citizen.Wait(300)
+			Wait(300)
 
 			if IsPauseMenuActive() and not isPaused then
 				isPaused = true
@@ -369,7 +369,7 @@ end
 
 function StartServerSyncLoops()
 	-- keep track of ammo
-	Citizen.CreateThread(function()
+	CreateThread(function()
 		local currentWeapon = {timer=0}
 		while ESX.PlayerLoaded do
 			local sleep = 5
@@ -396,12 +396,12 @@ function StartServerSyncLoops()
 			else
 				sleep = 200
 			end
-			Citizen.Wait(sleep)
+			Wait(sleep)
 		end
 	end)
 
 	-- sync current player coords with server
-	Citizen.CreateThread(function()
+	CreateThread(function()
 		local previousCoords = vector3(ESX.PlayerData.coords.x, ESX.PlayerData.coords.y, ESX.PlayerData.coords.z)
 
 		while ESX.PlayerLoaded do
@@ -419,7 +419,7 @@ function StartServerSyncLoops()
 					TriggerServerEvent('esx:updateCoords', formattedCoords)
 				end
 			end
-			Citizen.Wait(1500)
+			Wait(1500)
 		end
 	end)
 end
@@ -440,9 +440,9 @@ if not Config.EnableWantedLevel then
 	SetMaxWantedLevel(0)
 end
 
-Citizen.CreateThread(function()
+CreateThread(function()
 	while true do
-		Citizen.Wait(0)
+		Wait(0)
 		local playerCoords, letSleep = GetEntityCoords(ESX.PlayerData.ped), true
 		local closestPlayer, closestDistance = ESX.Game.GetClosestPlayer(playerCoords)
 
@@ -461,7 +461,7 @@ Citizen.CreateThread(function()
 							local dict, anim = 'weapons@first_person@aim_rng@generic@projectile@sticky_bomb@', 'plant_floor'
 							ESX.Streaming.RequestAnimDict(dict)
 							TaskPlayAnim(ESX.PlayerData.ped, dict, anim, 8.0, 1.0, 1000, 16, 0.0, false, false, false)
-							Citizen.Wait(1000)
+							Wait(1000)
 
 							TriggerServerEvent('esx:onPickup', pickupId)
 							PlaySoundFrontend(-1, 'PICK_UP', 'HUD_FRONTEND_DEFAULT_SOUNDSET', false)
@@ -482,7 +482,7 @@ Citizen.CreateThread(function()
 		end
 
 		if letSleep then
-			Citizen.Wait(500)
+			Wait(500)
 		end
 	end
 end)
@@ -506,7 +506,7 @@ AddEventHandler("esx:tpm", function()
                 break
             end
 
-            Citizen.Wait(5)
+            Wait(5)
         end
         TriggerEvent('chatMessage', "Successfully Teleported")
     else
@@ -534,9 +534,9 @@ AddEventHandler("esx:noclip", function(input)
 	end)
 	
 	local heading = 0
-	Citizen.CreateThread(function()
+	CreateThread(function()
 	while true do
-		Citizen.Wait(0)
+		Wait(0)
 
 		if(noclip)then
 			SetEntityCoordsNoOffset(ESX.PlayerData.ped, noclip_pos.x, noclip_pos.y, noclip_pos.z, 0, 0, 0)
@@ -575,7 +575,7 @@ AddEventHandler("esx:noclip", function(input)
 				noclip_pos = GetOffsetFromEntityInWorldCoords(ESX.PlayerData.ped, 0.0, 0.0, -1.0)
 			end
 		else
-			Citizen.Wait(200)
+			Wait(200)
 		end
 	end
 end)

--- a/Example_Frameworks/es_extended/client/modules/death.lua
+++ b/Example_Frameworks/es_extended/client/modules/death.lua
@@ -1,8 +1,8 @@
-Citizen.CreateThread(function()
+CreateThread(function()
 	local isDead = false
 
 	while true do
-		Citizen.Wait(0)
+		Wait(0)
 		local letSleep = 0
 		local player = PlayerId()
 
@@ -28,7 +28,7 @@ Citizen.CreateThread(function()
 			end
 		end
 		if letSleep then
-			Citizen.Wait(500)
+			Wait(500)
 		end
 	end
 end)

--- a/Example_Frameworks/es_extended/client/modules/scaleform.lua
+++ b/Example_Frameworks/es_extended/client/modules/scaleform.lua
@@ -7,7 +7,7 @@ ESX.Scaleform.ShowFreemodeMessage = function(title, msg, sec)
 	EndScaleformMovieMethod()
 
 	while sec > 0 do
-		Citizen.Wait(1)
+		Wait(1)
 		sec = sec - 0.01
 
 		DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255)
@@ -38,7 +38,7 @@ ESX.Scaleform.ShowBreakingNews = function(title, msg, bottom, sec)
 	EndScaleformMovieMethod()
 
 	while sec > 0 do
-		Citizen.Wait(1)
+		Wait(1)
 		sec = sec - 0.01
 
 		DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255)
@@ -61,7 +61,7 @@ ESX.Scaleform.ShowPopupWarning = function(title, msg, bottom, sec)
 	EndScaleformMovieMethod()
 
 	while sec > 0 do
-		Citizen.Wait(1)
+		Wait(1)
 		sec = sec - 0.01
 
 		DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255)
@@ -78,7 +78,7 @@ ESX.Scaleform.ShowTrafficMovie = function(sec)
 	EndScaleformMovieMethod()
 
 	while sec > 0 do
-		Citizen.Wait(1)
+		Wait(1)
 		sec = sec - 0.01
 
 		DrawScaleformMovieFullscreen(scaleform, 255, 255, 255, 255)
@@ -91,7 +91,7 @@ ESX.Scaleform.Utils.RequestScaleformMovie = function(movie)
 	local scaleform = RequestScaleformMovie(movie)
 
 	while not HasScaleformMovieLoaded(scaleform) do
-		Citizen.Wait(0)
+		Wait(0)
 	end
 
 	return scaleform

--- a/Example_Frameworks/es_extended/client/modules/streaming.lua
+++ b/Example_Frameworks/es_extended/client/modules/streaming.lua
@@ -5,7 +5,7 @@ function ESX.Streaming.RequestModel(modelHash, cb)
 		RequestModel(modelHash)
 
 		while not HasModelLoaded(modelHash) do
-			Citizen.Wait(4)
+			Wait(4)
 		end
 	end
 
@@ -19,7 +19,7 @@ function ESX.Streaming.RequestStreamedTextureDict(textureDict, cb)
 		RequestStreamedTextureDict(textureDict)
 
 		while not HasStreamedTextureDictLoaded(textureDict) do
-			Citizen.Wait(4)
+			Wait(4)
 		end
 	end
 
@@ -33,7 +33,7 @@ function ESX.Streaming.RequestNamedPtfxAsset(assetName, cb)
 		RequestNamedPtfxAsset(assetName)
 
 		while not HasNamedPtfxAssetLoaded(assetName) do
-			Citizen.Wait(4)
+			Wait(4)
 		end
 	end
 
@@ -47,7 +47,7 @@ function ESX.Streaming.RequestAnimSet(animSet, cb)
 		RequestAnimSet(animSet)
 
 		while not HasAnimSetLoaded(animSet) do
-			Citizen.Wait(4)
+			Wait(4)
 		end
 	end
 
@@ -61,7 +61,7 @@ function ESX.Streaming.RequestAnimDict(animDict, cb)
 		RequestAnimDict(animDict)
 
 		while not HasAnimDictLoaded(animDict) do
-			Citizen.Wait(4)
+			Wait(4)
 		end
 	end
 
@@ -75,7 +75,7 @@ function ESX.Streaming.RequestWeaponAsset(weaponHash, cb)
 		RequestWeaponAsset(weaponHash)
 
 		while not HasWeaponAssetLoaded(weaponHash) do
-			Citizen.Wait(4)
+			Wait(4)
 		end
 	end
 

--- a/Example_Frameworks/es_extended/docs.md
+++ b/Example_Frameworks/es_extended/docs.md
@@ -1,7 +1,7 @@
 # es_extended Documentation
 
 ## Overview and Runtime Context
-ES Extended is a legacy roleplay framework for FiveM that manages players, inventory, jobs, accounts and a minimal HUD. The resource ships both client and server Lua scripts, shared utility modules, an HTML based NUI, and interacts with a MySQL database via `mysql-async`. It exports a `getSharedObject` method so other resources can access the ESX API.
+ES Extended is a legacy roleplay framework for FiveM that manages players, inventory, jobs, accounts and a minimal HUD. The resource ships both client and server Lua scripts, shared utility modules, an HTML based NUI, and interacts with a MySQL database via `mysql-async`. It exports a `getSharedObject` method so other resources can access the ESX API. The codebase now targets the modern `cerulean` fxmanifest with Lua 5.4 enabled and uses the streamlined `CreateThread`/`Wait` primitives for asynchronous logic.
 
 ## File Inventory
 - **Client**
@@ -21,7 +21,7 @@ ES Extended is a legacy roleplay framework for FiveM that manages players, inven
   - `server/classes/player.lua`
   - `server/paycheck.lua`
 - **Shared**
-  - `fxmanifest.lua`
+  - `fxmanifest.lua` (`cerulean`, `lua54`)
   - `config.lua`
   - `config.weapons.lua`
   - `imports.lua`
@@ -81,6 +81,7 @@ Orchestrates player loading/saving and network events.
 - Handles coordinate and ammo updates from clients (`esx:updateCoords`, `esx:updateWeaponAmmo`) and inventory transfers (`esx:giveInventoryItem`, `esx:removeInventoryItem`, `esx:onPickup`).
 - Exposes callbacks `esx:getPlayerData`, `esx:getOtherPlayerData`, and `esx:getPlayerNames` for external resources.
 - Saves all players before a txAdmin scheduled restart via `txAdmin:events:scheduledRestart`.
+- Determines a player's default permission group locally to avoid creating unintended global variables when setting ACE-based admin rights.
 
 ### server/functions.lua
 Core server utilities and persistence helpers.

--- a/Example_Frameworks/es_extended/fxmanifest.lua
+++ b/Example_Frameworks/es_extended/fxmanifest.lua
@@ -1,6 +1,8 @@
-fx_version 'adamant'
+fx_version 'cerulean'
 
 game 'gta5'
+
+lua54 'yes'
 
 description 'ES Extended'
 

--- a/Example_Frameworks/es_extended/server/common.lua
+++ b/Example_Frameworks/es_extended/server/common.lua
@@ -19,8 +19,8 @@ function getSharedObject()
 end
 
 local function StartDBSync()
-	Citizen.CreateThread(function()
-		Citizen.Wait(10 * 60 * 1000)
+	CreateThread(function()
+		Wait(10 * 60 * 1000)
 		ESX.SavePlayers()
 	end)
 end

--- a/Example_Frameworks/es_extended/server/functions.lua
+++ b/Example_Frameworks/es_extended/server/functions.lua
@@ -164,7 +164,7 @@ ESX.TriggerServerCallback = function(name, requestId, source, cb, ...)
 end
 
 local savePlayers = -1
-Citizen.CreateThread(function()
+CreateThread(function()
 	savePlayers = MySQL.Sync.store("UPDATE users SET `accounts` = ?, `job` = ?, `job_grade` = ?, `group` = ?, `position` = ?, `inventory` = ?, `loadout` = ? WHERE `identifier` = ?")
 end)
 

--- a/Example_Frameworks/es_extended/server/main.lua
+++ b/Example_Frameworks/es_extended/server/main.lua
@@ -1,5 +1,5 @@
 local NewPlayer, LoadPlayer = -1, -1
-Citizen.CreateThread(function()
+CreateThread(function()
 	SetMapName('San Andreas')
 	SetGameType('ESX Legacy')
 	
@@ -62,19 +62,28 @@ function onPlayerJoined(playerId)
 	end
 end
 
+--[[
+    -- Type: Function
+    -- Name: createESXPlayer
+    -- Use: Initializes a player's database record and loads them into ESX
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function createESXPlayer(identifier, playerId, data)
-	local accounts = {}
+       local accounts = {}
 
-	for account,money in pairs(Config.StartingAccountMoney) do
-		accounts[account] = money
-	end
+       for account,money in pairs(Config.StartingAccountMoney) do
+               accounts[account] = money
+       end
 
-	if IsPlayerAceAllowed(playerId, "command") then
-		print(('^2[INFO] ^0 Player ^5%s ^0Has been granted admin permissions via ^5Ace Perms.^7'):format(playerId))
-		defaultGroup = "admin"
-	else
-		defaultGroup = "user"
-	end
+       local defaultGroup
+
+       if IsPlayerAceAllowed(playerId, "command") then
+               print(('^2[INFO] ^0 Player ^5%s ^0Has been granted admin permissions via ^5Ace Perms.^7'):format(playerId))
+               defaultGroup = "admin"
+       else
+               defaultGroup = "user"
+       end
 
 	if not Config.Multichar then
 		MySQL.Async.execute(NewPlayer, {
@@ -104,7 +113,7 @@ AddEventHandler('playerConnecting', function(name, setCallback, deferrals)
 	deferrals.defer()
 	local playerId = source
 	local identifier = ESX.GetIdentifier(playerId)
-	Citizen.Wait(100)
+	Wait(100)
 
 	if identifier then
 		if ESX.GetPlayerFromIdentifier(identifier) then
@@ -590,8 +599,8 @@ end)
 
 AddEventHandler('txAdmin:events:scheduledRestart', function(eventData)
 	if eventData.secondsRemaining == 60 then
-		Citizen.CreateThread(function()
-			Citizen.Wait(50000)
+		CreateThread(function()
+			Wait(50000)
 			ESX.SavePlayers()
 		end)
 	end

--- a/Example_Frameworks/es_extended/server/paycheck.lua
+++ b/Example_Frameworks/es_extended/server/paycheck.lua
@@ -1,7 +1,7 @@
 StartPayCheck = function()
-	Citizen.CreateThread(function()
+	CreateThread(function()
 		while true do
-			Citizen.Wait(Config.PaycheckInterval)
+			Wait(Config.PaycheckInterval)
 			local xPlayers = ESX.GetExtendedPlayers()
 			for _, xPlayer in pairs(xPlayers) do
 				local job     = xPlayer.job.grade_name


### PR DESCRIPTION
## Summary
- upgrade fxmanifest to cerulean and enable Lua 5.4
- refactor Citizen.CreateThread/Wait to CreateThread/Wait across client and server
- fix default permission group using local variable and document modernization

## Testing
- `find Example_Frameworks/es_extended -name '*.lua' -print0 | xargs -0 -n1 luac -p` *(fails: unexpected symbol near '`' for files using FiveM backtick hashes)*
- `luac -p Example_Frameworks/es_extended/server/main.lua`
- `luac -p Example_Frameworks/es_extended/server/functions.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1b03f4944832d93c8dced25e4c146