### PR TITLE
refactor: guard server callbacks and optimize timeout

### DIFF
--- a/Example_Frameworks/es_extended/docs.md
+++ b/Example_Frameworks/es_extended/docs.md
@@ -54,7 +54,8 @@ Creates the ESX client object and utility methods.
 - Provides notification helpers and a generic `ESX.TriggerServerCallback` RPC using `esx:triggerServerCallback`/`esx:serverCallback` events.
 - `ESX.SetPlayerData` broadcasts changes through `esx:setPlayerData` so imports.lua can mirror PlayerData.
 - Registers network events to update inventory, weapons, accounts, job, and to display `esx:showNotification`, `esx:showAdvancedNotification`, and `esx:showHelpNotification` messages from the server.
-- Implements a robust `ESX.SetTimeout` scheduler using unique identifiers and pair iteration to prevent skipped callbacks.
+- Implements a robust `ESX.SetTimeout` scheduler using unique identifiers, calculating precise waits to minimize idle CPU time.
+- Safely handles server callback responses by verifying the request ID before executing the stored callback and logging unexpected responses.
 - `ESX.ShowNotification` now passes boolean parameters to `DrawNotification` per current native recommendations.
 
 ### client/common.lua


### PR DESCRIPTION
## Summary
- validate `esx:serverCallback` responses before executing stored handler
- reduce idle CPU by sleeping until the next scheduled ESX timeout
- document safer callback handling and improved scheduler

## Testing
- `luac -p Example_Frameworks/es_extended/client/functions.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1bed34424832d8f3625f919ac52b3