### PR TITLE
refactor: modernize cron scheduler

### DIFF
--- a/Example_Frameworks/NoPixelServer/cron/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/cron/__resource.lua
@@ -1,7 +1,0 @@
-resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
-
-description 'cron'
-
-version '1.0.0'
-
-server_script 'server/main.lua'

--- a/Example_Frameworks/NoPixelServer/cron/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/cron/fxmanifest.lua
@@ -1,0 +1,9 @@
+fx_version 'cerulean'
+game 'gta5'
+
+lua54 'yes'
+
+description 'cron'
+version '1.0.0'
+
+server_script 'server/main.lua'

--- a/Example_Frameworks/NoPixelServer/docs.md
+++ b/Example_Frameworks/NoPixelServer/docs.md
@@ -6,3 +6,8 @@
 - Added radius constant to blackjack table locator and corrected prop name outputs.
 - Moved animation dictionary cleanup outside the dealer creation loop to prevent missing animation issues.
 - Converted global state to local variables and tightened betting validation on the server.
+
+## cron
+- Migrated resource to `fxmanifest.lua` and enabled Lua 5.4 support.
+- Replaced legacy timer loop with `CreateThread` scheduler that accounts for skipped minutes.
+- Added `cron:runAt` event and `RunAt` export for registering scheduled callbacks.


### PR DESCRIPTION
## Summary
- migrate cron resource to fxmanifest and enable Lua 5.4
- refactor cron scheduler to CreateThread-based loop and expose RunAt export
- document cron changes in NoPixelServer docs

## Testing
- `luac -p Example_Frameworks/NoPixelServer/cron/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1c4839fb4832daebb668c0af8859d