### PR TITLE
Refactor EssentialMode and remove jQuery

### DIFF
--- a/Example_Frameworks/essentialmode/essentialmode/client/main.lua
+++ b/Example_Frameworks/essentialmode/essentialmode/client/main.lua
@@ -12,7 +12,6 @@ CreateThread(function()
     TriggerServerEvent('es:firstJoinProper')
 end)
 
-local loaded = false
 local cash = 0
 local oldPos
 local decorators = {}
@@ -20,7 +19,7 @@ local decorators = {}
 --[[
     -- Type: Thread
     -- Name: PositionReporter
-    -- Use: Sends position updates and refreshes money UI
+    -- Use: Sends position updates
     -- Created: 09/10/2025
     -- By: VSSVSSN
 --]]
@@ -30,13 +29,6 @@ CreateThread(function()
         local pos = GetEntityCoords(PlayerPedId())
         if not oldPos or pos.x ~= oldPos.x or pos.y ~= oldPos.y or pos.z ~= oldPos.z then
             TriggerServerEvent('es:updatePositions', pos.x, pos.y, pos.z)
-            if loaded then
-                SendNUIMessage({
-                    setmoney = true,
-                    money = cash
-                })
-                loaded = false
-            end
             oldPos = pos
         end
     end

--- a/Example_Frameworks/essentialmode/essentialmode/fxmanifest.lua
+++ b/Example_Frameworks/essentialmode/essentialmode/fxmanifest.lua
@@ -1,6 +1,8 @@
 fx_version 'cerulean'
 game 'gta5'
 
+lua54 'yes'
+
 description 'EssentialMode by Kanersps.'
 
 ui_page 'ui.html'
@@ -12,6 +14,7 @@ files {
 
 server_scripts {
     '@oxmysql/lib/MySQL.lua',
+    'server/config.lua',
     'server/util.lua',
     'server/classes/player.lua',
     'server/classes/groups.lua',

--- a/Example_Frameworks/essentialmode/essentialmode/server/config.lua
+++ b/Example_Frameworks/essentialmode/essentialmode/server/config.lua
@@ -1,0 +1,22 @@
+--[[
+    -- Type: Config
+    -- Name: ServerConfig
+    -- Use: Shared state and default settings for EssentialMode
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
+
+Users = Users or {}
+commands = commands or {}
+settings = settings or {
+    defaultSettings = {
+        banReason = 'You are currently banned. Please go to: insertsite.com/bans',
+        pvpEnabled = false,
+        permissionDenied = false,
+        debugInformation = false,
+        startingCash = 0,
+        enableRankDecorators = false
+    },
+    sessionSettings = {}
+}
+

--- a/Example_Frameworks/essentialmode/essentialmode/server/main.lua
+++ b/Example_Frameworks/essentialmode/essentialmode/server/main.lua
@@ -6,19 +6,7 @@
     -- By: VSSVSSN
 --]]
 
-local Users = {}
-local commands = {}
-local settings = {
-    defaultSettings = {
-        banReason = 'You are currently banned. Please go to: insertsite.com/bans',
-        pvpEnabled = false,
-        permissionDenied = false,
-        debugInformation = false,
-        startingCash = 0,
-        enableRankDecorators = false
-    },
-    sessionSettings = {}
-}
+-- Globals `Users`, `commands` and `settings` are defined in server/config.lua
 
 --[[
     -- Type: Event
@@ -58,7 +46,7 @@ AddEventHandler('playerDropped', function()
     local src = source
     local user = Users[src]
     if user then
-        MySQL.update('UPDATE users SET money = ? WHERE identifier = ?', {
+        MySQL.update.await('UPDATE users SET money = ? WHERE identifier = ?', {
             user.money,
             user.identifier
         })

--- a/Example_Frameworks/essentialmode/essentialmode/ui.html
+++ b/Example_Frameworks/essentialmode/essentialmode/ui.html
@@ -1,92 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
 <head>
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:light,regular,medium,thin,italic,mediumitalic,bold" title="roboto">
-	<script src="nui://game/ui/jquery.js" type="text/javascript"></script>
-	<script>
-		function addCommas(nStr) {
-			nStr += '';
-			var x = nStr.split('.');
-			var x1 = x[0];
-			var x2 = x.length > 1 ? '.' + x[1] : '';
-			var rgx = /(\d+)(\d{3})/;
-			while (rgx.test(x1)) {
-				x1 = x1.replace(rgx, '$1' + '<span style="margin-left: 3px; margin-right: 3px;"/>' + '$2');
-			}
-			return x1 + x2;
-		}
+    <meta charset="utf-8" />
+    <title>EssentialMode UI</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:light,regular,medium,thin,italic,mediumitalic,bold" title="roboto" />
+    <style>
+        @font-face {
+            font-family: pcdown;
+            src: url(pdown.ttf);
+        }
+        .tiny {
+            font-size: 29px;
+            position: absolute;
+            right: 10;
+            opacity: 1;
+            transition: opacity 0.6s;
+        }
+        #money {
+            font-family: pcdown;
+            font-size: 35px;
+            color: white;
+            padding: 4px;
+            text-shadow:
+               -1px -1px 0 #000,
+                1px -1px 0 #000,
+               -1px 1px 0 #000,
+                1px 1px 0 #000;
+        }
+        #container {
+            position: absolute;
+            top: 40;
+            right: 40;
+        }
+    </style>
+    <script>
+        function addCommas(nStr) {
+            nStr += '';
+            var x = nStr.split('.');
+            var x1 = x[0];
+            var x2 = x.length > 1 ? '.' + x[1] : '';
+            var rgx = /(\d+)(\d{3})/;
+            while (rgx.test(x1)) {
+                x1 = x1.replace(rgx, '$1<span style="margin-left: 3px; margin-right: 3px;"/>' + '$2');
+            }
+            return x1 + x2;
+        }
 
-		window.onload = function(e){
-			// NUI Callback
-			window.addEventListener('message', function(event){
-				var item = event.data;
-
-				if(item.setmoney == true)
-					document.getElementById("cash").innerHTML = "<div><font style='color: rgb(0, 125, 0); font-weight: 700; margin-right: 6px;'>£</font>" + addCommas(item.money);
-				if(item.addcash == true){
-					$(".tiny").remove();
-
-					var element = $("<div class='tiny'>+<font style='color: rgb(0, 125, 0); font-weight: 700; margin-right: 6px;'>£</font>"+addCommas(item.money)+"</div>")
-					$("#money").append(element)
-
-					setTimeout(function(){
-						$(element).fadeOut(600, function() { $(this).remove(); })
-					}, 1000)
-				}
-				if(item.removecash == true){
-					$(".tiny").remove();
-					
-					var element = $("<div class='tiny'>-<font style='color: rgb(250, 0, 0); font-weight: 700; margin-right: 6px;'>£</font>"+addCommas(item.money)+"</div>")
-					$("#money").append(element)
-
-					setTimeout(function(){
-						$(element).fadeOut(600, function() { $(this).remove(); })
-					}, 1000)
-				}
-				if(item.removeStartWindow == true){
-					$("#starter").remove();
-				}
-				if(item.setDisplay == true){
-					$("#money").css('opacity', item.display)
-				}
-			})
-		}
-	</script>
-
-	<style>
-		@font-face {
-			font-family: pcdown;
-			src: url(pdown.ttf);
-		}
-		.tiny {
-			font-size: 29px;
-			position: absolute; right: 10;
-		}
-		#money {
-			font-family: pcdown;
-			font-size: 35px;
-			color: white;
-			padding: 4px;
-		text-shadow:
-		   -1px -1px 0 #000,
-			1px -1px 0 #000,
-			-1px 1px 0 #000,
-			 1px 1px 0 #000;
-				}
-
-		#container {
-			position: absolute;
-			top: 40; right: 40;
-		}
-	</style>
+        window.addEventListener('message', function(event) {
+            var item = event.data;
+            if (item.setmoney) {
+                document.getElementById('cash').innerHTML = "<div><font style='color: rgb(0, 125, 0); font-weight: 700; margin-right: 6px;'>£</font>" + addCommas(item.money);
+            }
+            if (item.addcash) {
+                document.querySelectorAll('.tiny').forEach(function(el){ el.remove(); });
+                var element = document.createElement('div');
+                element.className = 'tiny';
+                element.innerHTML = "+<font style='color: rgb(0, 125, 0); font-weight: 700; margin-right: 6px;'>£</font>" + addCommas(item.money);
+                document.getElementById('money').appendChild(element);
+                setTimeout(function(){ element.style.opacity = 0; setTimeout(function(){ element.remove(); }, 600); }, 1000);
+            }
+            if (item.removecash) {
+                document.querySelectorAll('.tiny').forEach(function(el){ el.remove(); });
+                var element = document.createElement('div');
+                element.className = 'tiny';
+                element.innerHTML = "-<font style='color: rgb(250, 0, 0); font-weight: 700; margin-right: 6px;'>£</font>" + addCommas(item.money);
+                document.getElementById('money').appendChild(element);
+                setTimeout(function(){ element.style.opacity = 0; setTimeout(function(){ element.remove(); }, 600); }, 1000);
+            }
+            if (item.removeStartWindow) {
+                var starter = document.getElementById('starter');
+                if (starter) starter.remove();
+            }
+            if (item.setDisplay) {
+                document.getElementById('money').style.opacity = item.display;
+            }
+        });
+    </script>
 </head>
-
 <body>
-	<div id="starter" style="font-family: 'roboto'; color: white; position: absolute; left: 20%; top: 5%; width: 60%; background: rgba(40, 40, 40, 0.8)">
-
-	</div>
-	<div id="container">
-		<div id="money">
-
-			<div id="cash"/>
-		</div>
-	</div>
+    <div id="starter" style="font-family: 'roboto'; color: white; position: absolute; left: 20%; top: 5%; width: 60%; background: rgba(40, 40, 40, 0.8)"></div>
+    <div id="container">
+        <div id="money">
+            <div id="cash"></div>
+        </div>
+    </div>
 </body>
+</html>


### PR DESCRIPTION
## Summary
- centralize EssentialMode globals and defaults in a shared config file
- modernize manifest and server logic to use Lua 5.4 and awaited MySQL queries
- simplify client position reporting and rewrite NUI to vanilla JS
- document new architecture and jQuery removal

## Testing
- `luac -p Example_Frameworks/essentialmode/essentialmode/server/config.lua`
- `luac -p Example_Frameworks/essentialmode/essentialmode/server/main.lua`
- `luac -p Example_Frameworks/essentialmode/essentialmode/server/player/login.lua`
- `luac -p Example_Frameworks/essentialmode/essentialmode/client/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1bb58830c832d8cac6976f1de1f9a