### PR TITLE
refactor: modernize np-heatmap

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-heatmap/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-heatmap/__resource.lua
@@ -1,7 +1,0 @@
-resource_manifest_version '77731fab-63ca-442c-a67b-abc70f28dfa5'
-
-
-client_script "@np-errorlog/client/cl_errorlog.lua"
-
-client_script "client.lua"
-server_script "server.lua"

--- a/Example_Frameworks/NoPixelServer/np-heatmap/client.lua
+++ b/Example_Frameworks/NoPixelServer/np-heatmap/client.lua
@@ -1,44 +1,50 @@
 local blips = {}
 
-local reasonsColor = {
-  [1] = {"Game crashed: green-music-cola (gta-core-five.dll+4A8E0)",2},
-  [2] = {"Game crashed: mockingbird-two-purple (GTA5+AA7719)",58}
+local reasonColors = {
+    ["Game crashed: green-music-cola (gta-core-five.dll+4A8E0)"] = 2,
+    ["Game crashed: mockingbird-two-purple (GTA5+AA7719)"] = 58
 }
 
-
-
-function clearHeatMap()
-  for k,v in pairs(blips) do
-    RemoveBlip(v)
-    blips[k] = nil
-  end
-
-end
-RegisterNetEvent("heatmap:clear");
-AddEventHandler("heatmap:clear", clearHeatMap);
-
-
-function setHeatMap(locations)
-  for k,v in pairs(locations) do
-    local pos = json.decode(v[1])
-    local blip = AddBlipForCoord(pos[1],pos[2],pos[3])
-    SetBlipCategory(blip, 2)
-    SetBlipAsShortRange(blip, false)
-    local custColor = 0
-    for i=1,#reasonsColor do
-      if v[2] == reasonsColor[i][1] then 
-        custColor = reasonsColor[i][2]
-      end
+--[[
+    -- Type: Function
+    -- Name: clearHeatMap
+    -- Use: Removes all heatmap blips from the map
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+local function clearHeatMap()
+    for id, blip in pairs(blips) do
+        RemoveBlip(blip)
+        blips[id] = nil
     end
-    if custColor ~= 0 then
-      SetBlipColour(blip,custColor)
-    else
-      SetBlipColour(blip, 81)
-    end
-    SetBlipScale(blip, 1.0)
-
-    blips[k] = blip
-  end
 end
-RegisterNetEvent("heatmap:set");
-AddEventHandler("heatmap:set", setHeatMap);
+RegisterNetEvent('heatmap:clear', clearHeatMap)
+
+AddEventHandler('onResourceStop', function(resource)
+    if resource == GetCurrentResourceName() then
+        clearHeatMap()
+    end
+end)
+
+--[[
+    -- Type: Function
+    -- Name: setHeatMap
+    -- Use: Draws blips for crash locations provided by the server
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+local function setHeatMap(locations)
+    clearHeatMap()
+    for k, v in ipairs(locations) do
+        local pos = json.decode(v[1])
+        local blip = AddBlipForCoord(pos[1], pos[2], pos[3])
+        SetBlipCategory(blip, 2)
+        SetBlipAsShortRange(blip, false)
+        local color = reasonColors[v[2]] or 81
+        SetBlipColour(blip, color)
+        SetBlipScale(blip, 1.0)
+        blips[k] = blip
+    end
+end
+RegisterNetEvent('heatmap:set', setHeatMap)
+

--- a/Example_Frameworks/NoPixelServer/np-heatmap/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-heatmap/fxmanifest.lua
@@ -1,0 +1,15 @@
+fx_version 'cerulean'
+game 'gta5'
+
+lua54 'yes'
+
+client_scripts {
+    '@np-errorlog/client/cl_errorlog.lua',
+    'client.lua'
+}
+
+server_scripts {
+    '@np-errorlog/server/sv_errorlog.lua',
+    'server.lua'
+}
+

--- a/Example_Frameworks/NoPixelServer/np-heatmap/server.lua
+++ b/Example_Frameworks/NoPixelServer/np-heatmap/server.lua
@@ -1,0 +1,46 @@
+local displaying = {}
+
+--[[
+    -- Type: Function
+    -- Name: fetchHeatmapData
+    -- Use: Retrieves heatmap entries from the database
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+local function fetchHeatmapData()
+    local p = promise.new()
+    exports['ghmattimysql']:execute('SELECT coords, reason FROM heatmap', {}, function(rows)
+        p:resolve(rows)
+    end)
+    return Citizen.Await(p)
+end
+
+--[[
+    -- Type: Event Handler
+    -- Name: heatmap:display
+    -- Use: Toggles heatmap visibility for a player
+    -- Created: 2024-05-16
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('heatmap:display', function()
+    local src = source
+    if displaying[src] then
+        TriggerClientEvent('heatmap:clear', src)
+        displaying[src] = nil
+        return
+    end
+
+    local result = fetchHeatmapData() or {}
+    local locations = {}
+    for _, row in ipairs(result) do
+        locations[#locations + 1] = {row.coords, row.reason}
+    end
+
+    TriggerClientEvent('heatmap:set', src, locations)
+    displaying[src] = true
+end)
+
+AddEventHandler('playerDropped', function()
+    displaying[source] = nil
+end)
+


### PR DESCRIPTION
## Summary
- migrate np-heatmap to fxmanifest with Lua 5.4
- refactor client blip logic and add resource cleanup
- add server handler to fetch heatmap data and toggle display

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-heatmap/client.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-heatmap/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1ced67c40832d9fe20a10358bf2da