### PR TITLE
refactor(np-broadcaster): modernize broadcaster resource

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-broadcaster/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-broadcaster/__resource.lua
@@ -1,9 +1,0 @@
-resource_manifest_version "44febabe-d386-4d18-afbe-5e627f4af937"
-
-
-client_script "@np-errorlog/client/cl_errorlog.lua"
-
-client_script {
-  "cl_broadcast.lua"
-}
-server_script "sv_broadcast.lua"

--- a/Example_Frameworks/NoPixelServer/np-broadcaster/cl_broadcast.lua
+++ b/Example_Frameworks/NoPixelServer/np-broadcaster/cl_broadcast.lua
@@ -1,87 +1,102 @@
-local isBroadcasting = false
-local takingService = {
-	{x=1989.08, y=-1753.94, z=-158.86},
-}
+local BROADCAST_RADIO = 19829
+local STATIONS = { vector3(1989.08, -1753.94, -158.86) }
+local NEAR_DISTANCE = 3.0
+local LEAVE_DISTANCE = 30.0
 
-function DrawText3Ds(x,y,z, text)
-    local onScreen,_x,_y=World3dToScreen2d(x,y,z)
-    local px,py,pz=table.unpack(GetGameplayCamCoords())
-    
+local isBroadcasting = false
+
+--[[ 
+    -- Type: Function
+    -- Name: drawText3D
+    -- Use: Renders 3D text at a world coordinate
+    -- Created: 2024-02-16
+    -- By: VSSVSSN
+--]]
+local function drawText3D(x, y, z, text)
+    local onScreen, _x, _y = World3dToScreen2d(x, y, z)
+    if not onScreen then return end
     SetTextScale(0.35, 0.35)
     SetTextFont(4)
     SetTextProportional(1)
     SetTextColour(255, 255, 255, 215)
-
-    SetTextEntry("STRING")
+    SetTextEntry('STRING')
     SetTextCentre(1)
     AddTextComponentString(text)
-    DrawText(_x,_y)
-    local factor = (string.len(text)) / 370
-    DrawRect(_x,_y+0.0125, 0.015+ factor, 0.03, 41, 11, 41, 68)
+    DrawText(_x, _y)
+    local factor = string.len(text) / 370
+    DrawRect(_x, _y + 0.0125, 0.015 + factor, 0.03, 41, 11, 41, 68)
 end
 
--- #MarkedForMarker
-function isNearTakeService()
-	for i = 1, #takingService do
-		local ply = PlayerPedId()
-		local plyCoords = GetEntityCoords(ply, 0)
-		local distance = #(vector3(takingService[i].x, takingService[i].y, takingService[i].z) - vector3(plyCoords["x"], plyCoords["y"], plyCoords["z"]))
-		if(distance < 3.0) then
-			DrawText3Ds(takingService[i].x, takingService[i].y, takingService[i].z, "[E] To Broadcast Here ,[F] Stop Broadcasting Here" )
-		end
-		if(distance < 3.0) then
-			return true
-		end
-	end
+--[[ 
+    -- Type: Function
+    -- Name: isPlayerNearStation
+    -- Use: Checks if player is within distance of a broadcast station
+    -- Created: 2024-02-16
+    -- By: VSSVSSN
+--]]
+local function isPlayerNearStation(dist)
+    local ped = PlayerPedId()
+    local pCoords = GetEntityCoords(ped)
+    for _, station in ipairs(STATIONS) do
+        if #(pCoords - station) < dist then
+            return true, station
+        end
+    end
+    return false, nil
 end
 
-function isNearBroadcast()
-	for i = 1, #takingService do
-		local ply = PlayerPedId()
-		local plyCoords = GetEntityCoords(ply, 0)
-		local distance = #(vector3(takingService[i].x, takingService[i].y, takingService[i].z) - vector3(plyCoords["x"], plyCoords["y"], plyCoords["z"]))
-		if(distance < 30.0) then
-			return true
-		end
-	end
+--[[ 
+    -- Type: Function
+    -- Name: startBroadcast
+    -- Use: Adds player to radio channel and marks broadcasting
+    -- Created: 2024-02-16
+    -- By: VSSVSSN
+--]]
+local function startBroadcast()
+    TriggerServerEvent('TokoVoip:addPlayerToRadio', BROADCAST_RADIO, GetPlayerServerId(PlayerId()))
+    isBroadcasting = true
+end
+
+--[[ 
+    -- Type: Function
+    -- Name: stopBroadcast
+    -- Use: Removes player from radio and job
+    -- Created: 2024-02-16
+    -- By: VSSVSSN
+--]]
+local function stopBroadcast()
+    isBroadcasting = false
+    TriggerServerEvent('TokoVoip:removePlayerFromAllRadio', GetPlayerServerId(PlayerId()))
+    TriggerServerEvent('jobssystem:jobs', 'unemployed')
+    TriggerEvent('DoLongHudText', 'You have left the broadcasting job!', 1)
 end
 
 RegisterNetEvent('event:control:broadcast')
 AddEventHandler('event:control:broadcast', function(useID)
     if useID == 1 then
-    	TriggerServerEvent('attemptBroadcast')	
+        TriggerServerEvent('attemptBroadcast')
     elseif useID == 2 and isBroadcasting then
-    	isBroadcasting = false
-		TriggerServerEvent("TokoVoip:removePlayerFromAllRadio",GetPlayerServerId(PlayerId()))
-		TriggerServerEvent("jobssystem:jobs", "unemployed")
-	    TriggerEvent("DoLongHudText",'You have left the boradcasting job!',1)
-	    Wait(1200)
+        stopBroadcast()
     end
 end)
 
+RegisterNetEvent('broadcast:becomejob')
+AddEventHandler('broadcast:becomejob', startBroadcast)
 
-function becomeJob()
-	TriggerServerEvent("TokoVoip:addPlayerToRadio",19829, GetPlayerServerId(PlayerId()))
-	isBroadcasting = true
-end
-RegisterNetEvent("broadcast:becomejob");
-AddEventHandler("broadcast:becomejob", becomeJob);
+CreateThread(function()
+    while true do
+        local sleep = 1000
+        local near, station = isPlayerNearStation(NEAR_DISTANCE)
+        if near then
+            sleep = 5
+            drawText3D(station.x, station.y, station.z, '[E] Start Broadcasting | [F] Stop Broadcasting')
+        end
 
--- #MarkedForMarker
-Citizen.CreateThread(function()
-	while true do
-		Citizen.Wait(0)
+        if isBroadcasting and not isPlayerNearStation(LEAVE_DISTANCE) then
+            stopBroadcast()
+        end
 
-		if isBroadcasting and not isNearBroadcast() then
-			isBroadcasting = false
-			TriggerServerEvent("TokoVoip:removePlayerFromAllRadio",GetPlayerServerId(PlayerId()))
-			TriggerServerEvent("jobssystem:jobs", "unemployed")
-		    TriggerEvent("DoLongHudText",'You have left the boradcasting job!',1)
-		    Wait(1200)
-		end
-
-		if not isNearTakeService() then	
-			Wait(1200)
-		end
-	end
+        Wait(sleep)
+    end
 end)
+

--- a/Example_Frameworks/NoPixelServer/np-broadcaster/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-broadcaster/fxmanifest.lua
@@ -1,0 +1,14 @@
+fx_version 'cerulean'
+game 'gta5'
+
+lua54 'yes'
+
+description 'Refactored broadcaster resource'
+
+client_scripts {
+    '@np-errorlog/client/cl_errorlog.lua',
+    'cl_broadcast.lua'
+}
+
+server_script 'sv_broadcast.lua'
+

--- a/Example_Frameworks/NoPixelServer/np-broadcaster/sv_broadcast.lua
+++ b/Example_Frameworks/NoPixelServer/np-broadcaster/sv_broadcast.lua
@@ -1,11 +1,23 @@
-RegisterServerEvent('attemptBroadcast')
+--[[
+    -- Type: Event
+    -- Name: attemptBroadcast
+    -- Use: Assigns the broadcaster job if slots are available
+    -- Created: 2024-02-16
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('attemptBroadcast')
 AddEventHandler('attemptBroadcast', function()
     local src = source
-    local user = exports["np-base"]:getModule("Player"):GetUser(src)
-    local jobs = exports["np-base"]:getModule("JobManager")
-    local jobs = exports["np-base"]:getModule("JobManager"):CountJob("broadcaster")
-    if activeBroadcast >= 5 then TriggerClientEvent("DoLongHudText",src, "There is already too many broadcasters here",2) end
-    jobs:SetJob(user, "broadcaster", false, function()
-        TriggerClientEvent("broadcast:becomejob",src)
+    local user = exports['np-base']:getModule('Player'):GetUser(src)
+    local jobManager = exports['np-base']:getModule('JobManager')
+    local active = jobManager:CountJob('broadcaster')
+
+    if active >= 5 then
+        TriggerClientEvent('DoLongHudText', src, 'There are already too many broadcasters here', 2)
+        return
+    end
+
+    jobManager:SetJob(user, 'broadcaster', false, function()
+        TriggerClientEvent('broadcast:becomejob', src)
     end)
 end)


### PR DESCRIPTION
## Summary
- convert broadcaster resource to `fxmanifest` and enable Lua 5.4
- refactor client broadcast logic with start/stop helpers and proximity checks
- fix server event to count active broadcasters before assigning job

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-broadcaster/cl_broadcast.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-broadcaster/sv_broadcast.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd3fb214832da88c4157a924fc88