### PR TITLE
refactor(np-barriers): modernize barrier placement

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-barriers/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-barriers/__resource.lua
@@ -1,1 +1,0 @@
-client_script "client.lua"

--- a/Example_Frameworks/NoPixelServer/np-barriers/client.lua
+++ b/Example_Frameworks/NoPixelServer/np-barriers/client.lua
@@ -1,106 +1,167 @@
-RegisterNetEvent('barriers:pickup')
-RegisterNetEvent('barriers:cone')
-RegisterNetEvent('barriers:sbarrier')
-RegisterNetEvent('barriers:barrier')
+--[[
+    -- Type: Resource
+    -- Name: np-barriers
+    -- Use: Handles placement and removal of cones and barriers
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
 
-objList = {
-	[1] = "prop_mp_cone_01",
-	[2] = "prop_mp_barrier_02b",
-	[3] = "prop_barrier_work05",
-	[4] = "prop_flare_01",
-	[5] = "prop_flare_01b",
-	[6] = "prop_mp_cone_01",
+--[[
+    -- Type: Table
+    -- Name: objList
+    -- Use: Models that can be picked up by the pickup event
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+local objList = {
+    "prop_mp_cone_01",
+    "prop_mp_barrier_02b",
+    "prop_barrier_work05",
+    "prop_flare_01",
+    "prop_flare_01b"
 }
 
-function loadAnimDict( dict )
-    while ( not HasAnimDictLoaded( dict ) ) do
-        RequestAnimDict( dict )
-        Citizen.Wait( 5 )
+--[[
+    -- Type: Function
+    -- Name: loadAnimDict
+    -- Use: Requests and waits for an animation dictionary
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+local function loadAnimDict(dict)
+    while not HasAnimDictLoaded(dict) do
+        RequestAnimDict(dict)
+        Wait(0)
     end
 end
 
-AddEventHandler('barriers:pickup', function()
-    loadAnimDict('anim@narcotics@trash')
-    TaskPlayAnim(PlayerPedId(),'anim@narcotics@trash', 'drop_front',0.9, -8, 1700, 49, 1.0, 0, 0, 0)
-	local finished = exports["np-taskbar"]:taskBar(1800,"Picking up barrier")
-  	if finished == 100 then
-		local x,y,z = table.unpack(GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 0.25, 0.0))
-		local heading = GetEntityHeading(PlayerPedId())
-		local objFound = 0
-		for i = 1, #objList do
-			local x,y,z = table.unpack(GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 0.25, 0.0))
-			objFound = GetClosestObjectOfType(x, y, z, 5.0, GetHashKey(objList[i]), 0, 0, 0)
-			DeleteObject(objFound)
-			DeleteEntity(objFound)
+--[[
+    -- Type: Function
+    -- Name: loadModel
+    -- Use: Requests and waits for a model to load
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+local function loadModel(model)
+    if type(model) == "string" then
+        model = GetHashKey(model)
+    end
+    while not HasModelLoaded(model) do
+        RequestModel(model)
+        Wait(0)
+    end
+    return model
+end
 
-			DeleteObject(objFound)
-			DeleteEntity(objFound)
-		end
-		TriggerServerEvent("aidsarea",false,x,y,z, heading)
-	end
+--[[
+    -- Type: Function
+    -- Name: playPlacementAnim
+    -- Use: Plays placement animation and shows taskbar
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+local function playPlacementAnim(label)
+    loadAnimDict("anim@narcotics@trash")
+    TaskPlayAnim(PlayerPedId(), "anim@narcotics@trash", "drop_front", 0.9, -8.0, 1700, 49, 0.0, false, false, false)
+    local finished = exports["np-taskbar"]:taskBar(1800, label)
+    return finished == 100
+end
+
+--[[
+    -- Type: Function
+    -- Name: placeProp
+    -- Use: Spawns a prop at provided coordinates and heading
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+local function placeProp(modelName, x, y, z, heading)
+    local model = loadModel(modelName)
+    local obj = CreateObject(model, x, y, z, true, false, false)
+    PlaceObjectOnGroundProperly(obj)
+    SetEntityHeading(obj, heading or 0.0)
+    SetModelAsNoLongerNeeded(model)
+    return obj
+end
+
+--[[
+    -- Type: Event
+    -- Name: barriers:pickup
+    -- Use: Removes nearby barrier objects
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("barriers:pickup")
+AddEventHandler("barriers:pickup", function()
+    if not playPlacementAnim("Picking up barrier") then return end
+    local ped = PlayerPedId()
+    local x, y, z = table.unpack(GetOffsetFromEntityInWorldCoords(ped, 0.0, 0.25, 0.0))
+    local heading = GetEntityHeading(ped)
+    for _, model in ipairs(objList) do
+        local obj = GetClosestObjectOfType(x, y, z, 5.0, GetHashKey(model), false, false, false)
+        if obj and obj ~= 0 then
+            SetEntityAsMissionEntity(obj, true, true)
+            DeleteObject(obj)
+        end
+    end
+    TriggerServerEvent("aidsarea", false, x, y, z, heading)
 end)
 
-AddEventHandler('barriers:cone', function()
-    loadAnimDict('anim@narcotics@trash')
-    TaskPlayAnim(PlayerPedId(),'anim@narcotics@trash', 'drop_front',0.9, -8, 1700, 49, 3.0, 0, 0, 0)
-	local finished = exports["np-taskbar"]:taskBar(1800,"Placing Cone")
-  	if finished == 100 then	
-		local x,y,z = table.unpack(GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 2.2, 0.0))
-		local heading = GetEntityHeading(PlayerPedId())
-		RequestModel('prop_mp_cone_01')
-		while not HasModelLoaded('prop_mp_cone_01') do
-			Citizen.Wait(1)
-		end
-		local cone = CreateObject('prop_mp_cone_01', x, y, z, true, false, false)
-		exports["isPed"]:GlobalObject(cone)
-		PlaceObjectOnGroundProperly(cone)
-		SetEntityHeading(cone, heading)
-	end
+--[[
+    -- Type: Event
+    -- Name: barriers:cone
+    -- Use: Places a traffic cone in front of the player
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("barriers:cone")
+AddEventHandler("barriers:cone", function()
+    if not playPlacementAnim("Placing Cone") then return end
+    local ped = PlayerPedId()
+    local x, y, z = table.unpack(GetOffsetFromEntityInWorldCoords(ped, 0.0, 2.2, 0.0))
+    local heading = GetEntityHeading(ped)
+    local cone = placeProp("prop_mp_cone_01", x, y, z, heading)
+    exports["isPed"]:GlobalObject(cone)
 end)
 
-AddEventHandler('barriers:sbarrier', function()
-    loadAnimDict('anim@narcotics@trash')
-    TaskPlayAnim(PlayerPedId(),'anim@narcotics@trash', 'drop_front',0.9, -8, 1700, 49, 3.0, 0, 0, 0)
-	local finished = exports["np-taskbar"]:taskBar(1800,"Placing Barrier")
-  	if finished == 100 then	
-		local x,y,z = table.unpack(GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 2.2, 0.0))
-		local heading = GetEntityHeading(PlayerPedId())
-		RequestModel('prop_barrier_work05')
-		while not HasModelLoaded('prop_barrier_work05') do
-			Citizen.Wait(1)
-		end
-		local sbarrier = CreateObject('prop_barrier_work05', x, y, z, true, false, false)
-		exports["isPed"]:GlobalObject(sbarrier)
-		PlaceObjectOnGroundProperly(sbarrier)
-		SetEntityHeading(sbarrier, heading)
-	end
+--[[
+    -- Type: Event
+    -- Name: barriers:sbarrier
+    -- Use: Places a single barrier in front of the player
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("barriers:sbarrier")
+AddEventHandler("barriers:sbarrier", function()
+    if not playPlacementAnim("Placing Barrier") then return end
+    local ped = PlayerPedId()
+    local x, y, z = table.unpack(GetOffsetFromEntityInWorldCoords(ped, 0.0, 2.2, 0.0))
+    local heading = GetEntityHeading(ped)
+    local barrier = placeProp("prop_barrier_work05", x, y, z, heading)
+    exports["isPed"]:GlobalObject(barrier)
 end)
 
-AddEventHandler('barriers:barrier', function()
-    loadAnimDict('anim@narcotics@trash')
-    TaskPlayAnim(PlayerPedId(),'anim@narcotics@trash', 'drop_front',0.9, -8, 1700, 49, 3.0, 0, 0, 0)
-	local finished = exports["np-taskbar"]:taskBar(1800,"Placing Roadblock")
-  	if finished == 100 then
-		local x,y,z = table.unpack(GetOffsetFromEntityInWorldCoords(PlayerPedId(), 0.0, 2.2, 0.0))
-		local c1x,c1y,c1z = table.unpack(GetOffsetFromEntityInWorldCoords(PlayerPedId(), 1.5, 2.2, 0.0))
-		local c2x,c2y,c2z = table.unpack(GetOffsetFromEntityInWorldCoords(PlayerPedId(), -1.5, 2.2, 0.0))
-		local heading = GetEntityHeading(PlayerPedId())
-		RequestModel('prop_barrier_work05')
-		while not HasModelLoaded('prop_barrier_work05') do
-			Citizen.Wait(1)
-		end
-		local barrier = CreateObject('prop_barrier_work05', x, y, z, true, false, false)
-		local cone = CreateObject('prop_mp_cone_01', c1x,c1y,c1z, true, false, false)
-		local cone2 = CreateObject('prop_mp_cone_01', c2x,c2y,c2z, true, false, false)
-		PlaceObjectOnGroundProperly(barrier)
-		PlaceObjectOnGroundProperly(cone)
-		PlaceObjectOnGroundProperly(cone2)
-		SetEntityHeading(barrier, heading)
-		exports["isPed"]:GlobalObject(barrier)
-		exports["isPed"]:GlobalObject(cone)
-		exports["isPed"]:GlobalObject(cone2)
-		TriggerEvent("DoLongHudText","Traffic Blocked in facing direction.",1)
-		TriggerServerEvent("aidsarea",true,x,y,z, heading)
-	end
+--[[
+    -- Type: Event
+    -- Name: barriers:barrier
+    -- Use: Places a barrier with cones on each side and notifies players
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("barriers:barrier")
+AddEventHandler("barriers:barrier", function()
+    if not playPlacementAnim("Placing Roadblock") then return end
+    local ped = PlayerPedId()
+    local bx, by, bz = table.unpack(GetOffsetFromEntityInWorldCoords(ped, 0.0, 2.2, 0.0))
+    local c1x, c1y, c1z = table.unpack(GetOffsetFromEntityInWorldCoords(ped, 1.5, 2.2, 0.0))
+    local c2x, c2y, c2z = table.unpack(GetOffsetFromEntityInWorldCoords(ped, -1.5, 2.2, 0.0))
+    local heading = GetEntityHeading(ped)
+    local barrier = placeProp("prop_barrier_work05", bx, by, bz, heading)
+    local cone1 = placeProp("prop_mp_cone_01", c1x, c1y, c1z, heading)
+    local cone2 = placeProp("prop_mp_cone_01", c2x, c2y, c2z, heading)
+    exports["isPed"]:GlobalObject(barrier)
+    exports["isPed"]:GlobalObject(cone1)
+    exports["isPed"]:GlobalObject(cone2)
+    TriggerEvent("DoLongHudText", "Traffic Blocked in facing direction.", 1)
+    TriggerServerEvent("aidsarea", true, bx, by, bz, heading)
 end)
 

--- a/Example_Frameworks/NoPixelServer/np-barriers/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-barriers/fxmanifest.lua
@@ -1,0 +1,5 @@
+fx_version 'cerulean'
+game 'gta5'
+lua54 'yes'
+
+client_script 'client.lua'


### PR DESCRIPTION
## Summary
- replace deprecated __resource manifest with fxmanifest and Lua 5.4
- refactor barrier client script with reusable helpers and improved deletion logic
- standardize animation/model loading and add structured comments

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-barriers/client.lua`
- `luacheck Example_Frameworks/NoPixelServer/np-barriers/client.lua` *(warnings: accessing undefined globals)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cd22bb80832d81fb2a7b397835c7