### PR TITLE
refactor: modernize np-commands resource

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-commands/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-commands/__resource.lua
@@ -1,6 +1,0 @@
-resource_manifest_version '05cfa83c-a124-4cfa-a768-c24a5811d8f9'
-
-
-client_script 'cl_commands.lua'
-server_script 'sv_commands.lua'
-server_script 'sv_list.lua'

--- a/Example_Frameworks/NoPixelServer/np-commands/cl_commands.lua
+++ b/Example_Frameworks/NoPixelServer/np-commands/cl_commands.lua
@@ -1,134 +1,57 @@
- 
+--[[
+    -- Type: Client Script
+    -- Name: cl_commands
+    -- Use: Registers client-side chat commands for various utility actions
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 
-
- AddEventHandler('onResourceStart', function(resourceName)
-  if (GetCurrentResourceName() ~= resourceName) then
-    return
-  end
-  TriggerServerEvent("np-commands:buildCommands","")
+AddEventHandler('onResourceStart', function(resourceName)
+    if GetCurrentResourceName() ~= resourceName then
+        return
+    end
+    TriggerServerEvent('np-commands:buildCommands')
 end)
 
-RegisterCommand("cpr", function(source, args, rawCommand)
-  TriggerEvent('pixerium:check', 3, 'trycpr', false)
-end, false)
+local commands = {
+    { 'cpr', function() TriggerEvent('pixerium:check', 3, 'trycpr', false) end },
+    { 'door1', function() TriggerEvent('car:doors', 'open', 0) end },
+    { 'door2', function() TriggerEvent('car:doors', 'open', 1) end },
+    { 'door3', function() TriggerEvent('car:doors', 'open', 2) end },
+    { 'door4', function() TriggerEvent('car:doors', 'open', 3) end },
+    { 'hood', function() TriggerEvent('car:doors', 'open', 4) end },
+    { 'as', function() TriggerEvent('idk also') end },
+    { 'selfie', function() TriggerEvent('selfiePhone') end },
+    { 'showid', function() TriggerEvent('showID') end },
+    { 'givekey', function() TriggerEvent('keys:give') end },
+    { 'window', function(args) TriggerEvent('car:windows', args[1], args[2]) end },
+    { 'rollup', function() TriggerEvent('car:windowsup') end },
+    { 'phone', function() TriggerEvent('phoneGui2') end },
+    { 'finance', function() TriggerEvent('finance1') end },
+    { 'inv', function() TriggerEvent('OpenInv') end },
+    { 'vm', function() TriggerEvent('shop:useVM') end },
+    { 'news', function() TriggerEvent('NewsStandCheck') end },
+    { 'confirm', function() TriggerEvent('housing:confirmed') end },
+    { 'notes', function() TriggerEvent('Notepad:open') end },
+    { 'trunkkidnap', function() TriggerEvent('ped:forceTrunk') end },
+    { 'trunkeject', function() TriggerEvent('ped:releaseTrunkCheck') end },
+    { 'trunkgetin', function() TriggerEvent('ped:forceTrunkSelf') end },
+    { 'trunkejectself', function() TriggerEvent('ped:releaseTrunkCheckSelf') end },
+    { 'anchor', function() TriggerEvent('client:anchor') end },
+    { 'debug', function() TriggerEvent('server:enablehuddebug') end },
+    { 'carry', function() TriggerEvent('police:carryAI') end },
+    { 'atm', function() TriggerEvent('bank:checkATM') end },
+    { 'getpos', function()
+        local ped = PlayerPedId()
+        local coords = GetEntityCoords(ped)
+        local heading = GetEntityHeading(ped)
+        Citizen.Trace(string.format('X: %s Y: %s Z: %s HEADING: %s', coords.x, coords.y, coords.z, heading))
+    end }
+}
 
+for _, cmd in ipairs(commands) do
+    RegisterCommand(cmd[1], function(_, args)
+        cmd[2](args)
+    end, false)
+end
 
-RegisterCommand("door1", function(source, args, rawCommand)
-  TriggerEvent('car:doors', "open",0)
-end, false)
-
-RegisterCommand("door2", function(source, args, rawCommand)
-  TriggerEvent('car:doors', "open",1)
-end, false)
-
-RegisterCommand("door3", function(source, args, rawCommand)
-  TriggerEvent('car:doors', "open",2)
-end, false)
-
-RegisterCommand("door4", function(source, args, rawCommand)
-  TriggerEvent('car:doors', "open",3)
-end, false)
-
-
-RegisterCommand("hood", function(source, args, rawCommand)
-  TriggerEvent('car:doors', "open",4)
-end, false)
-
-
-RegisterCommand("as", function(source, args, rawCommand)
-  TriggerEvent("idk also")
-end, false)
-
-RegisterCommand("selfie", function(source, args, rawCommand)
-  TriggerEvent("selfiePhone")
-end, false)
-
-
-RegisterCommand("showid", function(source, args, rawCommand)
-  TriggerEvent("showID")
-end, false)
-
-RegisterCommand("givekey", function(source, args, rawCommand)
-  TriggerEvent("keys:give")
-end, false)
-
-RegisterCommand("window", function(source, args, rawCommand)
-  TriggerEvent("car:windows",args[2], args[3])
-end, false)
-
-
-RegisterCommand("rollup", function(source, args, rawCommand)
-  TriggerEvent("car:windowsup")
-end, false)
-
-RegisterCommand("phone", function(source, args, rawCommand)
-  TriggerEvent('phoneGui2')
-end, false)
-
-
-RegisterCommand("finance", function(source, args, rawCommand)
-  TriggerEvent('finance1')
-end, false)
-
-RegisterCommand("inv", function(source, args, rawCommand)
-  TriggerEvent('OpenInv')
-end, false)
-
-RegisterCommand("vm", function(source, args, rawCommand)
-  TriggerEvent('shop:useVM')
-end, false)
-
-RegisterCommand("news", function(source, args, rawCommand)
-  TriggerEvent('NewsStandCheck')
-end, false)
-
-RegisterCommand("confirm", function(source, args, rawCommand)
-  TriggerEvent('housing:confirmed')
-end, false)
-
-RegisterCommand("notes", function(source, args, rawCommand)
-  TriggerEvent('Notepad:open')
-end, false)
-
-
-RegisterCommand("trunkkidnap", function(source, args, rawCommand)
-  TriggerEvent('ped:forceTrunk')
-end, false)
-
-RegisterCommand("trunkeject", function(source, args, rawCommand)
-  TriggerEvent('ped:releaseTrunkCheck')
-end, false)
-
-RegisterCommand("trunkgetin", function(source, args, rawCommand)
-  TriggerEvent('ped:forceTrunkSelf')
-end, false)
-
-RegisterCommand("trunkejectself", function(source, args, rawCommand)
-  TriggerEvent('ped:releaseTrunkCheckSelf')
-end, false)
-
-RegisterCommand("anchor", function(source, args, rawCommand)
-  TriggerEvent('client:anchor')
-end, false)
-
-
-RegisterCommand("debug", function(source, args, rawCommand)
-  TriggerEvent('server:enablehuddebug')
-end, false)
-
-
-RegisterCommand("carry", function(source, args, rawCommand)
-  TriggerEvent('police:carryAI')
-end, false)
-
-RegisterCommand("atm", function(src, args, raw)
-  TriggerEvent('bank:checkATM')
-end)
-
-
-RegisterCommand("getpos", function(source, args, raw)
-  local ped = GetPlayerPed(PlayerId())
-  local coords = GetEntityCoords(ped, false)
-  local heading = GetEntityHeading(ped)
-  Citizen.Trace(tostring("X: " .. coords.x .. " Y: " .. coords.y .. " Z: " .. coords.z .. " HEADING: " .. heading))
-end, false)

--- a/Example_Frameworks/NoPixelServer/np-commands/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-commands/fxmanifest.lua
@@ -1,0 +1,14 @@
+--[[
+    -- Type: Resource Manifest
+    -- Name: np-commands
+    -- Use: Defines client and server scripts for command handling
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+
+fx_version 'cerulean'
+game 'gta5'
+
+client_script 'cl_commands.lua'
+server_script 'sv_commands.lua'
+

--- a/Example_Frameworks/NoPixelServer/np-commands/sv_commands.lua
+++ b/Example_Frameworks/NoPixelServer/np-commands/sv_commands.lua
@@ -1,101 +1,133 @@
-function buildCommands(job,src)
-    local Lsrc
-    if src == nil then Lsrc = source else Lsrc = src end
-    local commandExport = exports["np-base"]:getModule("Commands")
-    exports["np-base"]:getModule("Player"):GetUser(Lsrc)
-    local charID = user:getVar("character").id
-    local hexID = user:getVar("hexid")
+--[[
+    -- Type: Server Script
+    -- Name: sv_commands
+    -- Use: Builds command permissions based on player roles and whitelist data
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 
-    --clear all personal commands
+local commands = require('sv_list')
+
+--[[
+    -- Type: Function
+    -- Name: isSafe
+    -- Use: Validates if a command is allowed for a player's role
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+local function isSafe(police, ems, doctor, judge, driving, tow, jobEnum, job)
+    if not jobEnum then return false end
+    if jobEnum.F then return true end
+    if jobEnum.P and police and job == 'police' then return true end
+    if jobEnum.E and ems and job == 'ems' then return true end
+    if jobEnum.NE and job == 'ems' then return true end
+    if jobEnum.D and doctor and job == 'doctor' then return true end
+    if jobEnum.J and judge and job == 'judge' then return true end
+    if jobEnum.DI and driving and job == 'driving' then return true end
+    if jobEnum.T and tow and job == 'tow' then return true end
+    return false
+end
+
+--[[
+    -- Type: Function
+    -- Name: buildCommands
+    -- Use: Assigns valid commands to a player based on job and whitelist
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+local function buildCommands(job, src)
+    local Lsrc = src or source
+    local commandExport = exports['np-base']:getModule('Commands')
+    local user = exports['np-base']:getModule('Player'):GetUser(Lsrc)
+    if not user then return end
+    local charID = user:getVar('character').id
+    local hexID = user:getVar('hexid')
+
     commandExport:RemoveAllSelfCommands(Lsrc)
 
-    IsWhiteListed(hexID, charID, function(police, ems, doctor, driving)
+    IsWhiteListed(hexID, charID, function(police, ems, doctor, driving, tow)
         IsWhiteListedJudge(charID, function(judge)
-            for k,v in pairs(commands) do
-                if isSafe(police,ems,doctor,judge,driving,v[3],job) then
-                    commandExport:AddCommandValid(v[1],v[2], Lsrc, v[4])
+            for _, v in ipairs(commands) do
+                if isSafe(police, ems, doctor, judge, driving, tow, v[3], job) then
+                    commandExport:AddCommandValid(v[1], v[2], Lsrc, v[4])
                 end
             end
         end)
     end)
 
-    TriggerEvent("admin:reBuildAdminCommands",Lsrc)
-    TriggerEvent("isVip",Lsrc)
+    TriggerEvent('admin:reBuildAdminCommands', Lsrc)
+    TriggerEvent('isVip', Lsrc)
 end
 
-RegisterServerEvent("np-commands:buildCommands")
-AddEventHandler("np-commands:buildCommands", buildCommands)
+RegisterServerEvent('np-commands:buildCommands')
+AddEventHandler('np-commands:buildCommands', buildCommands)
 
-function buildOnlyValid()
-    local commandExport = exports["np-base"]:getModule("Commands")
-    for k,v in pairs(commands) do
-        if isSafe(police,ems,doctor,judge,v[3],job) then
-            commandExport:AddCommandValid(v[1],v[2],v[4])
-        end
-    end
-end
-
-AddEventHandler("np-jobmanager:playerBecameJob", function(src, job)
-    buildCommands(job,src)
+AddEventHandler('np-jobmanager:playerBecameJob', function(src, job)
+    buildCommands(job, src)
 end)
 
-function isSafe(police,ems,doctor,judge,driving,jobEnum,job)
-
-    if jobEnum then
-        if jobEnum.F then
-            return true
-        else
-            if jobEnum.P and police and job == "police" then
-                return true
-            elseif jobEnum.E and ems and job == "ems" then
-                return true
-            elseif jobEnum.NE and job == "ems" then
-                return true
-            end
-        end
-    end
-    return false 
-end
-
+--[[
+    -- Type: Function
+    -- Name: IsWhiteListed
+    -- Use: Checks job whitelist for a character
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function IsWhiteListed(hexId, characterId, callback)
-    if not hexId or not characterId then return end
-    
-    local q = [[SELECT id, owner, cid, job, rank FROM jobs_whitelist WHERE cid = @cid;]]
-    local v = {['owner'] = hexId, ['cid'] = characterId}
+    if not hexId or not characterId then
+        callback(false, false, false, false, false)
+        return
+    end
 
-    exports.ghmattimysql:execute(q,v, function(results)
-        if not results then callback(false,false,false) return end
-        local police = false
-        local ems = false
-        
-        for k,v in ipairs (results)do
-          if v.job == "police" and v.rank >= 1 then police = true end
-            if v.job == "ems" and v.rank >= 1 then ems = true end
+    local q = [[SELECT job, rank FROM jobs_whitelist WHERE cid = @cid;]]
+    local v = { ['cid'] = characterId }
+
+    exports.ghmattimysql:execute(q, v, function(results)
+        if not results then
+            callback(false, false, false, false, false)
+            return
         end
 
-        callback(police,ems)
+        local police, ems, doctor, driving, tow = false, false, false, false, false
+        for _, r in ipairs(results) do
+            if r.job == 'police' and r.rank >= 1 then police = true end
+            if r.job == 'ems' and r.rank >= 1 then ems = true end
+            if r.job == 'doctor' and r.rank >= 1 then doctor = true end
+            if r.job == 'driving' and r.rank >= 1 then driving = true end
+            if r.job == 'tow' and r.rank >= 1 then tow = true end
+        end
+
+        callback(police, ems, doctor, driving, tow)
     end)
 end
 
+--[[
+    -- Type: Function
+    -- Name: IsWhiteListedJudge
+    -- Use: Determines if a character has judge permissions
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function IsWhiteListedJudge(characterId, callback)
     if not characterId then
+        callback(false)
         return
     end
 
     exports.ghmattimysql:execute(
-        "SELECT judge_type from characters WHERE id = @cid",
-        { ["cid"] = characterId}, function(result)
-            if not reuslt then
+        'SELECT judge_type FROM characters WHERE id = @cid',
+        { ['cid'] = characterId },
+        function(result)
+            if not result then
                 callback(false)
                 return
             end
             local isJudge = false
-
-            if result[1] then
-                if result[1].judge_type >= 1 then
-                    isJudge = true
-                end
+            if result[1] and result[1].judge_type and result[1].judge_type >= 1 then
+                isJudge = true
             end
             callback(isJudge)
-    end)
+        end
+    )
 end
+

--- a/Example_Frameworks/NoPixelServer/np-commands/sv_list.lua
+++ b/Example_Frameworks/NoPixelServer/np-commands/sv_list.lua
@@ -1,3 +1,11 @@
+--[[
+    -- Type: Module
+    -- Name: sv_list
+    -- Use: Defines command permissions and handlers
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+
 local ALL = {F = true}
 local EMS = {E = true}
 local NEMS = {P = true, E = true, NE = true, D = true}
@@ -18,9 +26,7 @@ local DI_JD_PL = {DI = true, J = true, P = true}
 local POLICE_Judge = {P = true, J = true}
 local TOW = {T = true}
 
-
-
-commands = {
+local commands = {
 
     {"/wing", "Toggle Lock for hospital WING", EMERGENCY_Judge, function(src, args)
       TriggerClientEvent('inter:wing', src)
@@ -95,7 +101,7 @@ commands = {
     end},
     
     {"/remove", "Remove character ID's whitelist (/remove job CharID)", EMERGENCY_Judge, function(src, args)
-      TriggerClientEvent('police:chatCommand', src, args, 'remove', false, fals)
+      TriggerClientEvent('police:chatCommand', src, args, 'remove', false, false)
     end},
     
     {"/jail", "/jail [player id] [length]", POLICE_Judge, function(src, args)
@@ -312,10 +318,6 @@ commands = {
     end},
 
     {"/help", "Shows commands list", POLICE, function(src, args)
-      TriggerClientEvent('pixerium:check', src, 3, 'trycpr', false)
-    end},
-
-    {"/help", "Shows commands list", POLICE, function(src, args)
       TriggerClientEvent('commands:help', src)
     end},
 
@@ -343,10 +345,6 @@ commands = {
     
     {"/trunk", "Toggle's hood", ALL, function(src, args)
       TriggerClientEvent('ped:forceTrunkSelf', src)
-    end},
-
-    {"/cpr", "Toggle's hood", ALL, function(src, args)
-      TriggerClientEvent('client:cpr', src)
     end},
 
     {"/use", "idk that", ALL, function(src, args)
@@ -378,11 +376,7 @@ commands = {
     end},
 
     {"/selfie", "Toggle's selfie cam on", ALL, function(src, args)
-      TriggerClientEvent('selfiePhone', src) 
-    end},
-
-    {"/selfie", "Toggle's selfie cam on", ALL, function(src, args)
-      TriggerClientEvent('selfiePhone', src) 
+      TriggerClientEvent('selfiePhone', src)
     end},
 
     {"/showid", "Show your ID card", ALL, function(src, args)
@@ -421,14 +415,14 @@ commands = {
       TriggerClientEvent( "chatMessage",-1 , "OOC " .. name .. " [".. src .. "]", 2 , msg)
       exports["np-log"]:AddLog("OOC Chat [".. src .."]", user, name .. ": " .. msg, {})
     end},
-    
-    }
 
-    RegisterCommand('sport', function(source, args)
-      local src = source
-    local user = exports["np-base"]:getModule("Player"):GetUser(src)
-
+    {"/sport", "Toggle sport mode for police", POLICE, function(src, args)
+      local user = exports["np-base"]:getModule("Player"):GetUser(src)
       if user:getVar("job") == 'police' then
         TriggerClientEvent('police:sport', src)
-  end
-end)
+      end
+    end},
+
+}
+
+return commands


### PR DESCRIPTION
## Summary
- replace deprecated __resource.lua with fxmanifest.lua
- refactor client command registrations and use modern natives
- rebuild server command permissions with improved whitelist and command definitions

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-commands/cl_commands.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-commands/sv_commands.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-commands/sv_list.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd5b1fd4832d9842b36d72ed0cfb