### PR TITLE
feat: harden voip server

### DIFF
--- a/Example_Frameworks/vRP/docs.md
+++ b/Example_Frameworks/vRP/docs.md
@@ -52,7 +52,7 @@ Per-module descriptive documents explaining behaviour and configuration of each 
 Immutable Node configuration defining WebSocket signalling port, WebRTC port range, and optional STUN servers.
 
 ### voip_server/main.js
-Modernized WebSocket/WebRTC relay that tracks players with a `Map`, forwards voice packets between shared channels, and cleans up channel membership on disconnect.
+WebSocket/WebRTC relay that tracks players with a `Map`, forwards voice packets between shared channels, and cleans up channel membership on disconnect. The server now pings clients every 30s to remove stale connections and parses incoming messages defensively to avoid crashes from malformed data.
 
 ## vrp Framework
 ### Core Files


### PR DESCRIPTION
## Summary
- add heartbeat ping to VOIP server to drop stale websocket connections
- wrap inbound JSON parsing in try/catch for stability
- document new heartbeat and defensive parsing in vRP docs

## Testing
- `node --check Example_Frameworks/vRP/voip_server/main.js`
- `node Example_Frameworks/vRP/voip_server/main.js` *(fails: Cannot find module 'ws')*


------
https://chatgpt.com/codex/tasks/task_e_68c1bf0b7a58832d85e2d645e751984b