### PR TITLE
refactor(np-eblips): modernize blip handling

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-eblips/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-eblips/__resource.lua
@@ -1,8 +1,0 @@
-resource_manifest_version "44febabe-d386-4d18-afbe-5e627f4af937"
-
-client_script "@np-infinity/client/classes/blip.lua"
-client_script "@np-infinity/client/cl_lib.lua"
-server_script "@np-infinity/server/sv_lib.lua"
-
-client_script "cl_eblips.lua"
-server_script "sv_eblips.lua"

--- a/Example_Frameworks/NoPixelServer/np-eblips/cl_eblips.lua
+++ b/Example_Frameworks/NoPixelServer/np-eblips/cl_eblips.lua
@@ -1,13 +1,19 @@
 local BlipHandlers = {}
 
-Citizen.CreateThread(function()
-	while true do
-		if NetworkIsSessionStarted() then
-			DecorRegister("EmergencyType", 3)
-			DecorSetInt(PlayerPedId(), "EmergencyType", 0)
-			return
-		end
-	end
+--[[
+    -- Type: Thread
+    -- Name: sessionInit
+    -- Use: Waits for network session before initializing decor
+    -- Created: 2024-09-08
+    -- By: VSSVSSN
+--]]
+CreateThread(function()
+    while not NetworkIsSessionStarted() do
+        Wait(0)
+    end
+
+    DecorRegister("EmergencyType", 3)
+    DecorSetInt(PlayerPedId(), "EmergencyType", 0)
 end)
 
 --[[
@@ -17,65 +23,64 @@ end)
 ]]
 
 function IsDOC(pCallSign)
-	if pCallSign then
-		local sign = string.sub(pCallSign, 1, 1)
-		return sign == '7'
-	else
-		return false
-	end
+    if pCallSign then
+        local sign = string.sub(pCallSign, 1, 1)
+        return sign == '7'
+    else
+        return false
+    end
 end
 
 function GetBlipSettings(pJobId, pCallSign)
-	local settings = {}
+    local settings = {
+        short = true,
+        sprite = 1,
+        category = 7
+    }
 
-	settings.short = true
-	settings.sprite = 1
-	settings.category = 7
+    if pJobId == 'police' then
+        settings.color = 3
+        settings.heading = true
+        settings.text = ('Officer | %s'):format(pCallSign)
+    elseif pJobId == 'doc' then
+        settings.color = 2
+        settings.heading = true
+        settings.text = ('DOC | %s'):format(pCallSign)
+    elseif pJobId == 'ems' then
+        settings.color = 23
+        settings.heading = true
+        settings.text = ('Paramedic | %s'):format(pCallSign)
+    else
+        return false
+    end
 
-	if pJobId == 'police' then
-		settings.color = 3
-		settings.heading =  true
-		settings.text = ('Officer | %s'):format(pCallSign)
-	elseif pJobId == 'doc' then
-		settings.color = 2
-		settings.heading =  true
-		settings.text = ('DOC | %s'):format(pCallSign)
-	elseif pJobId == 'ems' then
-		settings.color = 23
-		settings.heading =  true
-		settings.text = ('Paramedic | %s'):format(pCallSign)
-	else 
-		return false
-	end
-
-	return settings
+    return settings
 end
 
 function CreateBlipHandler(pServerId, pJob, pCallSign)
-	local serverId = pServerId
-	local callsign = pCallSign
-	local job = pJob
+    local serverId = pServerId
+    local callsign = pCallSign
+    local job = pJob
 
-	if job == 'police' and IsDOC(callsign) then
-		job = 'doc'
-	end
+    if job == 'police' and IsDOC(callsign) then
+        job = 'doc'
+    end
 
-	local settings = GetBlipSettings(job, callsign)
+    local settings = GetBlipSettings(job, callsign)
 
-	if not settings then 
-		return
-	end
+    if not settings then
+        return
+    end
 
-	local handler = EntityBlip:new('player', serverId, settings)
+    local handler = EntityBlip:new('player', serverId, settings)
+    handler:enable(true)
 
-	handler:enable(true)
-
-	BlipHandlers[serverId] = handler
+    BlipHandlers[serverId] = handler
 end
 
 function DeleteBlipHandler(pServerId)
-	BlipHandlers[pServerId]:disable()
-	BlipHandlers[pServerId] = nil
+    BlipHandlers[pServerId]:disable()
+    BlipHandlers[pServerId] = nil
 end
 
 RegisterNetEvent('e-blips:setHandlers')
@@ -100,93 +105,107 @@ end)
 
 RegisterNetEvent('e-blips:addHandler')
 AddEventHandler('e-blips:addHandler', function(pData)
-	if pData then
-		CreateBlipHandler(pData.netId, pData.job, pData.callsign)
-	end
+    if pData then
+        CreateBlipHandler(pData.netId, pData.job, pData.callsign)
+    end
 end)
 
 RegisterNetEvent('e-blips:removeHandler')
 AddEventHandler('e-blips:removeHandler', function(pServerId)
-	if BlipHandlers[pServerId] then
-		DeleteBlipHandler(pServerId)
-	end
+    if BlipHandlers[pServerId] then
+        DeleteBlipHandler(pServerId)
+    end
 end)
+
+--[[
+    -- Type: Function
+    -- Name: updateEmergencyDecor
+    -- Use: Sets decor based on player's job
+    -- Created: 2024-09-08
+    -- By: VSSVSSN
+--]]
+local function updateEmergencyDecor(job)
+    local decorType = 0
+    if job == 'police' then
+        decorType = 1
+    elseif job == 'ems' then
+        decorType = 2
+    end
+
+    DecorSetInt(PlayerPedId(), "EmergencyType", decorType)
+end
 
 RegisterNetEvent("np-jobmanager:playerBecameJob")
 AddEventHandler("np-jobmanager:playerBecameJob", function(job, name, notify)
-	if job == "police" then
-		DecorSetInt(PlayerPedId(), "EmergencyType", 1)
-	elseif job == "ems" then
-		DecorSetInt(PlayerPedId(), "EmergencyType", 2)
-	else
-		DecorSetInt(PlayerPedId(), "EmergencyType", 0)
-	end
+    updateEmergencyDecor(job)
 
-	TriggerServerEvent('e-blips:updateBlips', source, job, name)
+    TriggerServerEvent('e-blips:updateBlips', GetPlayerServerId(PlayerId()), job, name)
 end)
-
 
 RegisterNetEvent("e-blips:updateAfterPedChange")
 AddEventHandler("e-blips:updateAfterPedChange", function(job)
-	if job == "police" then
-		DecorSetInt(PlayerPedId(), "EmergencyType", 1)
-	elseif job == "ems" then
-		DecorSetInt(PlayerPedId(), "EmergencyType", 2)
-	else
-		DecorSetInt(PlayerPedId(), "EmergencyType", 0)
-	end
+    updateEmergencyDecor(job)
 
-	TriggerServerEvent('e-blips:updateBlips', source, job)
+    TriggerServerEvent('e-blips:updateBlips', GetPlayerServerId(PlayerId()), job)
 end)
 
 RegisterNetEvent('np:infinity:player:coords')
 AddEventHandler('np:infinity:player:coords', function (pCoords)
-	for serverId, handler in pairs(BlipHandlers) do
-		if handler and handler.mode == 'coords' and pCoords[serverId] then
-			handler:onUpdateCoords(pCoords[serverId])
+    for serverId, handler in pairs(BlipHandlers) do
+        if handler and handler.mode == 'coords' and pCoords[serverId] then
+            handler:onUpdateCoords(pCoords[serverId])
 
-			if handler:entityExistLocally() then
-				handler:onModeChange('entity')
-			end
-		end
-	end
+            if handler:entityExistLocally() then
+                handler:onModeChange('entity')
+            end
+        end
+    end
 end)
 
 RegisterNetEvent('onPlayerJoining')
 AddEventHandler('onPlayerJoining', function(player)
-	if BlipHandlers[player] then
-		BlipHandlers[player]['inScope'] = true
-		Citizen.Wait(1000)
-		if BlipHandlers[player]['inScope'] then
-			BlipHandlers[player]:onModeChange('entity')
-		end
-	end
+    if BlipHandlers[player] then
+        BlipHandlers[player].inScope = true
+        Wait(1000)
+        if BlipHandlers[player].inScope then
+            BlipHandlers[player]:onModeChange('entity')
+        end
+    end
 end)
 
 RegisterNetEvent('onPlayerDropped')
 AddEventHandler('onPlayerDropped', function(player)
-	if BlipHandlers[player] then
-		BlipHandlers[player]['inScope'] = false
-		BlipHandlers[player]:onModeChange('coords')
-	end
+    if BlipHandlers[player] then
+        BlipHandlers[player].inScope = false
+        BlipHandlers[player]:onModeChange('coords')
+    end
 end)
 
-local function setDecor()
-	local type = 0
 
-	TriggerEvent("nowIsCop", function(_isCop)
-		TriggerEvent("nowIsEMS", function(_isMedic)
-			type = _isCop and 1 or 0
-			type = (type == 0 and _isMedic) and 2 or type
-			DecorSetInt(PlayerPedId(), "EmergencyType", type)
-		end)
-	end)
+--[[
+    -- Type: Function
+    -- Name: refreshDecor
+    -- Use: Refreshes decor when player ped changes
+    -- Created: 2024-09-08
+    -- By: VSSVSSN
+--]]
+local function refreshDecor()
+    local decorType = 0
+
+    TriggerEvent("nowIsCop", function(isCop)
+        TriggerEvent("nowIsEMS", function(isMedic)
+            decorType = isCop and 1 or 0
+            decorType = (decorType == 0 and isMedic) and 2 or decorType
+            DecorSetInt(PlayerPedId(), "EmergencyType", decorType)
+        end)
+    end)
 end
 
-
-Citizen.CreateThread(function()
-	while true do
-		Citizen.Wait(2000)
-		if not DecorExistOn(PlayerPedId(), "EmergencyType") then setDecor() end -- Decors don't stick with players when their ped changes, currently only works with police.
-	end
+CreateThread(function()
+    while true do
+        Wait(2000)
+        if not DecorExistOn(PlayerPedId(), "EmergencyType") then
+            refreshDecor() -- Decors don't stick with players when their ped changes.
+        end
+    end
 end)

--- a/Example_Frameworks/NoPixelServer/np-eblips/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-eblips/fxmanifest.lua
@@ -1,0 +1,17 @@
+fx_version 'cerulean'
+game 'gta5'
+
+description 'Emergency blips handlers'
+
+client_scripts {
+    '@np-infinity/client/classes/blip.lua',
+    '@np-infinity/client/cl_lib.lua',
+    'cl_eblips.lua'
+}
+
+server_scripts {
+    '@np-infinity/server/sv_lib.lua',
+    'sv_eblips.lua'
+}
+
+lua54 'yes'

--- a/Example_Frameworks/NoPixelServer/np-eblips/sv_eblips.lua
+++ b/Example_Frameworks/NoPixelServer/np-eblips/sv_eblips.lua
@@ -1,10 +1,17 @@
-RegisterServerEvent('e-blips:updateBlips')
+--[[
+    -- Type: Event
+    -- Name: e-blips:updateBlips
+    -- Use: Broadcasts blip updates to all clients
+    -- Created: 2024-09-08
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('e-blips:updateBlips')
 AddEventHandler('e-blips:updateBlips', function(id, job, name)
-    local src = source
     local data = {
         netId = id,
         job = job,
         callsign = name
     }
-    TriggerClientEvent('e-blips:addHandler', source, data)
+
+    TriggerClientEvent('e-blips:addHandler', -1, data)
 end)


### PR DESCRIPTION
## Summary
- migrate to `fxmanifest.lua` and enable Lua 5.4
- add robust decor management and blip update utilities
- broadcast blip updates to all clients

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-eblips/cl_eblips.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-eblips/sv_eblips.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1ce05b9a8832d830dedeafca5cb63