### PR TITLE
refactor(np-errorlog): modernize error logging

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-errorlog/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-errorlog/__resource.lua
@@ -1,4 +1,0 @@
-resource_manifest_version "44febabe-d386-4d18-afbe-5e627f4af937"
-
-server_script "server/sv_errorlog.lua"
-client_script "client/cl_errorlog.lua"

--- a/Example_Frameworks/NoPixelServer/np-errorlog/client/cl_errorlog.lua
+++ b/Example_Frameworks/NoPixelServer/np-errorlog/client/cl_errorlog.lua
@@ -1,27 +1,41 @@
-local oldError = error
-local oldTrace = Citizen.Trace
+--[[
+    -- Type: Client Script
+    -- Name: cl_errorlog
+    -- Use: Detects error-related traces and forwards them to the server
+    -- Created: 2024-05-27
+    -- By: VSSVSSN
+--]]
 
-local errorWords = {"failure", "error", "not", "failed", "not safe", "invalid", "cannot", ".lua", "server", "client", "attempt", "traceback", "stack", "function"}
+local originalError = error
+local originalTrace = Citizen.Trace
 
-function error(...)
+local errorWords = {
+    "failure", "error", "not", "failed", "not safe", "invalid", "cannot",
+    ".lua", "server", "client", "attempt", "traceback", "stack", "function"
+}
+
+local function sendErrorLog(msg)
     local resource = GetCurrentResourceName()
-    print("------------------ ERROR IN RESOURCE: " .. resource)
-    print(...)
-    print("------------------ END OF ERROR")
-    TriggerServerEvent("error", resource, args)
+    TriggerServerEvent('np-errorlog:logError', resource, msg)
 end
 
-function Citizen.Trace(...)
-    oldTrace(...)
+function error(message, ...)
+    sendErrorLog(tostring(message))
+    return originalError(message, ...)
+end
 
-    if type(...) == "string" then
-        args = string.lower(...)
-        
+function Citizen.Trace(message, ...)
+    originalTrace(message, ...)
+
+    if type(message) == 'string' then
+        local lower = message:lower()
+
         for _, word in ipairs(errorWords) do
-            if string.find(args, word) then
-                error(...)
-                return
+            if lower:find(word, 1, true) then
+                sendErrorLog(message)
+                break
             end
         end
     end
 end
+

--- a/Example_Frameworks/NoPixelServer/np-errorlog/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-errorlog/fxmanifest.lua
@@ -1,0 +1,10 @@
+fx_version 'cerulean'
+game 'gta5'
+
+lua54 'yes'
+
+description 'Error logging to Discord'
+
+client_script 'client/cl_errorlog.lua'
+server_script 'server/sv_errorlog.lua'
+

--- a/Example_Frameworks/NoPixelServer/np-errorlog/server/sv_errorlog.lua
+++ b/Example_Frameworks/NoPixelServer/np-errorlog/server/sv_errorlog.lua
@@ -1,23 +1,37 @@
-RegisterServerEvent('error')
-AddEventHandler('error',function(resource, args)
+--[[
+    -- Type: Server Script
+    -- Name: sv_errorlog
+    -- Use: Receives client error logs and forwards them to Discord
+    -- Created: 2024-05-27
+    -- By: VSSVSSN
+--]]
 
-    sendToDiscord("```Error in "..resource..'```', args)
-end)
+local WEBHOOK_URL = 'https://canary.discord.com/api/webhooks/801641849546342410/LJYXEy_wyWjPpCr412cPcs4ae5-7ynLx86pwPPzxdao8p1Wpv6B_VBBTdOxWTK_qn28u'
 
+local function sendToDiscord(title, message)
+    local embeds = {
+        {
+            color = 16711680,
+            title = title,
+            description = message or 'no message',
+            footer = { text = 'Made by Sway' }
+        }
+    }
 
-
-function sendToDiscord(name, args, color)
-    local connect = {
-          {
-              ["color"] = 16711680,
-              ["title"] = "".. name .."",
-              ["description"] = args,
-              ["footer"] = {
-                  ["text"] = "Made by Sway",
-              },
-          }
-      }
-    PerformHttpRequest('https://canary.discord.com/api/webhooks/801641849546342410/LJYXEy_wyWjPpCr412cPcs4ae5-7ynLx86pwPPzxdao8p1Wpv6B_VBBTdOxWTK_qn28u', function(err, text, headers) end, 'POST', json.encode({username = "Error Log", embeds = connect, avatar_url = "https://i.imgur.com/VuKnN5P_d.webp?maxwidth=728&fidelity=grand"}), { ['Content-Type'] = 'application/json' })
+    PerformHttpRequest(
+        WEBHOOK_URL,
+        function(err, text, headers) end,
+        'POST',
+        json.encode({
+            username = 'Error Log',
+            embeds = embeds,
+            avatar_url = 'https://i.imgur.com/VuKnN5P_d.webp?maxwidth=728&fidelity=grand'
+        }),
+        { ['Content-Type'] = 'application/json' }
+    )
 end
 
--- it must be saving into a file with io.open("test.lua", "r")
+RegisterNetEvent('np-errorlog:logError', function(resource, message)
+    sendToDiscord(string.format('```Error in %s```', resource or 'unknown'), message)
+end)
+


### PR DESCRIPTION
## Summary
- convert np-errorlog to fxmanifest and enable Lua 5.4
- refactor client tracing to forward errors via `np-errorlog:logError`
- replace server legacy event with `RegisterNetEvent` and tidy Discord webhook payload

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-errorlog/client/cl_errorlog.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-errorlog/server/sv_errorlog.lua`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ce1785e8832d886e558c5b5db5b9