### PR TITLE
refactor(np-oHideFrames): modernize HUD handling

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-oHideFrames/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-oHideFrames/__resource.lua
@@ -1,7 +1,0 @@
-resource_manifest_version '77731fab-63ca-442c-a67b-abc70f28dfa5'
-
-client_script "@np-errorlog/client/cl_errorlog.lua"
-
-client_script 'client.lua'
-
-

--- a/Example_Frameworks/NoPixelServer/np-oHideFrames/client.lua
+++ b/Example_Frameworks/NoPixelServer/np-oHideFrames/client.lua
@@ -1,46 +1,40 @@
+--[[
+    -- Type: Thread
+    -- Name: HideFramesLoop
+    -- Use: Continuously hides HUD elements and adjusts player settings
+    -- Created: 2024-06-09
+    -- By: VSSVSSN
+--]]
 
+local hiddenComponents = {
+    1, -- Weapon icon
+    6, -- Vehicle name
+    7, -- Area name
+    9  -- Street name
+}
 
-
-Citizen.CreateThread(function()
+CreateThread(function()
+    SetPlayerHealthRechargeMultiplier(PlayerId(), 0.0)
+    SetPedMinGroundTimeForStungun(PlayerPedId(), 6000)
 
     while true do
+        Wait(0)
 
-        Citizen.Wait(1)
+        local ped = PlayerPedId()
 
-        if not IsAimCamActive() or not IsFirstPersonAimCamActive() then
+        if not IsAimCamActive() and not IsFirstPersonAimCamActive() then
             HideHudComponentThisFrame(14)
         end
 
-        if IsHudComponentActive(1) then 
-            HideHudComponentThisFrame(1)
+        for _, component in ipairs(hiddenComponents) do
+            HideHudComponentThisFrame(component)
         end
 
-        if IsHudComponentActive(6) then 
-            HideHudComponentThisFrame(6)
-        end
-
-        if IsHudComponentActive(7) then 
-            HideHudComponentThisFrame(7)
-        end
-
-        if IsHudComponentActive(9) then 
-            HideHudComponentThisFrame(9)
-        end
-
-        if IsHudComponentActive(0) and not IsPedInAnyVehicle(GetPlayerPed( -1 ), true) then 
+        if not IsPedInAnyVehicle(ped, true) then
             HideHudComponentThisFrame(0)
         end
 
-
-        if IsControlPressed(0,44) then
-            DisplayHud(1)
-        else
-            DisplayHud(0)
-        end
-
-
-        SetPlayerHealthRechargeMultiplier(PlayerId(), 0.0)
-
-        SetPedMinGroundTimeForStungun(PlayerPedId(), 6000)
+        DisplayHud(IsControlPressed(0, 44))
     end
 end)
+

--- a/Example_Frameworks/NoPixelServer/np-oHideFrames/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-oHideFrames/fxmanifest.lua
@@ -1,0 +1,16 @@
+--[[
+    -- Type: Manifest
+    -- Name: np-oHideFrames
+    -- Use: Defines resource metadata and scripts for FiveM
+    -- Created: 2024-06-09
+    -- By: VSSVSSN
+--]]
+
+fx_version 'cerulean'
+game 'gta5'
+
+client_scripts {
+    '@np-errorlog/client/cl_errorlog.lua',
+    'client.lua'
+}
+


### PR DESCRIPTION
## Summary
- replace deprecated `__resource.lua` with `fxmanifest.lua`
- refactor client loop to reduce overhead and fix crosshair logic
- use `PlayerPedId` and table-driven HUD component hiding

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-oHideFrames/client.lua`

------
https://chatgpt.com/codex/tasks/task_e_68c1e0287794832d9e198d0fbf345411