### PR TITLE
refactor: modernize qb-core event handling

### DIFF
--- a/Example_Frameworks/qb-core/docs.md
+++ b/Example_Frameworks/qb-core/docs.md
@@ -136,13 +136,13 @@ The `qb-core` resource provides the foundational framework for QBCore-based Five
 **Role:** Network event handlers and connection management.
 - Suppresses chat messages starting with `/` to route through command system.
 - `playerDropped` saves character and logs departure, clearing bucket tracking.
-- On resource stop, cleans up registered usable items.
+- On resource stop, cleans up registered usable items and skips processing when none exist to prevent errors.
 - `playerConnecting` defers connection while checking whitelist, duplicate licenses, database connectivity and bans (MySQL queries).
 - `QBCore:Server:CloseServer` / `OpenServer` toggle join access and optionally kick players lacking permissions.
  - Callback relays: `TriggerClientCallback` and `TriggerCallback` implement the client/server callback protocol.
  - `QBCore:UpdatePlayer` reduces hunger/thirst, updates HUD (`hud:client:UpdateNeeds`) and saves data.
  - `QBCore:ToggleDuty` flips job duty status with notifications, firing `QBCore:Client:SetDuty` and server event `QBCore:Server:SetDuty`.
- - Baseevents mirror vehicle seat changes to clients via `QBCore:Client:VehicleInfo` and issue `QBCore:Client:AbortVehicleEntering` when entry is cancelled.
+ - Baseevents use `RegisterNetEvent` and mirror vehicle seat changes to clients via `QBCore:Client:VehicleInfo`, issuing `QBCore:Client:AbortVehicleEntering` when entry is cancelled.
  - Deprecated item events (`Server:UseItem`, `RemoveItem`, `AddItem`) only log potential exploitation.
  - `QBCore:CallCommand` executes a command programmatically with permission checks.
  - Callbacks `QBCore:Server:SpawnVehicle` and `QBCore:Server:CreateVehicle` spawn vehicles server-side and return network IDs.
@@ -171,7 +171,7 @@ The `qb-core` resource provides the foundational framework for QBCore-based Five
 ### server/debug.lua
 **Role:** Debug and logging utilities.
 - `tPrint` recursively prints tables with colour coding.
-- Event `QBCore:DebugSomething` receives data to print; `QBCore.Debug` triggers it with the invoking resource name.
+- Event `QBCore:DebugSomething` (registered via `RegisterNetEvent`) receives data to print; `QBCore.Debug` triggers it with the invoking resource name.
 - `ShowError` and `ShowSuccess` output coloured console messages.
 
 ## shared

--- a/Example_Frameworks/qb-core/server/debug.lua
+++ b/Example_Frameworks/qb-core/server/debug.lua
@@ -25,7 +25,7 @@ local function tPrint(tbl, indent)
     end
 end
 
-RegisterServerEvent('QBCore:DebugSomething', function(tbl, indent, resource)
+RegisterNetEvent('QBCore:DebugSomething', function(tbl, indent, resource)
     print(('\x1b[4m\x1b[36m[ %s : DEBUG]\x1b[0m'):format(resource))
     tPrint(tbl, indent)
     print('\x1b[4m\x1b[36m[ END DEBUG ]\x1b[0m')

--- a/Example_Frameworks/qb-core/server/events.lua
+++ b/Example_Frameworks/qb-core/server/events.lua
@@ -19,7 +19,8 @@ AddEventHandler('playerDropped', function(reason)
 end)
 
 AddEventHandler("onResourceStop", function(resName)
-    for i,v in pairs(QBCore.UsableItems) do
+    if not QBCore.UsableItems then return end
+    for i, v in pairs(QBCore.UsableItems) do
         if v.resource == resName then
             QBCore.UsableItems[i] = nil
         end
@@ -185,7 +186,7 @@ end)
 -- BaseEvents
 
 -- Vehicles
-RegisterServerEvent('baseevents:enteringVehicle', function(veh, seat, modelName)
+RegisterNetEvent('baseevents:enteringVehicle', function(veh, seat, modelName)
     local src = source
     local data = {
         vehicle = veh,
@@ -196,7 +197,7 @@ RegisterServerEvent('baseevents:enteringVehicle', function(veh, seat, modelName)
     TriggerClientEvent('QBCore:Client:VehicleInfo', src, data)
 end)
 
-RegisterServerEvent('baseevents:enteredVehicle', function(veh, seat, modelName)
+RegisterNetEvent('baseevents:enteredVehicle', function(veh, seat, modelName)
     local src = source
     local data = {
         vehicle = veh,
@@ -207,12 +208,12 @@ RegisterServerEvent('baseevents:enteredVehicle', function(veh, seat, modelName)
     TriggerClientEvent('QBCore:Client:VehicleInfo', src, data)
 end)
 
-RegisterServerEvent('baseevents:enteringAborted', function()
+RegisterNetEvent('baseevents:enteringAborted', function()
     local src = source
     TriggerClientEvent('QBCore:Client:AbortVehicleEntering', src)
 end)
 
-RegisterServerEvent('baseevents:leftVehicle', function(veh, seat, modelName)
+RegisterNetEvent('baseevents:leftVehicle', function(veh, seat, modelName)
     local src = source
     local data = {
         vehicle = veh,


### PR DESCRIPTION
## Summary
- guard usable item cleanup on resource stop
- replace deprecated `RegisterServerEvent` usage with `RegisterNetEvent`
- document new event handling and cleanup behavior

## Testing
- `find Example_Frameworks/qb-core -name "*.lua" -print -exec luac -p {} \;` *(fails: unexpected symbol near '`')*

------
https://chatgpt.com/codex/tasks/task_e_68c1b9c19ab8832d9ca3e98c7a9e8faa