### PR TITLE
refactor: modernize recoil handling

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-oRecoil/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-oRecoil/__resource.lua
@@ -1,7 +1,0 @@
-resource_manifest_version '77731fab-63ca-442c-a67b-abc70f28dfa5'
-
-client_script "@np-errorlog/client/cl_errorlog.lua"
-
-client_script 'client.lua'
-
-

--- a/Example_Frameworks/NoPixelServer/np-oRecoil/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-oRecoil/fxmanifest.lua
@@ -1,0 +1,6 @@
+fx_version 'cerulean'
+game 'gta5'
+lua54 'yes'
+
+client_script '@np-errorlog/client/cl_errorlog.lua'
+client_script 'client.lua'


### PR DESCRIPTION
## Summary
- modernize np-oRecoil manifest and Lua scripts
- clamp recoil factor and fix stress check bug
- streamline crouch/prone logic and drive-by camera handling

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-oRecoil/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1e0398450832d9b37cee791f449c9