### PR TITLE
refactor: modernize np-jobmanager

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-jobmanager/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-jobmanager/__resource.lua
@@ -1,8 +1,0 @@
-resource_manifest_version "44febabe-d386-4d18-afbe-5e627f4af937"
-
-dependency "np-base"
-
-shared_script "shared/sh_jobmanager.lua"
-
-server_script "server/sv_jobmanager.lua"
-client_script "client/cl_jobmanager.lua"

--- a/Example_Frameworks/NoPixelServer/np-jobmanager/client/cl_jobmanager.lua
+++ b/Example_Frameworks/NoPixelServer/np-jobmanager/client/cl_jobmanager.lua
@@ -1,50 +1,56 @@
+--[[
+    -- Type: Client Script
+    -- Name: cl_jobmanager.lua
+    -- Use: Handles client-side job updates and notifications
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
 
-RegisterNetEvent("np-jobmanager:playerBecameJob")
-AddEventHandler("np-jobmanager:playerBecameJob", function(job, name, notify)
-    local LocalPlayer = exports["np-base"]:getModule("LocalPlayer")
-    LocalPlayer:setVar("job", job)
-    if notify ~= false then TriggerEvent("DoLongHudText", job ~= "unemployed" and "New Job: " .. tostring(name) or "You're now unemployed", 1) end
+local function handleSpecialMessages(job, name)
     if name == "Entertainer" then
-	    TriggerEvent('DoLongHudText',"College DJ and Comedy Club pay per person around you",1)
-	end
-    if name == "Broadcaster" then
-        TriggerEvent('DoLongHudText',"(RadioButton + LeftCtrl for radio toggle)",3)
-        TriggerEvent('DoLongHudText',"Broadcast from this room and give out the vibes to los santos on 1982.9",1)
-    end  
-	if job == "unemployed"  then
-		SetPedRelationshipGroupDefaultHash(PlayerPedId(),`PLAYER`)
-        SetPoliceIgnorePlayer(PlayerPedId(),false)
-        TriggerEvent("ResetRadioChannel");
-	end
-    
-    if job == "trucker" then
-        TriggerServerEvent("TokoVoip:addPlayerToRadio", 4, GetPlayerServerId(PlayerId()))
+        TriggerEvent('DoLongHudText', "College DJ and Comedy Club pay per person around you", 1)
+    elseif name == "Broadcaster" then
+        TriggerEvent('DoLongHudText', "(RadioButton + LeftCtrl for radio toggle)", 3)
+        TriggerEvent('DoLongHudText', "Broadcast from this room and give out the vibes to los santos on 1982.9", 1)
+    elseif job == "news" then
+        TriggerEvent('DoLongHudText', "'H' to use item, F1 change item. (/light r g b)", 1)
+    elseif job == "driving instructor" then
+        TriggerEvent('DoLongHudText', "'/driving' to access driving instructor systems", 1)
+    elseif job == "towtruck" then
+        TriggerEvent('DoLongHudText', "Use /tow to tow cars to your truck.", 1)
+    end
+end
+
+RegisterNetEvent("np-jobmanager:playerBecameJob", function(job, name, notify)
+    local localPlayer = exports["np-base"]:getModule("LocalPlayer")
+    localPlayer:setVar("job", job)
+
+    if notify ~= false then
+        TriggerEvent("DoLongHudText", job ~= "unemployed" and "New Job: " .. tostring(name) or "You're now unemployed", 1)
     end
 
-    if job == "towtruck" then
-        TriggerEvent("DoLongHudText","Use /tow to tow cars to your truck.",1)
+    handleSpecialMessages(job, name)
+
+    if job == "unemployed" then
+        local ped = PlayerPedId()
+        SetPedRelationshipGroupDefaultHash(ped, GetHashKey("PLAYER"))
+        SetPoliceIgnorePlayer(ped, false)
+        TriggerEvent("ResetRadioChannel")
+    elseif job == "trucker" then
+        TriggerServerEvent("TokoVoip:addPlayerToRadio", 4, GetPlayerServerId(PlayerId()))
+    elseif job == "towtruck" then
         TriggerServerEvent("TokoVoip:addPlayerToRadio", 3, GetPlayerServerId(PlayerId()))
     end
 
-    if job == "news"  then
-        TriggerEvent('DoLongHudText',"'H' to use item, F1 change item. (/light r g b)",1)
-    end
-
-    if job == "driving instructor"  then
-        TriggerEvent('DoLongHudText',"'/driving' to use access driving instructor systems",1)
-    end
-    
-    TriggerServerEvent("np-items:updateID",job,exports["isPed"]:retreiveBusinesses())
+    TriggerServerEvent("np-items:updateID", job, exports["isPed"]:retreiveBusinesses())
 end)
 
-RegisterNetEvent("np-base:characterLoaded")
-AddEventHandler("np-base:characterLoaded", function(character)
-    local LocalPlayer = exports["np-base"]:getModule("LocalPlayer")
-    LocalPlayer:setVar("job", "unemployed")
-
+RegisterNetEvent("np-base:characterLoaded", function()
+    local localPlayer = exports["np-base"]:getModule("LocalPlayer")
+    localPlayer:setVar("job", "unemployed")
 end)
 
-RegisterNetEvent("np-base:exportsReady")
-AddEventHandler("np-base:exportsReady", function()
+RegisterNetEvent("np-base:exportsReady", function()
     exports["np-base"]:addModule("JobManager", NPX.Jobs)
 end)
+

--- a/Example_Frameworks/NoPixelServer/np-jobmanager/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-jobmanager/fxmanifest.lua
@@ -1,0 +1,23 @@
+fx_version 'cerulean'
+game 'gta5'
+
+lua54 'yes'
+
+name 'np-jobmanager'
+description 'Job management system'
+author 'VSSVSSN'
+version '1.0.1'
+
+dependency 'np-base'
+
+shared_scripts {
+    'shared/sh_jobmanager.lua'
+}
+
+server_scripts {
+    'server/sv_jobmanager.lua'
+}
+
+client_scripts {
+    'client/cl_jobmanager.lua'
+}

--- a/Example_Frameworks/NoPixelServer/np-jobmanager/shared/sh_jobmanager.lua
+++ b/Example_Frameworks/NoPixelServer/np-jobmanager/shared/sh_jobmanager.lua
@@ -1,5 +1,13 @@
-NPX = {}
-NPX.Jobs = {}
+--[[
+    -- Type: Shared Script
+    -- Name: sh_jobmanager.lua
+    -- Use: Defines available jobs and base configuration
+    -- Created: 09/10/2025
+    -- By: VSSVSSN
+--]]
+
+NPX = NPX or {}
+NPX.Jobs = NPX.Jobs or {}
 NPX.Jobs.ValidJobs = {
     ["unemployed"] = {
         name = "Unemployed",
@@ -18,7 +26,7 @@ NPX.Jobs.ValidJobs = {
         },
     },
     ["police"] = {
-        name = "Police officer",
+        name = "Police Officer",
         paycheck = 150,
         whitelisted = true,
         ranks = {
@@ -46,7 +54,7 @@ NPX.Jobs.ValidJobs = {
         paycheck = 50
     },
     ["taxi"] = {
-        name = "Taxi driver",
+        name = "Taxi Driver",
         paycheck = 20
     },
     ["trucker"] = {
@@ -93,5 +101,5 @@ NPX.Jobs.ValidJobs = {
         name = "Food Truck Vendor",
         paycheck = 10
     },
-
 }
+


### PR DESCRIPTION
## Summary
- migrate np-jobmanager to `fxmanifest.lua` with Lua 5.4 support
- refactor client notifications and reset handling
- fix server whitelist, rank, and paycheck logic

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-jobmanager/client/cl_jobmanager.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-jobmanager/server/sv_jobmanager.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-jobmanager/shared/sh_jobmanager.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1cf1590bc832d9bfdab4a82f81410