### PR TITLE
fix: standardize increments and document job utilities in qb-core

### DIFF
--- a/Example_Frameworks/qb-core/docs.md
+++ b/Example_Frameworks/qb-core/docs.md
@@ -116,9 +116,11 @@ The `qb-core` resource provides the foundational framework for QBCore-based Five
 - Player lookup functions: by source, citizen ID, license, phone number or account; utility `GetPlayers` returns active sources.
 - Identifier helpers, bucket management, and offline player retrieval using MySQL queries.
 - Callback system: `CreateCallback`, `TriggerClientCallback`, `TriggerCallback` allow asynchronous request/response between client and server.
+- Job queries: `GetPlayersByJob` returns list and count for a job or job type, while `GetPlayersOnDuty` and `GetDutyCount` provide on-duty filtering.
 - Money and item helpers, vehicle spawning (`SpawnVehicle`, `CreateAutomobile`), and webhook-friendly `Kick`.
 - Hunger/thirst saving, job/gang setters, permission checks (`HasPermission`, `IsGod`, `IsOptin`).
 - `HasItem` delegates to `qb-inventory` if present; `Notify` sends client notification events.
+- Proximity helpers `GetClosestPlayer`, `GetClosestVehicle`, and `GetClosestPed` search nearby players, vehicles, and peds.
 - `PrepForSQL` validates strings against patterns to deter SQL injection.
 
 ### server/player.lua

--- a/Example_Frameworks/qb-core/server/commands.lua
+++ b/Example_Frameworks/qb-core/server/commands.lua
@@ -34,7 +34,7 @@ function QBCore.Commands.Add(name, help, arguments, argsrequired, callback, perm
     local extraPerms = ... and table.pack(...) or nil
     if extraPerms then
         extraPerms[extraPerms.n + 1] = permission -- The `n` field is the number of arguments in the packed table
-        extraPerms.n += 1
+        extraPerms.n = extraPerms.n + 1
         permission = extraPerms
         for i = 1, permission.n do
             if not QBCore.Commands.IgnoreList[permission[i]] then -- only create aces for extra perm levels

--- a/Example_Frameworks/qb-core/server/functions.lua
+++ b/Example_Frameworks/qb-core/server/functions.lua
@@ -144,11 +144,11 @@ function QBCore.Functions.GetPlayersByJob(job, checkOnDuty)
             if checkOnDuty then
                 if playerData.job.onduty then
                     players[#players + 1] = src
-                    count += 1
+                    count = count + 1
                 end
             else
                 players[#players + 1] = src
-                count += 1
+                count = count + 1
             end
         end
     end


### PR DESCRIPTION
## Summary
- replace nonstandard `+=` with `count = count + 1` in job lookup helpers
- fix extra permission counter in command registration
- document job query and proximity helper functions

## Testing
- `luac -p Example_Frameworks/qb-core/server/functions.lua` *(fails: unexpected symbol near `CREATE_AUTOMOBILE`)*
- `luac -p Example_Frameworks/qb-core/server/commands.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1b07bb734832da88cee346d59d5ff