### PR TITLE
refactor: modernize np-voice

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-voice/client/client.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/client/client.lua
@@ -1,53 +1,16 @@
 Transmissions, Targets, Channels, Settings = Context:new(), Context:new(), Context:new(), {}
-CurrentTarget, CurrentInstance, CurrentProximity, CurrentVoiceChannel, Player, PlayerCoords, PreviousCoords, VoiceEnabled = 2, 0, 1, 0
+CurrentTarget, CurrentInstance, CurrentProximity, CurrentVoiceChannel, Player, PlayerCoords, PreviousCoords, VoiceEnabled = 2, 0, 1, 0, nil, nil, nil, false
 _myServerId = nil
 _isDead = false
 isVoiceActive = false
 
-
-AddEventHandler("syd:isdead",function(isdead)
+RegisterNetEvent('syd:isdead')
+AddEventHandler('syd:isdead', function(isDead)
     _isDead = isDead
 end)
 
-Citizen.CreateThread(function()
-    RegisterKeyMapping('+cycleProximity', "Cambia Volume Voce", 'keyboard', Config.cycleProximityHotkey)
-    RegisterCommand('+cycleProximity', CycleVoiceProximity, false)
-    RegisterCommand('-cycleProximity', function() end, false)
-
-    -- while not exports['es_extended']:hasPlayerLoaded() do
-    --     Wait(1000)
-    -- end
-
-    for i = 1, 4 do
-        MumbleClearVoiceTarget(i)
-    end
-
-    if Config.enableGrids then
-        LoadGridModule()
-    end
-
-    if Config.enableRadio then
-        LoadRadioModule()
-    end
-
-    if Config.enablePhone then
-        LoadPhoneModule()
-    end
-
-    if Config.enableCar then
-        LoadCarModule()
-    end
-
-    SetVoiceProximity(2)
-    TriggerEvent("np:voice:ready")
-
-    _myServerId = GetPlayerServerId(PlayerId())
-    voiceCheck()
-    voiceThread()
-end)
-
 function voiceCheck()
-    Citizen.CreateThread(function()
+    CreateThread(function()
         local toggle = false
         while true do
             local idle = 500
@@ -64,7 +27,7 @@ function voiceCheck()
                 toggle = true
             end
     
-            Citizen.Wait(idle)
+            Wait(idle)
         end
     end)
 end
@@ -73,7 +36,7 @@ end
 function voiceThread()
     --local id = PlayerId()
     local toggle = false
-    Citizen.CreateThread(function()
+    CreateThread(function()
         while true do
             local idle = 250
 
@@ -87,12 +50,13 @@ function voiceThread()
                 TriggerEvent('yeahlol:ofc', false)
             end
     
-            Citizen.Wait(idle)
+            Wait(idle)
         end
     end)
 end
 
 
+RegisterNetEvent('np:voice:state')
 AddEventHandler('np:voice:state', function(state)
     VoiceEnabled = state
 
@@ -104,7 +68,7 @@ AddEventHandler('np:voice:state', function(state)
         _myServerId = GetPlayerServerId(PlayerId())
         while MumbleGetVoiceChannelFromServerId(_myServerId) == 0 do
             NetworkSetVoiceChannel(CurrentVoiceChannel)
-            Citizen.Wait(100)
+            Wait(100)
         end
 
         SetVoiceProximity(2)
@@ -384,7 +348,7 @@ AddEventHandler("np:voice:transmission:state", function(serverID, context, trans
 
     if not transmitting then
         MumbleSetVolumeOverrideByServerId(serverID, data.volume)
-        Citizen.Wait(0)
+        Wait(0)
     end
 
     if context == "radio" and IsRadioOn then
@@ -392,7 +356,7 @@ AddEventHandler("np:voice:transmission:state", function(serverID, context, trans
     end
 
     if transmitting then
-        Citizen.Wait(0)
+        Wait(0)
         MumbleSetVolumeOverrideByServerId(serverID, data.volume)
     end
 
@@ -409,7 +373,7 @@ AddEventHandler('np:voice:targets:player:add', AddPlayerToTargetList)
 RegisterNetEvent('np:voice:targets:player:remove')
 AddEventHandler('np:voice:targets:player:remove', RemovePlayerFromTargetList)
 
-Citizen.CreateThread(function()
+CreateThread(function()
     RegisterKeyMapping('+cycleProximity', "Cycle Proximity Range", 'keyboard', Config.cycleProximityHotkey)
     RegisterCommand('+cycleProximity', CycleVoiceProximity, false)
     RegisterCommand('-cycleProximity', function() end, false)
@@ -440,9 +404,17 @@ Citizen.CreateThread(function()
         LoadPhoneModule()
     end
 
+    if Config.enableCar then
+        LoadCarModule()
+    end
+
     SetVoiceProximity(2)
 
     TriggerEvent("np:voice:ready")
+
+    _myServerId = GetPlayerServerId(PlayerId())
+    voiceCheck()
+    voiceThread()
 
     SetSettings(exports["np-base"]:getModule("SettingsData"):getSettingsTable())
 end)

--- a/Example_Frameworks/NoPixelServer/np-voice/client/modules/cl_car.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/client/modules/cl_car.lua
@@ -18,10 +18,10 @@ function LoadCarModule()
     AddEventHandler('baseevents:leftVehicle',function(leftVehicle, netId)
 
         --if _inVeh then
-            Citizen.Wait(1100)
+            Wait(1100)
             local count = 0
             while not targetSet and count < 50 do
-                Citizen.Wait(100)
+                Wait(100)
                 count = count + 1
             end
 
@@ -101,7 +101,7 @@ function startVehThread()
             end
         end
         targetSet = true
-        Citizen.Wait(500)
+        Wait(500)
     end
 end
 

--- a/Example_Frameworks/NoPixelServer/np-voice/client/modules/cl_radio.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/client/modules/cl_radio.lua
@@ -187,7 +187,7 @@ function CycleRadioChannels()
 end
 
 function StartRadioTask()
-    Citizen.CreateThread(function()
+    CreateThread(function()
         local lib = "random@arrests"
         local anim = "generic_radio_chatter"
 
@@ -200,7 +200,7 @@ function StartRadioTask()
 
             SetControlNormal(0, 249, 1.0)
 
-            Citizen.Wait(0)
+            Wait(0)
         end
 
         StopAnimTask(Player, lib, anim, 3.0)

--- a/Example_Frameworks/NoPixelServer/np-voice/client/modules/filter.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/client/modules/filter.lua
@@ -108,21 +108,21 @@ function CreateFilterChain(serverID, data)
         Wait(200)
         if node then
             if index == 1 then
-                Citizen.Wait(0)
+                Wait(0)
                 AudiocontextDisconnect(audio.context, audio.destination, audio.source, 0, 0)
-                Citizen.Wait(0)
+                Wait(0)
                 AudiocontextConnect(audio.context, node, audio.source, 0, 0)
-                Citizen.Wait(0)
+                Wait(0)
                 AudiocontextConnect(audio.context, audio.destination, node, 0, 0)
-                Citizen.Wait(0)
+                Wait(0)
             else
-                Citizen.Wait(0)
+                Wait(0)
                 AudiocontextDisconnect(audio.context, audio.destination, audio.node, 0, 0)
-                Citizen.Wait(0)
+                Wait(0)
                 AudiocontextConnect(audio.context, node, audio.node, 0, 0)
-                Citizen.Wait(0)
+                Wait(0)
                 AudiocontextConnect(audio.context, audio.destination, node, 0, 0)
-                Citizen.Wait(0)
+                Wait(0)
             end
 
             audio.node = node
@@ -160,9 +160,9 @@ function DeleteFilterChain(serverID)
         Debug("[Filter] Chain Deleted | Player: %s ", serverID)
         if audio.active then
             AudiocontextDisconnect(audio.context, audio.destination, audio.node, 0, 0)
-            Citizen.Wait(0)
+            Wait(0)
             AudiocontextConnect(audio.context, audio.destination, audio.source, 0, 0)
-            Citizen.Wait(100)
+            Wait(100)
         end
 
         for _, filter in pairs(audio.filters) do
@@ -178,7 +178,7 @@ end
 function ConnectFilterChain(audio)
     AudiocontextDisconnect(audio.context, audio.destination, audio.source, 0, 0)
 
-    Citizen.Wait(50) -- 100
+    Wait(50) -- 100
 
     for index, filter in ipairs(audio.filters) do
         if index == 1 then
@@ -187,12 +187,12 @@ function ConnectFilterChain(audio)
             AudiocontextConnect(audio.context, filter.node, audio.filters[index - 1]["node"], 0, 0)
         end
 
-        Citizen.Wait(50) --200
+        Wait(50) --200
     end
 
     AudiocontextConnect(audio.context, audio.destination, audio.filters[#audio.filters]["node"], 0, 0)
 
-    Citizen.Wait(50) --100
+    Wait(50) --100
     
     audio.active = true
 end
@@ -202,7 +202,7 @@ function DisconnectFilterChain(audio)
 
     if node then
       AudiocontextDisconnect(audio.context, audio.destination, node, 0, 0)
-      Citizen.Wait(100)
+      Wait(100)
       AudiocontextConnect(audio.context, audio.destination, audio.source, 0, 0)
     end
 

--- a/Example_Frameworks/NoPixelServer/np-voice/client/modules/grid.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/client/modules/grid.lua
@@ -80,7 +80,7 @@ function LoadGridModule()
     RegisterModuleContext("grid", 0)
     UpdateContextVolume("grid", -1.0)
 
-    Citizen.CreateThread(function()
+    CreateThread(function()
         while true do
             local idle = 250 --100
 
@@ -96,7 +96,7 @@ function LoadGridModule()
 
             PreviousGrid = currentGrid
     
-            Citizen.Wait(idle)
+            Wait(idle)
         end
     end)
 
@@ -118,7 +118,7 @@ end
 -- end
 
 -- function nearbyGridsThread()
---     Citizen.CreateThread(function()
+--     CreateThread(function()
 --         while true do
 --             MumbleClearVoiceTarget(CurrentTarget)
 --                 for _, channel in pairs(edgeGrids) do
@@ -127,7 +127,7 @@ end
 --                 end
 --             MumbleSetVoiceTarget(CurrentTarget)
     
---             Citizen.Wait(200)
+--             Wait(200)
 --         end
 --     end)
 -- end

--- a/Example_Frameworks/NoPixelServer/np-voice/client/tools/lib.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/client/tools/lib.lua
@@ -20,7 +20,7 @@ function Throttled(name, time)
     if not Throttles[name] then
         if time then
             Throttles[name] = true
-            Citizen.SetTimeout(time, function() Throttles[name] = false end)
+            SetTimeout(time, function() Throttles[name] = false end)
         end
 
         return false
@@ -46,7 +46,7 @@ function LoadAnimDict(dict)
         RequestAnimDict(dict)
 
         while not HasAnimDictLoaded(dict) do
-            Citizen.Wait(0)
+            Wait(0)
         end
     end
 end
@@ -104,7 +104,7 @@ end
 function TimeOut(time)
     local p = promise:new()
 
-    Citizen.SetTimeout(time, function ()
+    SetTimeout(time, function ()
         p:resolve(true)
     end)
 

--- a/Example_Frameworks/NoPixelServer/np-voice/config.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/config.lua
@@ -1,6 +1,6 @@
 Config = {}
 
-Config.version = "1.1.0"
+Config.version = "1.2.0"
 
 ------- Modules -------
 Config.enableDebug = true

--- a/Example_Frameworks/NoPixelServer/np-voice/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/fxmanifest.lua
@@ -1,22 +1,19 @@
-fx_version "bodacious"
-
-games { "gta5" }
+fx_version 'cerulean'
+game 'gta5'
+lua54 'yes'
 
 server_scripts {
-    "config.lua",
-    -- "rtc/server/*.lua",
-    -- "rtc/cfg/*.lua",
-    "server/modules/*.lua",
-    "server/*.lua"
+    'config.lua',
+    'server/modules/*.lua',
+    'server/*.lua'
 }
 
 client_scripts {
-    "config.lua",
-    -- "rtc/client/*.lua",
-    "client/tools/*.lua",
-    "client/classes/*.lua",
-    "client/modules/*.lua",
-    "client/client.lua",
+    'config.lua',
+    'client/tools/*.lua',
+    'client/classes/*.lua',
+    'client/modules/*.lua',
+    'client/client.lua'
 }
 
 -- ui_page "nui/ui.html"

--- a/Example_Frameworks/NoPixelServer/np-voice/server/modules/sv_phone.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/server/modules/sv_phone.lua
@@ -1,13 +1,13 @@
 local activeCallsByNumber = {}
 local activeCallsBySource = {}
 
-RegisterServerEvent("np:voice:server:phone:startCall")
+RegisterNetEvent("np:voice:server:phone:startCall")
 AddEventHandler("np:voice:server:phone:startCall", function(phoneNumber, receiverID)
     local src = source
     startCall(phoneNumber, src, receiverID)
 end)
 
-RegisterServerEvent("np:voice:server:phone:endCall")
+RegisterNetEvent("np:voice:server:phone:endCall")
 AddEventHandler("np:voice:server:phone:endCall", function(phoneNumber)
     endCall(phoneNumber)
 end)
@@ -27,8 +27,8 @@ function startCall(phoneNumber, callerID, receiverID)
     if activeCallsByNumber[phoneNumber] then
         --busy
     else
-        activeCallsByNumber[phoneNumber] = {caller = callerID, receiver = receiverID}
-        activeCallsBySource[src] = phoneNumber
+        activeCallsByNumber[phoneNumber] = { caller = callerID, receiver = receiverID }
+        activeCallsBySource[callerID] = phoneNumber
         activeCallsBySource[receiverID] = phoneNumber
         TriggerClientEvent('np:voice:phone:call:start', callerID, phoneNumber, receiverID)
         TriggerClientEvent('np:voice:phone:call:start', receiverID, phoneNumber, callerID)
@@ -46,3 +46,4 @@ function endCall(phoneNumber)
     end
 
 end
+

--- a/Example_Frameworks/NoPixelServer/np-voice/server/modules/sv_radio.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/server/modules/sv_radio.lua
@@ -77,3 +77,4 @@ end,true)
 RegisterCommand('channelSubscribers', function(src, args, raw)
     print(DumpTable(channelSubscribers))
 end,true)
+

--- a/Example_Frameworks/NoPixelServer/np-voice/server/sv_main.lua
+++ b/Example_Frameworks/NoPixelServer/np-voice/server/sv_main.lua
@@ -97,7 +97,6 @@ function DumpTable(table, nb)
 
 		return s .. '}'
 	else
-		return tostring(table)
-	end
+        return tostring(table)
+    end
 end
--- koil sucks


### PR DESCRIPTION
## Summary
- modernize voice client by centralizing initialization and supporting modern FiveM APIs
- fix phone call tracking bug and register server events securely
- upgrade fxmanifest to cerulean and Lua 5.4

## Testing
- `find np-voice -name '*.lua' ! -path 'np-voice/client/tools/natives.lua' -print0 | xargs -0 -n1 luac -p`


------
https://chatgpt.com/codex/tasks/task_e_68c1e17338c4832d9d3ddb6615c58b7c