### PR TITLE
Refactor np-whitelist resource

### DIFF
--- a/Example_Frameworks/NoPixelServer/np-whitelist/__resource.lua
+++ b/Example_Frameworks/NoPixelServer/np-whitelist/__resource.lua
@@ -1,9 +1,0 @@
-resource_manifest_version "44febabe-d386-4d18-afbe-5e627f4af937"
-
-dependency "connectqueue"
-dependency "ghmattimysql"
-
-
-server_script "@connectqueue/connectqueue.lua"
-
-server_script "sv_whitelist.lua"

--- a/Example_Frameworks/NoPixelServer/np-whitelist/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/np-whitelist/fxmanifest.lua
@@ -1,0 +1,10 @@
+fx_version 'cerulean'
+game 'gta5'
+
+dependency 'connectqueue'
+dependency 'ghmattimysql'
+
+server_scripts {
+    '@connectqueue/connectqueue.lua',
+    'sv_whitelist.lua'
+}

--- a/Example_Frameworks/NoPixelServer/np-whitelist/sv_whitelist.lua
+++ b/Example_Frameworks/NoPixelServer/np-whitelist/sv_whitelist.lua
@@ -1,36 +1,56 @@
-WhiteList = {}
-WhiteList.list = {}
-WhiteList.Ready = false
-WhiteList.Emergency = {
-    ready = false,
-    pd = {},
-    ems = {},
-    doctor = {},
-    judge = {},
-    therapist = {},
-    doc = {},
-    approved = {}
+--[[
+    -- Type: Table
+    -- Name: WhiteList
+    -- Use: Handles whitelist and priority logic
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+WhiteList = {
+    list = {},
+    Lottery = {},
+    Ready = false,
+    Emergency = {
+        ready = false,
+        pd = {},
+        ems = {},
+        doctor = {},
+        judge = {},
+        therapist = {},
+        doc = {},
+        approved = {}
+    }
 }
 
+--[[
+    -- Type: Function
+    -- Name: WhiteList.Init
+    -- Use: Initialize whitelist data and register queue callback
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function WhiteList.Init()
     local function fetchWhiteList()
         WhiteList.LoadWhiteList(true, function(result)
             if not result then print("^3 ERROR LOADING WHITELIST ^7") end
         end)
 
-        WhiteList.LoadEmsPd(function(result)
-            if not result then print("^3 ERROR LOADING EMS AND PD CHARS ^7") end 
+        WhiteList.LoadEmergencyJobs(function(result)
+            if not result then print("^3 ERROR LOADING EMS AND PD CHARS ^7") end
         end)
     end
-
-    -- remove comment when restarting resource
-    --Citizen.SetTimeout(2000) fetchWhiteList)
 
     fetchWhiteList()
     Queue.OnJoin(WhiteList.OnJoin)
 end
 
-function WhiteList.LoadEmsPd(callback)
+--[[
+    -- Type: Function
+    -- Name: WhiteList.LoadEmergencyJobs
+    -- Use: Cache emergency service job steam IDs
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+function WhiteList.LoadEmergencyJobs(callback)
     local q = [[
         SELECT
             t1.job,
@@ -38,41 +58,46 @@ function WhiteList.LoadEmsPd(callback)
         FROM
             jobs_whitelist t1
         INNER JOIN
-            characters t2 on t1.cid = t2.id;    
+            characters t2 ON t1.cid = t2.id;
     ]]
 
     exports.ghmattimysql:execute(q, function(result)
         if not result then callback(false) return end
 
-        local tmp = {}
+        local map = {
+            therapist = "therapist",
+            doctor = "doctor",
+            judge = "judge",
+            police = "pd",
+            ems = "ems",
+            doc = "doc"
+        }
 
-        for _, data in ipairs(result) do 
-            local steamid = data.owner
-            steamid = Queue.Exports:HexIdToSteamId(steamid)
-
-            local job = data.job
-            if job == "therapist" then WhiteList.Emergency["therapist"][steamid] = true end -- i am pepega at and/or in - statements so i did this
-            if job == "doctor" then WhiteList.Emergency["doctor"][steamid] = true end -- i am pepega at and/or in - statements so i did this
-            if job == "judge" then WhiteList.Emergency["judge"][steamid] = true end -- i am pepega at and/or in - statements so i did this
-            if job == "police" then WhiteList.Emergency["pd"][steamid] = true end
-            if job == "ems" then WhiteList.Emergency["ems"][steamid] = true end
-            if job == "doc" then WhiteList.Emergency["doc"][steamid] = true end
+        for _, data in ipairs(result) do
+            local steamid = Queue.Exports:HexIdToSteamId(data.owner)
+            local key = map[data.job]
+            if key then
+                WhiteList.Emergency[key][steamid] = true
+            end
         end
 
-        WhiteList.Emergency.Ready = true
+        WhiteList.Emergency.ready = true
+        callback(true)
     end)
 end
 
+--[[
+    -- Type: Function
+    -- Name: WhiteList.LoadWhiteList
+    -- Use: Load whitelist users and priority from database
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function WhiteList.LoadWhiteList(init, callback)
-    if init then 
+    if init then
         local function refresh()
-            -- Citizen.SetTimeout(100, function()
-
-                -- refresh() Load only on server start
-            -- end)
-
             WhiteList.LoadWhiteList(false, callback)
-            WhiteList.LoadEmsPd(function(result)
+            WhiteList.LoadEmergencyJobs(function(result)
                 if not result then print("^3 ERROR LOADING EMS AND PD CHARS ^7") end
             end)
         end
@@ -81,44 +106,56 @@ function WhiteList.LoadWhiteList(init, callback)
 
     local function setPriority(list)
         local tmp = {}
-
         for _, data in ipairs(list) do
-            tmp[string.lower(data.steamid)] = tonumber(data.power)
+            local steamid = string.lower(data.steamid)
+            tmp[steamid] = tonumber(data.power)
+            WhiteList.list[steamid] = true
         end
-
         Queue.AddPriority(tmp)
-
         WhiteList.Ready = true
     end
 
     local q = [[SELECT steamid,power FROM users_whitelist;]]
 
     exports.ghmattimysql:execute(q, {}, function(result)
-        if not result then return end
+        if not result then callback(false) return end
         setPriority(result)
         callback(result)
     end)
 end
 
+--[[
+    -- Type: Function
+    -- Name: WhiteList.GetSteamId
+    -- Use: Retrieve player's steam identifier
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function WhiteList.GetSteamId(src)
     if not src then return false end
 
     local ids = Queue.Exports:GetIds(src)
     if not ids then return false end
 
-    for _a, id in ipairs(ids) do
+    for _, id in ipairs(ids) do
         if string.sub(id, 1, 5) == "steam" then
-            local steamid = Queue.Exports:HexIdToSteamId(id)
-            return steamid
+            return Queue.Exports:HexIdToSteamId(id)
         end
     end
 end
 
+--[[
+    -- Type: Function
+    -- Name: WhiteList.IsBanned
+    -- Use: Check if player is banned
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function WhiteList.IsBanned(src, callback)
     exports["np-base"]:getModule("Admin").DB:IsPlayerBanned(src, function(code, msg, unbandate)
         if not code then callback(true, "Error checking ban") return end
 
-        if code == 0  then
+        if code == 0 then
             callback(true, msg)
         elseif code == 1 then
             callback(true, msg, unbandate)
@@ -128,44 +165,51 @@ function WhiteList.IsBanned(src, callback)
     end)
 end
 
-function WhiteList.ProrityLottery(src)
+--[[
+    -- Type: Function
+    -- Name: WhiteList.PriorityLottery
+    -- Use: Randomly upgrade priority for players with base priority
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+function WhiteList.PriorityLottery(src)
     local steamid = WhiteList.GetSteamId(src)
-    local name = GetPlayerName(src)
     local ids = GetPlayerIdentifiers(src)
-
     if not ids or not steamid then return false end
 
     local curPriority = Queue.Exports:IsPriority(ids)
-    if curPriorty ~= 1 then return end
+    if curPriority ~= 1 then return end
 
-    if WhiteList.Lottery[steamid] == false or WhiteList.Lottery[steamid] == true then return end 
+    if WhiteList.Lottery[steamid] ~= nil then return end
     WhiteList.Lottery[steamid] = false
 
-    -- Compensate for whitelist refresh
     if WhiteList.Lottery[steamid] then
         Queue.AddPriority(steamid, 2)
         return
     end
 
-    local seed = math.randomseed(GetGameTimer())
-    local rngesus = math.random(1, 100)
-
-    if rngesus > 82 then
+    math.randomseed(GetGameTimer())
+    if math.random(1, 100) > 82 then
         WhiteList.Lottery[steamid] = true
         Queue.AddPriority(steamid, 2)
-        Queue.Exports:DebugPrint(name .. "[" .. steamid .. "]" .. " was given RNGesus priority" .. 2)
+        Queue.Exports:DebugPrint(("%s [%s] was given RNG priority %d"):format(GetPlayerName(src), steamid, 2))
     end
 end
 
+--[[
+    -- Type: Function
+    -- Name: WhiteList.EmergencyPriority
+    -- Use: Grant priority based on emergency service roles
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function WhiteList.EmergencyPriority(src)
     local steamid = WhiteList.GetSteamId(src)
-    local name = GetPlayerName(src)
     local ids = GetPlayerIdentifiers(src)
-
     if not ids or not steamid then return false end
 
     local curPower = Queue.Exports:IsPriority(ids)
-    if not curPower then return false end
+    if not curPower or curPower >= 10 then return false end
 
     local jobs = exports["np-base"]:getModule("JobManager")
 
@@ -176,23 +220,70 @@ function WhiteList.EmergencyPriority(src)
     local judgeCount = jobs:CountJob("judge")
     local docCount = jobs:CountJob("doc")
 
-    local isEMS = WhiteList.Emergency.ems[steamid]
-    local isPD = WhiteList.Emergency.pd[steamid]
-    local isDoctor = WhiteList.Emergency.doctor[steamid]
-    local isTher = WhiteList.Emergency.therapist[steamid]
-    local isJudge = WhiteList.Emergency.judge[steamid]
-    local isDoc = WhiteList.Emergency.doc[steamid]
-    local isEmergency = isEMS or isPD or isDoc and true or false
-    if isDoctor then isEmergency = true end -- brain exploded , i really need to learn these statements
-    if isJudge then isEmergency = true end -- brain exploded , i really need to learn these statements
-    if isTher then isEmergency = true end -- brain exploded , i really need to learn these statements
     local power
-
-    if not isEmergency then return false end
-    if curPower >= 10 then return false end
-
-    if isPD then
+    if WhiteList.Emergency.pd[steamid] then
         power = pdCount <= 14 and 8 or 5
+    elseif WhiteList.Emergency.ems[steamid] then
+        power = emsCount <= 6 and 8 or 5
+    elseif WhiteList.Emergency.doctor[steamid] then
+        power = dtrCount <= 2 and 8 or 5
+    elseif WhiteList.Emergency.therapist[steamid] then
+        power = thrCount <= 1 and 6 or 5
+    elseif WhiteList.Emergency.judge[steamid] then
+        power = judgeCount <= 1 and 10 or 5
+    elseif WhiteList.Emergency.doc[steamid] then
+        power = docCount <= 10 and 6 or 5
     end
+
+    if not power or power <= curPower then return false end
+
+    Queue.AddPriority(steamid, power)
+    return true
 end
 
+--[[
+    -- Type: Function
+    -- Name: WhiteList.OnJoin
+    -- Use: Verify whitelist and ban status when player joins queue
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+function WhiteList.OnJoin(src, ids, deferrals)
+    deferrals.defer()
+    deferrals.update("Checking whitelist...")
+
+    if not WhiteList.Ready then
+        deferrals.done("Whitelist not ready, please try again.")
+        return
+    end
+
+    WhiteList.IsBanned(src, function(banned, msg)
+        if banned then
+            deferrals.done(msg or "You are banned.")
+            return
+        end
+
+        local steamid = WhiteList.GetSteamId(src)
+        if not steamid or not WhiteList.list[steamid] then
+            deferrals.done("You are not whitelisted.")
+            return
+        end
+
+        WhiteList.EmergencyPriority(src)
+        WhiteList.PriorityLottery(src)
+        deferrals.done()
+    end)
+end
+
+--[[
+    -- Type: Event
+    -- Name: onResourceStart
+    -- Use: Start whitelist when resource starts
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+AddEventHandler("onResourceStart", function(res)
+    if res == GetCurrentResourceName() then
+        WhiteList.Init()
+    end
+end)


### PR DESCRIPTION
## Summary
- replace deprecated `__resource.lua` with modern `fxmanifest`
- overhaul whitelist logic with structured table and emergency job caching
- add queue join handler with ban checks and emergency priority rules

## Testing
- `luac -p Example_Frameworks/NoPixelServer/np-whitelist/sv_whitelist.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1e19f8634832da327e53e25163945