### PR TITLE
Refactor np-dirtymoney resource

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-dirtymoney/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-dirtymoney/__resource.lua
@@ -1,2 +1,0 @@
-client_script 'client.lua'
-server_script 'server.lua'

--- a/Example_Frameworks/NoPixelServer/np-dirtymoney/client.lua
+++ b/Example_Frameworks/NoPixelServer/np-dirtymoney/client.lua
@@ -1,122 +1,147 @@
-CanDropOff = true
-DropOffTime = 0
+local CanDropOff = true
+local DropOffTime = 0
+local DROPOFF_COOLDOWN = 300
+local DROPOFF_COORDS = vector3(925.329, 46.152, 80.908)
 
-function DisplayHelpText(str)
-	SetTextComponentFormat("STRING")
-	AddTextComponentString(str)
-	DisplayHelpTextFromStringLabel(0, 0, 1, -1)
-end
+--[[
+    -- Type: Event
+    -- Name: np-dirtymoney:allowDirtyMoneyDrops
+    -- Use: Initiates and manages the cooldown timer for dropping off dirty money.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("np-dirtymoney:allowDirtyMoneyDrops", function()
+    if DropOffTime ~= 0 then
+        DropOffTime = DROPOFF_COOLDOWN
+        return
+    end
 
-function drawTxt(x, y, width, height, scale, text, r, g, b, a)
-    SetTextFont(0)
-    SetTextProportional(0)
-    SetTextScale(scale, scale)
-    SetTextColour(r, g, b, a)
-    SetTextDropShadow(0, 0, 0, 0,255)
-    SetTextEdge(1, 0, 0, 0, 255)
-    SetTextDropShadow()
-    SetTextOutline()
-    SetTextEntry("STRING")
-    AddTextComponentString(text)
-    DrawText(x - width/2, y - height/2 + 0.005)
-end
+    DropOffTime = DROPOFF_COOLDOWN
+    CanDropOff = false
 
-RegisterNetEvent("np-dirtymoney:allowDirtyMoneyDrops")
-AddEventHandler("np-dirtymoney:allowDirtyMoneyDrops", function()
-	if DropOffTime == 0 then
-		DropOffTime = 300
-		CanDropOff = false
-		while DropOffTime > 0 do
-			Citizen.Wait(1000)
-			DropOffTime = DropOffTime - 1
-		end
-		CanDropOff = true
-		DropOffTime = 0
-		--TriggerEvent("DoLongHudText","Marked Bills is ready to be dropped off!")
-	else
-		DropOffTime = 300
-	end
+    CreateThread(function()
+        while DropOffTime > 0 do
+            Wait(1000)
+            DropOffTime = DropOffTime - 1
+        end
+
+        CanDropOff = true
+        DropOffTime = 0
+        --TriggerEvent("DoLongHudText","Marked Bills is ready to be dropped off!")
+    end)
 end)
 
-RegisterNetEvent("np-dirtymoney:attemptDirtyMoneyDrops")
-AddEventHandler("np-dirtymoney:attemptDirtyMoneyDrops", function()
-	if DropOffTime == 0 then
-		TriggerEvent('np-dirtymoney:allowDirtyMoneyDrops')
-		--TriggerServerEvent('mobdelivery:checkjob')
-		--TriggerServerEvent("np-dirtymoney:alterDirtyMoney", "TurnToCash", 0)
-	else
-		local msgtoplayer = "You must wait " .. DropOffTime .. " Seconds to drop off your cash.."
-		TriggerEvent("DoLongHudText", msgtoplayer)
-	end
-
+--[[
+    -- Type: Event
+    -- Name: np-dirtymoney:attemptDirtyMoneyDrops
+    -- Use: Checks cooldown before starting a dropoff attempt.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("np-dirtymoney:attemptDirtyMoneyDrops", function()
+    if DropOffTime == 0 then
+        TriggerEvent('np-dirtymoney:allowDirtyMoneyDrops')
+        --TriggerServerEvent('mobdelivery:checkjob')
+        --TriggerServerEvent("np-dirtymoney:alterDirtyMoney", "TurnToCash", 0)
+    else
+        local msgtoplayer = "You must wait " .. DropOffTime .. " Seconds to drop off your cash.."
+        TriggerEvent("DoLongHudText", msgtoplayer)
+    end
 end)
 
+--[[
+    -- Type: Function
+    -- Name: IsNearDirtyMoney
+    -- Use: Determines if the player is within range of the dropoff location.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
 function IsNearDirtyMoney()
-	if #(vector3(925.329, 46.152,80.908) - GetEntityCoords(PlayerPedId())) < 15 then
-		return true
-	end	
+    return #(DROPOFF_COORDS - GetEntityCoords(PlayerPedId())) < 15
 end
 
+local backpack = false
+local attachedProp = 0
 
-
---x=925.329, y=46.152, z=80.908
-
-
-backpack = false
-attachedProp = 0
-
-RegisterNetEvent("dmbackpack")
-AddEventHandler("dmbackpack", function(amt)
-
-	if amt > 5000 and not backpack then
-		backpack = true
-		attachProp("prop_cs_heist_bag_01", 24816, 0.15, -0.4, -0.38, 90.0, 0.0, 0.0)
-	elseif backpack and amt < 5000 then
-		backpack = false
-		removeAttachedProp()
-	end
+--[[
+    -- Type: Event
+    -- Name: dmbackpack
+    -- Use: Adds or removes a backpack prop based on dirty money amount.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("dmbackpack", function(amt)
+    if amt > 5000 and not backpack then
+        backpack = true
+        attachProp("prop_cs_heist_bag_01", 24816, 0.15, -0.4, -0.38, 90.0, 0.0, 0.0)
+    elseif backpack and amt < 5000 then
+        backpack = false
+        removeAttachedProp()
+    end
 end)
 
-function removeAttachedProp()
-	DeleteEntity(attachedProp)
-	attachedProp = 0
+--[[
+    -- Type: Function
+    -- Name: removeAttachedProp
+    -- Use: Deletes the currently attached prop from the player.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+local function removeAttachedProp()
+    DeleteEntity(attachedProp)
+    attachedProp = 0
 end
 
-function attachProp(attachModelSent,boneNumberSent,x,y,z,xR,yR,zR)
-	removeAttachedProp()
-	attachModel = GetHashKey(attachModelSent)
-	boneNumber = boneNumberSent
-	SetCurrentPedWeapon(PlayerPedId(), 0xA2719263) 
-	local bone = GetPedBoneIndex(PlayerPedId(), boneNumberSent)
-	--local x,y,z = table.unpack(GetEntityCoords(PlayerPedId(), true))
-	RequestModel(attachModel)
-	while not HasModelLoaded(attachModel) do
-		Citizen.Wait(100)
-	end
-	attachedProp = CreateObject(attachModel, 1.0, 1.0, 1.0, 1, 1, 0)
-	exports["isPed"]:GlobalObject(attachedProp)
-	AttachEntityToEntity(attachedProp, PlayerPedId(), bone, x, y, z, xR, yR, zR, 1, 1, 0, 0, 2, 1)
+--[[
+    -- Type: Function
+    -- Name: attachProp
+    -- Use: Attaches a specified prop to the player.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+local function attachProp(attachModelSent, boneNumberSent, x, y, z, xR, yR, zR)
+    removeAttachedProp()
+    local attachModel = GetHashKey(attachModelSent)
+    local boneNumber = boneNumberSent
+    SetCurrentPedWeapon(PlayerPedId(), 0xA2719263)
+    local bone = GetPedBoneIndex(PlayerPedId(), boneNumberSent)
+    RequestModel(attachModel)
+    while not HasModelLoaded(attachModel) do
+        Wait(100)
+    end
+    attachedProp = CreateObject(attachModel, 1.0, 1.0, 1.0, 1, 1, 0)
+    exports["isPed"]:GlobalObject(attachedProp)
+    AttachEntityToEntity(attachedProp, PlayerPedId(), bone, x, y, z, xR, yR, zR, 1, 1, 0, 0, 2, 1)
 end
 
---attachProp("prop_cs_heist_bag_01", 24816, 0.15, -0.4, -0.38, 90.0, 0.0, 0.0)
-
-
-RegisterNetEvent("dirtymoney:dropDirty")
-AddEventHandler("dirtymoney:dropDirty", function(DirtyMoney,amount)
-if DirtyMoney >= amount then
-	local pos = GetEntityCoords(PlayerPedId())
-		TriggerEvent("DoLongHudText","You Dropped $ "..amount.." Marked Bills.")
-		TriggerServerEvent("np-dirtymoney:alterDirtyMoney","ItemDrop",amount)
-		TriggerEvent('item:itemDrop',{"DirtyMoney"},{amount},{pos.x,pos.y,pos.z-0.7},{false},false)
-	else
-		TriggerEvent("DoLongHudText","You do not have enought Marked Bills to drop.")
-	end	
+--[[
+    -- Type: Event
+    -- Name: dirtymoney:dropDirty
+    -- Use: Drops marked bills on the ground and removes them from the player.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("dirtymoney:dropDirty", function(DirtyMoney, amount)
+    if DirtyMoney >= amount then
+        local pos = GetEntityCoords(PlayerPedId())
+        TriggerEvent("DoLongHudText", "You Dropped $ " .. amount .. " Marked Bills.")
+        TriggerServerEvent("np-dirtymoney:alterDirtyMoney", "ItemDrop", amount)
+        TriggerEvent('item:itemDrop', {"DirtyMoney"}, {amount}, {pos.x, pos.y, pos.z - 0.7}, {false}, false)
+    else
+        TriggerEvent("DoLongHudText", "You do not have enough Marked Bills to drop.")
+    end
 end)
 
-RegisterNetEvent("dirtymoney:dropCash")
-AddEventHandler("dirtymoney:dropCash", function(amount)
-	local pos = GetEntityCoords(PlayerPedId())
-	TriggerEvent("DoLongHudText","You Dropped $ "..amount..".")
-	TriggerEvent('item:itemDrop',{"Money"},{amount},{pos.x,pos.y,pos.z-0.7},{false},false)
-
+--[[
+    -- Type: Event
+    -- Name: dirtymoney:dropCash
+    -- Use: Drops clean cash on the ground.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("dirtymoney:dropCash", function(amount)
+    local pos = GetEntityCoords(PlayerPedId())
+    TriggerEvent("DoLongHudText", "You Dropped $ " .. amount .. ".")
+    TriggerEvent('item:itemDrop', {"Money"}, {amount}, {pos.x, pos.y, pos.z - 0.7}, {false}, false)
 end)
+

--- a/Example_Frameworks/NoPixelServer/np-dirtymoney/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-dirtymoney/fxmanifest.lua
@@ -1,0 +1,11 @@
+fx_version 'cerulean'
+game 'gta5'
+
+client_scripts {
+    'client.lua'
+}
+
+server_scripts {
+    'server.lua'
+}
+

--- a/Example_Frameworks/NoPixelServer/np-dirtymoney/server.lua
+++ b/Example_Frameworks/NoPixelServer/np-dirtymoney/server.lua
@@ -1,43 +1,68 @@
-RegisterServerEvent("np-dirtymoney:attemptDirtyMoneyDrops")
-AddEventHandler("np-dirtymoney:attemptDirtyMoneyDrops", function()
-	local src = source
-	local user = exports["np-base"]:getModule("Player"):GetUser(src)
-	local DirtyMoney = user:getDirtyMoney()
+--[[
+    -- Type: Server Event
+    -- Name: np-dirtymoney:attemptDirtyMoneyDrops
+    -- Use: Handles a player's attempt to drop dirty money by charging a fee and starting the dropoff process.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("np-dirtymoney:attemptDirtyMoneyDrops", function()
+    local src = source
+    local user = exports["np-base"]:getModule("Player"):GetUser(src)
+    if not user then return end
 
-	if DirtyMoney > 500 then
-		TriggerClientEvent("np-dirtymoney:attemptDirtyMoneyDrops",source)
-		DirtyMoney = DirtyMoney - 500
-		user:alterDirtyMoney(DirtyMoney)
-
-		TriggerClientEvent('UPV',src,500)
-	else
-		TriggerClientEvent("DoLongHudText",source,"You need $500 in Marked Bills.",2)
-	end
-
+    local dirtyMoney = user:getDirtyMoney()
+    if dirtyMoney >= 500 then
+        TriggerClientEvent("np-dirtymoney:attemptDirtyMoneyDrops", src)
+        user:alterDirtyMoney(dirtyMoney - 500)
+        TriggerClientEvent("UPV", src, 500)
+    else
+        TriggerClientEvent("DoLongHudText", src, "You need $500 in Marked Bills.", 2)
+    end
 end)
 
-RegisterServerEvent("np-dirtymoney:alterDirtyMoney")
-AddEventHandler("np-dirtymoney:alterDirtyMoney", function(reason, amount)
-	local src = source
-	local user = exports["np-base"]:getModule("Player"):GetUser(src)
-	local DirtyMoney = user:getDirtyMoney()
+--[[
+    -- Type: Server Event
+    -- Name: np-dirtymoney:alterDirtyMoney
+    -- Use: Adjusts a player's dirty money based on the provided reason and amount.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("np-dirtymoney:alterDirtyMoney", function(reason, amount)
+    local src = source
+    local user = exports["np-base"]:getModule("Player"):GetUser(src)
+    if not user then return end
 
-	if reason == "ItemDrop" then
-		TriggerClientEvent("np-dirtymoney:attemptDirtyMoneyDrops",source)
-		DirtyMoney = DirtyMoney - amount
-		user:alterDirtyMoney(DirtyMoney)
+    local amt = tonumber(amount) or 0
+    if amt <= 0 then return end
 
-		TriggerClientEvent('UPV',src,amount)
-	else
-		DirtyMoney = DirtyMoney + amount
-		user:alterDirtyMoney(DirtyMoney)
-	end
-
+    local dirtyMoney = user:getDirtyMoney()
+    if reason == "ItemDrop" then
+        if dirtyMoney >= amt then
+            TriggerClientEvent("np-dirtymoney:attemptDirtyMoneyDrops", src)
+            user:alterDirtyMoney(dirtyMoney - amt)
+            TriggerClientEvent("UPV", src, amt)
+        else
+            TriggerClientEvent("DoLongHudText", src, "Insufficient Marked Bills.", 2)
+        end
+    else
+        user:alterDirtyMoney(dirtyMoney + amt)
+    end
 end)
 
-RegisterServerEvent("np-dirtymoney:moneyPickup")
-AddEventHandler("np-dirtymoney:moneyPickup", function(amount)
-	local src = source
-	local user = exports["np-base"]:getModule("Player"):GetUser(src)
-	user:addMoney((amount))
+--[[
+    -- Type: Server Event
+    -- Name: np-dirtymoney:moneyPickup
+    -- Use: Converts collected dirty money into clean cash for the player.
+    -- Created: 2024-06-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent("np-dirtymoney:moneyPickup", function(amount)
+    local src = source
+    local user = exports["np-base"]:getModule("Player"):GetUser(src)
+    if not user then return end
+
+    local amt = tonumber(amount) or 0
+    if amt <= 0 then return end
+
+    user:addMoney(amt)
 end)


### PR DESCRIPTION
## Summary
- migrate np-dirtymoney to fxmanifest
- refactor server events with validation and net event API
- clean up client logic with cooldown and prop helpers

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-dirtymoney/client.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-dirtymoney/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd97b024832d92f20c6de6ea20c0