### PR TITLE
refactor: update tunershop resource

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-tunershop/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-tunershop/__resource.lua
@@ -1,8 +1,0 @@
-resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
-
-this_is_a_map 'yes'
-
-client_script "lib/common.lua"
-client_script "client.lua"
-
-client_script "dlc_import/vehicle_warehouse_2.lua"

--- a/Example_Frameworks/NoPixelServer/np-tunershop/client.lua
+++ b/Example_Frameworks/NoPixelServer/np-tunershop/client.lua
@@ -1,5 +1,14 @@
+--[[
+    -- Type: Client Script
+    -- Name: client.lua
+    -- Use: Initializes the tuner shop warehouse IPLs on client start
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 
-Citizen.CreateThread(function()
-    ImportVehicleWarehouse.LoadDefault()
+CreateThread(function()
+    if ImportVehicleWarehouse and ImportVehicleWarehouse.LoadDefault then
+        ImportVehicleWarehouse.LoadDefault()
+    end
 end)
 

--- a/Example_Frameworks/NoPixelServer/np-tunershop/dlc_import/vehicle_warehouse_2.lua
+++ b/Example_Frameworks/NoPixelServer/np-tunershop/dlc_import/vehicle_warehouse_2.lua
@@ -1,13 +1,21 @@
+--[[
+    -- Type: Module
+    -- Name: vehicle_warehouse_2.lua
+    -- Use: Configures import vehicle warehouse IPLs and styles
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 
--- Vehicle warehouse
--- Upper: 994.5925, -3002.594, -39.64699
--- Lower: 969.5376, -3000.411, -48.64689
-
+--[[
+    -- Type: Function
+    -- Name: GetImportVehicleWarehouseObject
+    -- Use: Exports the warehouse configuration object
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 exports('GetImportVehicleWarehouseObject', function()
     return ImportVehicleWarehouse
 end)
-
-
 
 ImportVehicleWarehouse = {
     Upper = {
@@ -15,47 +23,59 @@ ImportVehicleWarehouse = {
         Ipl = {
             Interior = {
                 ipl = "imp_impexp_interior_placement_interior_1_impexp_intwaremed_milo_",
-                Load = function() EnableIpl(ImportVehicleWarehouse.Upper.Ipl.Interior.ipl, true) end,
-                Remove = function() EnableIpl(ImportVehicleWarehouse.Upper.Ipl.Interior.ipl, false) end
+                Load = function() TunerLib.EnableIpl(ImportVehicleWarehouse.Upper.Ipl.Interior.ipl, true) end,
+                Remove = function() TunerLib.EnableIpl(ImportVehicleWarehouse.Upper.Ipl.Interior.ipl, false) end
             },
         },
         Style = {
             basic = "basic_style_set", branded = "branded_style_set", urban = "urban_style_set",
             Set = function(style, refresh)
                 ImportVehicleWarehouse.Upper.Style.Clear(false)
-                SetIplPropState(ImportVehicleWarehouse.Upper.interiorId, style, true, refresh)
+                TunerLib.SetIplPropState(ImportVehicleWarehouse.Upper.interiorId, style, true, refresh)
             end,
             Clear = function(refresh)
-                SetIplPropState(ImportVehicleWarehouse.Upper.interiorId, {ImportVehicleWarehouse.Upper.Style.basic, ImportVehicleWarehouse.Upper.Style.branded, ImportVehicleWarehouse.Upper.Style.urban}, false, refresh)
+                TunerLib.SetIplPropState(
+                    ImportVehicleWarehouse.Upper.interiorId,
+                    { ImportVehicleWarehouse.Upper.Style.basic, ImportVehicleWarehouse.Upper.Style.branded, ImportVehicleWarehouse.Upper.Style.urban },
+                    false,
+                    refresh
+                )
             end
         },
         Details = {
             floorHatch = "car_floor_hatch",
-            doorBlocker = "door_blocker",       -- Invisible wall
-            Enable = function (details, state, refresh)
-                SetIplPropState(ImportVehicleWarehouse.Upper.interiorId, details, state, refresh)
+            doorBlocker = "door_blocker", -- Invisible wall
+            Enable = function(details, state, refresh)
+                TunerLib.SetIplPropState(ImportVehicleWarehouse.Upper.interiorId, details, state, refresh)
             end
-        },
+        }
     },
     Lower = {
         interiorId = GetInteriorAtCoords(935.3496, -965.217, 30.51093),
         Ipl = {
             Interior = {
                 ipl = "imp_impexp_interior_placement_interior_3_impexp_int_02_milo_",
-                Load = function() EnableIpl(ImportVehicleWarehouse.Lower.Ipl.Interior.ipl, true) end,
-                Remove = function() EnableIpl(ImportVehicleWarehouse.Lower.Ipl.Interior.ipl, false) end
+                Load = function() TunerLib.EnableIpl(ImportVehicleWarehouse.Lower.Ipl.Interior.ipl, true) end,
+                Remove = function() TunerLib.EnableIpl(ImportVehicleWarehouse.Lower.Ipl.Interior.ipl, false) end
             },
         },
         Details = {
             Pumps = {
-                pump1 = "pump_01", pump2 = "pump_02", pump3 = "pump_03", pump4 = "pump_04", pump5 = "pump_05", pump6 = "pump_06", pump7 = "pump_07", pump8 = "pump_08",
+                pump1 = "pump_01", pump2 = "pump_02", pump3 = "pump_03", pump4 = "pump_04",
+                pump5 = "pump_05", pump6 = "pump_06", pump7 = "pump_07", pump8 = "pump_08",
             },
-            Enable = function (details, state, refresh)
-                SetIplPropState(ImportVehicleWarehouse.Lower.interiorId, details, state, refresh)
+            Enable = function(details, state, refresh)
+                TunerLib.SetIplPropState(ImportVehicleWarehouse.Lower.interiorId, details, state, refresh)
             end
-        },
+        }
     },
-
+    --[[
+        -- Type: Function
+        -- Name: LoadDefault
+        -- Use: Loads default styles and props for the warehouse
+        -- Created: 2025-09-10
+        -- By: VSSVSSN
+    --]]
     LoadDefault = function()
         ImportVehicleWarehouse.Upper.Ipl.Interior.Load()
         ImportVehicleWarehouse.Upper.Style.Set(ImportVehicleWarehouse.Upper.Style.branded)
@@ -68,3 +88,4 @@ ImportVehicleWarehouse = {
         RefreshInterior(ImportVehicleWarehouse.Lower.interiorId)
     end
 }
+

--- a/Example_Frameworks/NoPixelServer/np-tunershop/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-tunershop/fxmanifest.lua
@@ -1,0 +1,22 @@
+--[[
+    -- Type: Manifest
+    -- Name: fxmanifest.lua
+    -- Use: Defines resource metadata and client scripts
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+
+fx_version 'cerulean'
+game 'gta5'
+lua54 'yes'
+
+version '1.0.0'
+
+this_is_a_map 'yes'
+
+client_scripts {
+    'lib/common.lua',
+    'dlc_import/vehicle_warehouse_2.lua',
+    'client.lua'
+}
+


### PR DESCRIPTION
## Summary
- replace deprecated `__resource.lua` with modern `fxmanifest.lua`
- namespace common utilities and streamline IPL helpers
- initialize tuner shop warehouse via `CreateThread` with safety checks

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-tunershop/client.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-tunershop/dlc_import/vehicle_warehouse_2.lua`
- `luac -p Example_Frameworks/NoPixelServer/np-tunershop/lib/common.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1e15a8680832db611ae784430143b