### PR TITLE
refactor: modernize connectqueue resource

### DIFF
--- a/Example_Frameworks/NoPixelServer/connectqueue/connectqueue.lua
+++ b/Example_Frameworks/NoPixelServer/connectqueue/connectqueue.lua
@@ -1,42 +1,97 @@
-Queue = {}
-Queue.Ready = false
-Queue.Exports = nil
-Queue.ReadyCbs = {}
-Queue.CurResource = GetCurrentResourceName()
+Queue = {
+    Ready = false,
+    Exports = nil,
+    ReadyCbs = {},
+    CurResource = GetCurrentResourceName()
+}
 
-if Queue.CurResource == "connectqueue" then return end
+if Queue.CurResource == 'connectqueue' then
+    return
+end
 
+--[[
+    -- Type: Function
+    -- Name: OnReady
+    -- Use: Executes callback once queue exports are loaded
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function Queue.OnReady(cb)
     if not cb then return end
-    if Queue.IsReady() then cb() return end
+    if Queue.IsReady() then
+        cb()
+        return
+    end
     table.insert(Queue.ReadyCbs, cb)
 end
 
+--[[
+    -- Type: Function
+    -- Name: OnJoin
+    -- Use: Registers callback for player join events
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function Queue.OnJoin(cb)
     if not cb then return end
     Queue.Exports:OnJoin(cb, Queue.CurResource)
 end
 
+--[[
+    -- Type: Function
+    -- Name: AddPriority
+    -- Use: Grants priority to a specific identifier
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function Queue.AddPriority(id, power, temp)
     if not Queue.IsReady() then return end
     Queue.Exports:AddPriority(id, power, temp)
 end
 
+--[[
+    -- Type: Function
+    -- Name: RemovePriority
+    -- Use: Revokes priority from an identifier
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function Queue.RemovePriority(id)
     if not Queue.IsReady() then return end
     Queue.Exports:RemovePriority(id)
 end
 
+--[[
+    -- Type: Function
+    -- Name: IsReady
+    -- Use: Checks if queue exports are available
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function Queue.IsReady()
     return Queue.Ready
 end
 
+--[[
+    -- Type: Function
+    -- Name: LoadExports
+    -- Use: Retrieves queue exports and marks module ready
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function Queue.LoadExports()
     Queue.Exports = exports.connectqueue:GetQueueExports()
     Queue.Ready = true
     Queue.ReadyCallbacks()
 end
 
+--[[
+    -- Type: Function
+    -- Name: ReadyCallbacks
+    -- Use: Executes queued callbacks once exports are ready
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function Queue.ReadyCallbacks()
     if not Queue.IsReady() then return end
     for _, cb in ipairs(Queue.ReadyCbs) do
@@ -44,19 +99,24 @@ function Queue.ReadyCallbacks()
     end
 end
 
-AddEventHandler("onResourceStart", function(resource)
-    if resource == "connectqueue" then
-        while GetResourceState(resource) ~= "started" do Citizen.Wait(0) end
-        Citizen.Wait(1)
+AddEventHandler('onResourceStart', function(resource)
+    if resource == 'connectqueue' then
+        while GetResourceState(resource) ~= 'started' do
+            Wait(0)
+        end
+        Wait(1)
         Queue.LoadExports()
     end
 end)
 
-AddEventHandler("onResourceStop", function(resource)
-    if resource == "connectqueue" then
+AddEventHandler('onResourceStop', function(resource)
+    if resource == 'connectqueue' then
         Queue.Ready = false
         Queue.Exports = nil
     end
 end)
 
-SetTimeout(1, function() Queue.LoadExports() end)
+CreateThread(function()
+    Wait(0)
+    Queue.LoadExports()
+end)

--- a/Example_Frameworks/NoPixelServer/connectqueue/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/connectqueue/fxmanifest.lua
@@ -1,8 +1,11 @@
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'gta5'
 
-server_script "server/sv_queue_config.lua"
-server_script "connectqueue.lua"
+lua54 'yes'
 
-server_script "shared/sh_queue.lua"
-client_script "shared/sh_queue.lua"
+shared_script 'shared/sh_queue.lua'
+
+server_scripts {
+    'server/sv_queue_config.lua',
+    'connectqueue.lua'
+}

--- a/Example_Frameworks/NoPixelServer/connectqueue/shared/sh_queue.lua
+++ b/Example_Frameworks/NoPixelServer/connectqueue/shared/sh_queue.lua
@@ -1,7 +1,7 @@
 if not IsDuplicityVersion() then
-    Citizen.CreateThread(function()
+    CreateThread(function()
         while true do
-            Citizen.Wait(0)
+            Wait(0)
             if NetworkIsSessionStarted() then
                 TriggerServerEvent("Queue:playerActivated")
                 return
@@ -28,7 +28,7 @@ _Queue.Priority = {}
 _Queue.Connecting = {}
 _Queue.JoinCbs = {}
 _Queue.TempPriority = {}
-_Queue.JoinDelay = GetGameTimer() + Config.JoinDelay and Config.JoinDelay or 0
+_Queue.JoinDelay = GetGameTimer() + (Config.JoinDelay or 0)
 
 local tostring = tostring
 local tonumber = tonumber
@@ -59,13 +59,19 @@ function Queue:DebugPrint(msg)
     end
 end
 
+--[[
+    -- Type: Function
+    -- Name: HexIdToSteamId
+    -- Use: Converts a hexadecimal identifier to a Steam ID
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function Queue:HexIdToSteamId(hexId)
     local cid = math_floor(tonumber(string_sub(hexId, 7), 16))
-	local steam64 = math_floor(tonumber(string_sub( cid, 2)))
-	local a = steam64 % 2 == 0 and 0 or 1
-	local b = math_floor(math_abs(6561197960265728 - steam64 - a) / 2)
-	local sid = "steam_0:"..a..":"..(a == 1 and b -1 or b)
-    return sid
+    local steam64 = math_floor(tonumber(string_sub(tostring(cid), 2)))
+    local a = steam64 % 2
+    local b = math_floor(math_abs(6561197960265728 - steam64 - a) / 2)
+    return string_format("steam_0:%d:%d", a, a == 1 and b - 1 or b)
 end
 
 function Queue:IsSteamRunning(src)
@@ -422,7 +428,7 @@ function Queue:CanJoin(src, cb)
             await = false
         end)
 
-        while await do Citizen.Wait(0) end
+        while await do Wait(0) end
 
         if not allow then return end
     end
@@ -450,15 +456,15 @@ local function playerConnect(name, setKickReason, deferrals)
 
     deferrals.defer()
 
-    Citizen.CreateThread(function()
+    CreateThread(function()
         while connecting do
-            Citizen.Wait(100)
+            Wait(100)
             if not connecting then return end
             deferrals.update(Config.Language.connecting)
         end
     end)
 
-    Citizen.Wait(500)
+    Wait(500)
 
     local function done(msg, _deferrals)
         connecting = false
@@ -467,7 +473,7 @@ local function playerConnect(name, setKickReason, deferrals)
 
         if msg then deferrals.update(tostring(msg) or "") end
 
-        Citizen.Wait(500)
+        Wait(500)
 
         if not msg then
             deferrals.done()
@@ -520,7 +526,7 @@ local function playerConnect(name, setKickReason, deferrals)
         allow = true
     end) 
 
-    while allow == nil do Citizen.Wait(0) end
+    while allow == nil do Wait(0) end
     if not allow then return end
 
     if Config.PriorityOnly and not Queue:IsPriority(ids) then done(Config.Language.wlonly) return end
@@ -588,7 +594,7 @@ local function playerConnect(name, setKickReason, deferrals)
     if rejoined then return end
 
     while true do
-        Citizen.Wait(500)
+        Wait(500)
 
         local pos, data = Queue:IsInQueue(ids, true)
 
@@ -626,7 +632,7 @@ local function playerConnect(name, setKickReason, deferrals)
             local added = Queue:AddToConnecting(ids)
 
             update(Config.Language.joining, data.deferrals)
-            Citizen.Wait(500)
+            Wait(500)
 
             if not added then
                 done(Config.Language.connectingerr)
@@ -652,7 +658,7 @@ local function playerConnect(name, setKickReason, deferrals)
 end
 AddEventHandler("playerConnecting", playerConnect)
 
-Citizen.CreateThread(function()
+CreateThread(function()
     local function remove(data, pos, msg)
         if data and data.source then
             Queue:RemoveFromQueue(data.source, true)
@@ -663,7 +669,7 @@ Citizen.CreateThread(function()
     end
 
     while true do
-        Citizen.Wait(1000)
+        Wait(1000)
     
         local i = 1
     
@@ -705,7 +711,7 @@ Citizen.CreateThread(function()
     end
 end)
 
-RegisterServerEvent("Queue:playerActivated")
+RegisterNetEvent("Queue:playerActivated")
 AddEventHandler("Queue:playerActivated", function()
     local src = source
     local ids = Queue:GetIds(src)

--- a/Example_Frameworks/NoPixelServer/docs.md
+++ b/Example_Frameworks/NoPixelServer/docs.md
@@ -6,3 +6,10 @@
 - Added radius constant to blackjack table locator and corrected prop name outputs.
 - Moved animation dictionary cleanup outside the dealer creation loop to prevent missing animation issues.
 - Converted global state to local variables and tightened betting validation on the server.
+
+## connectqueue
+- Migrated to `cerulean` fx_version, enabled `lua54`, and consolidated shared scripts.
+- Replaced deprecated `Citizen` calls with `CreateThread` and `Wait` for both server and client contexts.
+- Corrected hexadecimal Steam ID conversion to prevent runtime errors.
+- Fixed join delay initialization so queue startup delay honors configuration.
+- Registered `Queue:playerActivated` with `RegisterNetEvent` for network event compatibility.


### PR DESCRIPTION
## Summary
- update connectqueue manifest to cerulean and Lua 5.4
- refactor queue exports loader to use modern threads and waits
- fix hex->steam conversion and join delay initialization in sh_queue

## Testing
- `luac -p Example_Frameworks/NoPixelServer/connectqueue/connectqueue.lua`
- `luac -p Example_Frameworks/NoPixelServer/connectqueue/shared/sh_queue.lua`
- `luac -p Example_Frameworks/NoPixelServer/connectqueue/server/sv_queue_config.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1c4734f54832dae9b4c61786a4b71