### PR TITLE
refactor(np-fx): modernize resource and fix typo

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-fx/client.lua
+++ b/Example_Frameworks/NoPixelServer/np-fx/client.lua
@@ -698,7 +698,7 @@ Citizen.CreateThread(function()
       end
     end
 
-    if currentLevel == 0 and newDrunklevel then
+    if currentLevel == 0 and newDrunkLevel then
       newDrunkLevel = false
     elseif currentLevel == 1 and newDrunkLevel then
       SetPedMovementClipset(PlayerPedId(), "move_m@drunk@slightlydrunk", 1.0)

--- a/Example_Frameworks/NoPixelServer/np-fx/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-fx/fxmanifest.lua
@@ -1,9 +1,11 @@
-resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
+fx_version 'cerulean'
+game 'gta5'
+lua54 'yes'
 
 ui_page 'index.html'
 
 client_scripts {
-  'client.lua',
+  'client.lua'
 }
 
 files {

--- a/Example_Frameworks/NoPixelServer/np-fx/index.html
+++ b/Example_Frameworks/NoPixelServer/np-fx/index.html
@@ -1,25 +1,21 @@
+<!DOCTYPE html>
 <html>
-    <head>
-        <!-- Need to include jQuery! -->
-        <script src="nui://game/ui/jquery.js" type="text/javascript"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.1.1/howler.min.js" type="text/javascript"></script>
-        <script>
-            var audioPlayer = null;
-            // Listen for NUI Messages.
-            window.addEventListener('message', function(event) {
-                // Check for playSound transaction
-                if (event.data.transactionType == "playSound") {
-				
-                  if (audioPlayer != null) {
-                    audioPlayer.pause();
-                  }
-
-                  audioPlayer = new Howl({src: ["./sounds/" + event.data.transactionFile + ".ogg"]});
-                  audioPlayer.volume(event.data.transactionVolume);
-                  audioPlayer.play();
-
-                }
-            });
-        </script>
-    </head>
+  <head>
+    <meta charset="utf-8" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/howler/2.1.1/howler.min.js"></script>
+    <script>
+      let audioPlayer = null;
+      window.addEventListener('message', (event) => {
+        if (event.data.transactionType === 'playSound') {
+          if (audioPlayer) {
+            audioPlayer.pause();
+          }
+          audioPlayer = new Howl({ src: [`./sounds/${event.data.transactionFile}.ogg`] });
+          audioPlayer.volume(event.data.transactionVolume);
+          audioPlayer.play();
+        }
+      });
+    </script>
+  </head>
+  <body></body>
 </html>


### PR DESCRIPTION
## Summary
- migrate np-fx to fxmanifest and enable Lua 5.4
- simplify NUI HTML and remove unused jQuery
- fix incorrect drunk state variable name

## Testing
- `luac -p client.lua` *(fails: command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ce57bc74832d89658ec76127ccda