### PR TITLE
refactor(np-keys): modernize key management

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-keys/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-keys/__resource.lua
@@ -1,7 +1,0 @@
-resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
-
-
-client_script "@np-errorlog/client/cl_errorlog.lua"
-
-client_script "client.lua"
-server_script "server.lua"

--- a/Example_Frameworks/NoPixelServer/np-keys/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-keys/fxmanifest.lua
@@ -1,0 +1,11 @@
+fx_version 'cerulean'
+game 'gta5'
+
+client_scripts {
+    '@np-errorlog/client/cl_errorlog.lua',
+    'client.lua'
+}
+
+server_scripts {
+    'server.lua'
+}

--- a/Example_Frameworks/NoPixelServer/np-keys/server.lua
+++ b/Example_Frameworks/NoPixelServer/np-keys/server.lua
@@ -1,4 +1,21 @@
-RegisterServerEvent('keys:send')
-AddEventHandler('keys:send', function(player, data)
-    TriggerClientEvent('keys:received', player, data)
+--[[
+    -- Type: Server
+    -- Name: np-keys server
+    -- Use: Handles key transfer between players
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+
+--[[
+    -- Type: Event
+    -- Name: keys:send
+    -- Use: Sends a key to another player by triggering a client event
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('keys:send')
+AddEventHandler('keys:send', function(targetId, plate)
+    local src = source
+    if type(targetId) ~= 'number' or type(plate) ~= 'string' then return end
+    TriggerClientEvent('keys:received', targetId, plate)
 end)


### PR DESCRIPTION
## Summary
- migrate np-keys to fxmanifest
- refactor client key handling into modular table with hotwire and search helpers
- add server-side validation for key transfer

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-keys/client.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-keys/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1cf27ce30832dba53ad9b8be9ccb1