### PR TITLE
feat(vrp): forward disconnect reasons

### DIFF
--- a/Example_Frameworks/vRP/docs.md
+++ b/Example_Frameworks/vRP/docs.md
@@ -69,7 +69,7 @@ Shared logic used by both client and server, including data structures and helpe
 Defines the server-side User class managing player state, identifiers, and data persistence.
 
 #### base.lua
-Server bootstrap registering spawn/death events and delegating to vRP handlers.
+Server bootstrap registering spawn/death events and delegating to vRP handlers. Event handlers now cache the player `source` locally and pass along disconnect reasons to ensure reliable processing.
 
 ### Client Scripts
 All client scripts use `CreateThread`, `Wait`, and `PlayerPedId()` to align with current FiveM best practices.
@@ -260,7 +260,7 @@ Shared utilities used by both client and server.
 | playerSpawned | client event | client/base.lua forwards spawn to server. |
 | vRPcli:playerSpawned | server event | base.lua calls `onPlayerSpawned`. |
 | vRPcli:playerDied | server event | base.lua calls `onPlayerDied`. |
-| playerDropped | server event | base.lua cleans up user data. |
+| playerDropped | server event | base.lua cleans up user data and forwards the disconnect reason. |
 | playerConnecting | server raw event | login.lua performs authentication and whitelist checks. |
 | vRP:profile | network event | utils.lua registers; profiler.lua triggers to start profiling. |
 | vRP:profile:res | network event | profiler.lua handles profiling results. |
@@ -268,7 +268,7 @@ Shared utilities used by both client and server.
 | playerDeath | local event | Money, PlayerState, Survival, Phone, Inventory, Home modules respond. |
 | characterLoad | local event | Aptitude, Garage, Group, Home, Identity, Inventory, Money, Phone, PlayerState, Police, Survival modules load character data. |
 | characterUnload | local event | Garage, GUI, Home, PlayerState modules save or cleanup. |
-| playerLeave | local event | GUI, Home, Map, Police modules handle disconnect. |
+| playerLeave | local event | GUI, Home, Map, Police modules handle disconnect; now receives an optional reason. |
 | playerMoneyUpdate | local event | Money module notifies of balance changes. |
 | playerStateLoaded | local event | Garage prepares owned vehicles. |
 | playerMissionStart/Step/Stop | local event | Mission module tracks mission progress. |

--- a/Example_Frameworks/vRP/vrp/base.lua
+++ b/Example_Frameworks/vRP/vrp/base.lua
@@ -93,16 +93,21 @@ async(function() vRP:execute("vRP/base_tables") end)
 
 -- handlers
 
-AddEventHandler("playerDropped",function(reason)
-  vRP:onPlayerDropped(source)
+AddEventHandler("playerDropped", function(reason)
+  local src = source
+  vRP:onPlayerDropped(src, reason)
 end)
 
-RegisterNetEvent("vRPcli:playerSpawned", function()
-  vRP:onPlayerSpawned(source)
+RegisterNetEvent("vRPcli:playerSpawned")
+AddEventHandler("vRPcli:playerSpawned", function()
+  local src = source
+  vRP:onPlayerSpawned(src)
 end)
 
-RegisterNetEvent("vRPcli:playerDied", function()
-  vRP:onPlayerDied(source)
+RegisterNetEvent("vRPcli:playerDied")
+AddEventHandler("vRPcli:playerDied", function()
+  local src = source
+  vRP:onPlayerDied(src)
 end)
 
 local lang = vRP.lang

--- a/Example_Frameworks/vRP/vrp/vRP.lua
+++ b/Example_Frameworks/vRP/vrp/vRP.lua
@@ -269,19 +269,23 @@ function vRP:connectUser(source)
   return user
 end
 
-function vRP:disconnectUser(source)
+function vRP:disconnectUser(source, reason)
   local user = self.users_by_source[source]
   if user then
     -- remove player from connected clients
     self.EXT.Base.remote._removePlayer(-1, user.source)
     self:triggerEventSync("characterUnload", user)
-    self:triggerEventSync("playerLeave", user)
+    self:triggerEventSync("playerLeave", user, reason)
     -- save user
     user:save()
     -- unreference
     self.users[user.id] = nil
     self.users_by_source[user.source] = nil
-    self:log(user.name.." ("..user.endpoint..") disconnected (user_id = "..user.id..")")
+    local msg = string.format("%s (%s) disconnected (user_id = %s)", user.name, user.endpoint, user.id)
+    if reason and reason ~= "" then
+      msg = msg .. " [reason: " .. reason .. "]"
+    end
+    self:log(msg)
   end
 end
 
@@ -374,8 +378,8 @@ function vRP:onPlayerSpawned(source)
   end
 end
 
-function vRP:onPlayerDropped(source)
-  self:disconnectUser(source)
+function vRP:onPlayerDropped(source, reason)
+  self:disconnectUser(source, reason)
 end
 
 function vRP:onPlayerDied(source)


### PR DESCRIPTION
## Summary
- capture player source locally for spawn, death and drop events
- forward disconnect reasons through vRP and include in logs
- document updated event behavior

## Testing
- `luac -p Example_Frameworks/vRP/vrp/base.lua`
- `luac -p Example_Frameworks/vRP/vrp/vRP.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1bdb50ebc832dbbc13f8de624bd2e