### PR TITLE
refactor(np-rehab): modernize rehab resource

### DIFF
--- a/Example_Frameworks/NoPixelServer/apartments/hotel_client.lua
+++ b/Example_Frameworks/NoPixelServer/apartments/hotel_client.lua
@@ -21,7 +21,7 @@ RegisterNetEvent('Relog')
 AddEventHandler('Relog', function()
 	currentselection = 1
 	TriggerServerEvent('isVip')
-	TriggerEvent('rehab:changeCharecter')
+        TriggerEvent('rehab:changeCharacter')
 	TriggerServerEvent('checkTypes')
 	TriggerEvent("resetinhouse")
 	TriggerEvent("fx:clear")

--- a/Example_Frameworks/NoPixelServer/np-rehab/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-rehab/__resource.lua
@@ -1,7 +1,0 @@
-resource_manifest_version '05cfa83c-a124-4cfa-a768-c24a5811d8f9'
-
-
-client_script "@np-errorlog/client/cl_errorlog.lua"
-
-client_script 'client.lua'
-server_script 'server.lua'

--- a/Example_Frameworks/NoPixelServer/np-rehab/client.lua
+++ b/Example_Frameworks/NoPixelServer/np-rehab/client.lua
@@ -1,60 +1,84 @@
+--[[ 
+    -- Type: Client
+    -- Name: np-rehab client
+    -- Use: Manages rehab holding area and player restrictions
+    -- Created: 2024-05-31
+    -- By: VSSVSSN
+--]]
+
 local groundCoords = {
-    {-1517.29,852.89,181.6}, 
-    { -1564.5,775.2,189.2},
-    { -1572.18,771.74,189.2},
-    { -1581.47,788.57,189.2},
-    { -1579.19,815.84,186.0},
+    vector3(-1517.29, 852.89, 181.6),
+    vector3(-1564.5, 775.2, 189.2),
+    vector3(-1572.18, 771.74, 189.2),
+    vector3(-1581.47, 788.57, 189.2),
+    vector3(-1579.19, 815.84, 186.0)
 }
 
 local restrictionCoords = {
-    [1] =  { ['x'] = -1512.66,['y'] = 863.0,['z'] = 181.9,['r'] = 80.0},
-    [2] =  { ['x'] = -1594.4,['y'] = 765.59,['z'] = 189.2,['r'] = 36.0},
-    [3] =  { ['x'] = -1576.23,['y'] = 815.9,['z'] = 185.99,['r'] = 60.0},
+    { x = -1512.66, y = 863.0,  z = 181.9,  r = 80.0 },
+    { x = -1594.4,  y = 765.59, z = 189.2, r = 36.0 },
+    { x = -1576.23, y = 815.9,  z = 185.99, r = 60.0 }
 }
 
 local placement = 0
 local isInRehab = false
-RegisterNetEvent('beginJailRehab')
-AddEventHandler('beginJailRehab', function(isInRehabSent)
+
+--[[ 
+    -- Type: Event
+    -- Name: beginJailRehab
+    -- Use: Initiates rehab and enforces movement restrictions
+    -- Created: 2024-05-31
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('beginJailRehab', function(isInRehabSent)
     isInRehab = isInRehabSent
-    local rnd = math.random(1,5)
-    placement = rnd
-    TriggerEvent("DensityModifierEnable",false)
-    TriggerEvent("DoLongHudText", "You are on a mental hold.",1)
-    Citizen.Wait(1000)
-    SetEntityCoords(PlayerPedId(),groundCoords[placement][1],groundCoords[placement][2],groundCoords[placement][3]) 
-    TriggerEvent("falseCuffs")  
+    placement = math.random(#groundCoords)
+
+    TriggerEvent("DensityModifierEnable", false)
+    TriggerEvent("DoLongHudText", "You are on a mental hold.", 1)
+    Wait(1000)
+
+    local targetPos = groundCoords[placement]
+    local ped = PlayerPedId()
+    SetEntityCoords(ped, targetPos.x, targetPos.y, targetPos.z, false, false, false, true)
+    TriggerEvent("falseCuffs")
     DoScreenFadeIn(1500)
-    if isInRehab then
-        while isInRehab do
-            Citizen.Wait(1000)
-            RemoveAllPedWeapons(PlayerPedId())
-            TriggerEvent("attachWeapons")
-            local inside = false
-            for k,v in pairs(restrictionCoords) do
-                if #(GetEntityCoords(PlayerPedId()) - vector3(v.x,v.y,v.z)) < v.r then
-                    inside = true
-                end
-            end
 
-            if not inside then
-                TriggerEvent("DoLongHudText", "The orderly have placed you back into the facility for protection.",1)
-                SetEntityCoords(PlayerPedId(), groundCoords[placement][1],groundCoords[placement][2],groundCoords[placement][3]) 
-            end
+    while isInRehab do
+        Wait(1000)
+        ped = PlayerPedId()
+        RemoveAllPedWeapons(ped, true)
+        TriggerEvent("attachWeapons")
 
-            if placement == 0 then break end
+        local pos = GetEntityCoords(ped)
+        local inside = false
+        for _, v in ipairs(restrictionCoords) do
+            if #(pos - vector3(v.x, v.y, v.z)) < v.r then
+                inside = true
+                break
+            end
         end
-    else
-        placement = 0
+
+        if not inside then
+            TriggerEvent("DoLongHudText", "The orderly have placed you back into the facility for protection.", 1)
+            local resetPos = groundCoords[placement]
+            SetEntityCoords(ped, resetPos.x, resetPos.y, resetPos.z, false, false, false, true)
+        end
     end
 
-    TriggerEvent("DoLongHudText", "You were removed from Mental health care.",1)
-    SetEntityCoords(PlayerPedId(), -1475.86,884.47,182.93)
-
-    TriggerEvent("DensityModifierEnable",true)
+    TriggerEvent("DoLongHudText", "You were removed from Mental health care.", 1)
+    SetEntityCoords(PlayerPedId(), -1475.86, 884.47, 182.93, false, false, false, true)
+    TriggerEvent("DensityModifierEnable", true)
 end)
 
-RegisterNetEvent('rehab:changeCharecter')
-AddEventHandler('rehab:changeCharecter', function()
-   isInRehab = false
+--[[ 
+    -- Type: Event
+    -- Name: rehab:changeCharacter
+    -- Use: Releases the player from the rehab loop
+    -- Created: 2024-05-31
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('rehab:changeCharacter', function()
+    isInRehab = false
 end)
+

--- a/Example_Frameworks/NoPixelServer/np-rehab/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-rehab/fxmanifest.lua
@@ -1,0 +1,17 @@
+--[[
+    -- Type: Manifest
+    -- Name: fxmanifest.lua
+    -- Use: Defines resource metadata for np-rehab
+    -- Created: 2024-05-31
+    -- By: VSSVSSN
+--]]
+
+fx_version 'cerulean'
+game 'gta5'
+lua54 'yes'
+
+client_script '@np-errorlog/client/cl_errorlog.lua'
+
+client_script 'client.lua'
+server_script 'server.lua'
+

--- a/Example_Frameworks/NoPixelServer/np-rehab/server.lua
+++ b/Example_Frameworks/NoPixelServer/np-rehab/server.lua
@@ -1,16 +1,33 @@
+--[[ 
+    -- Type: Server
+    -- Name: np-rehab server
+    -- Use: Provides commands to manage player rehabilitation
+    -- Created: 2024-05-31
+    -- By: VSSVSSN
+--]]
+
+--[[ 
+    -- Type: Command
+    -- Name: rehab
+    -- Use: Places or removes a player from rehab
+    -- Created: 2024-05-31
+    -- By: VSSVSSN
+--]]
 RegisterCommand('rehab', function(source, args)
     local src = source
-	local user = exports["np-base"]:getModule("Player"):GetUser(src)
+    local user = exports["np-base"]:getModule("Player"):GetUser(src)
+    if not user then return end
 
-    if user:getVar("job") == 'therapist' or user:getVar("job") == 'doctor' then
-        if args[1] then
-            if args[2] == tryue then
-                TriggerClientEvent("beginJailRehab", args[1], true)
-            else
-                TriggerClientEvent("beginJailRehab", args[1], false)
-            end
-        else
-            TriggerClientEvent("DoLongHudText", src, 'There are no player with this ID.', 2)
-        end
+    local job = user:getVar("job")
+    if job ~= 'therapist' and job ~= 'doctor' then return end
+
+    local target = tonumber(args[1])
+    if not target or not GetPlayerName(target) then
+        TriggerClientEvent("DoLongHudText", src, 'There are no player with this ID.', 2)
+        return
     end
-end)
+
+    local inRehab = args[2] and args[2]:lower() == 'true'
+    TriggerClientEvent("beginJailRehab", target, inRehab)
+end, false)
+


### PR DESCRIPTION
## Summary
- replace legacy __resource.lua with fxmanifest.lua and enable Lua 5.4
- refactor client and server scripts with detailed comments, stricter checks and modern API usage
- fix rehab command argument handling and corrected event names across resources

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-rehab/client.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-rehab/server.lua`
- `luac -p Example_Frameworks/NoPixelServer/apartments/hotel_client.lua` *(fails: unexpected symbol near '\`')*


------
https://chatgpt.com/codex/tasks/task_e_68c1e08a0ff4832da5935bab48b7879d