### PR TITLE
Refactor propattach for modern FiveM

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-propattach/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-propattach/__resource.lua
@@ -1,2 +1,0 @@
-resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
-client_script 'client.lua'

--- a/Example_Frameworks/NoPixelServer/np-propattach/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-propattach/fxmanifest.lua
@@ -1,0 +1,5 @@
+fx_version 'cerulean'
+game 'gta5'
+lua54 'yes'
+
+client_script 'client.lua'


### PR DESCRIPTION
## Summary
- migrate np-propattach to fxmanifest
- refactor client script with helper model/anim loaders and local scoping
- fix prop attach toggle logic and switch to hash-based weapon checks

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-propattach/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1e07da5c0832d8f8d699a9ebd06ea