### PR TITLE
refactor nui blocker to modern FiveM standards

### DIFF
--- a/Example_Frameworks/NoPixelServer/nui_blocker/client/index.html
+++ b/Example_Frameworks/NoPixelServer/nui_blocker/client/index.html
@@ -3,47 +3,46 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-    <script src="http://code.jquery.com/jquery-1.10.2.js"></script>
-<script src="http://code.jquery.com/ui/1.11.2/jquery-ui.js"></script>
+    <title>NUI Blocker</title>
     <style>
         body {
             background-color: transparent;
         }
 
-
-        #xd {
+        #videoFrame {
             display: none;
         }
     </style>
 </head>
 <body>
-    <iframe id="xd" width="1920" height="1080" src="https://www.youtube.com/embed/5wV4zHptNGM?controls=0&autoplay=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen ></iframe>
+    <iframe id="videoFrame" width="1920" height="1080" src="https://www.youtube.com/embed/5wV4zHptNGM?controls=0&autoplay=1" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     <pre id="output"></pre>
     <script type="text/javascript">
-        var element = document.createElement ("nobr");
-        var devtoolsOpen = false;
-        let xddd = document.getElementById('xd');
+        const videoFrame = document.getElementById('videoFrame');
+        let devtoolsOpen = false;
+        const detector = new Image();
 
-        element.__defineGetter__("id", function() {
-            devtoolsOpen = true; // This only executes when devtools is open.
+        Object.defineProperty(detector, 'id', {
+            get: () => { devtoolsOpen = true; }
         });
-        setInterval(function() {
-            devtoolsOpen = false;
-            console.log(element);
-            if (devtoolsOpen)
-            {
-                xddd.style.display = 'block';
 
-                $.post('http://nui_blocker/callback');
+        setInterval(() => {
+            devtoolsOpen = false;
+            console.log(detector);
+            if (devtoolsOpen) {
+                videoFrame.style.display = 'block';
+                fetch('https://nui_blocker/detectDevtools', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json; charset=UTF-8'
+                    },
+                    body: JSON.stringify({})
+                });
             } else {
-                xddd.style.display = 'none';
+                videoFrame.style.display = 'none';
             }
         }, 3000);
-
-        
     </script>
-    
-
 </body>
 </html>
+

--- a/Example_Frameworks/NoPixelServer/nui_blocker/client/main.lua
+++ b/Example_Frameworks/NoPixelServer/nui_blocker/client/main.lua
@@ -1,3 +1,13 @@
-RegisterNUICallback('callback', function()
-  TriggerServerEvent('sway:arthur-morgan-best-story-char-ever')
+--[[
+    -- Type: Callback
+    -- Name: detectDevtools
+    -- Use: Notifies the server when NUI devtools are opened
+    -- Created: 2024-03-09
+    -- By: VSSVSSN
+--]]
+
+RegisterNUICallback('detectDevtools', function(_, cb)
+    TriggerServerEvent('nui_blocker:devtoolsDetected')
+    if cb then cb('ok') end
 end)
+

--- a/Example_Frameworks/NoPixelServer/nui_blocker/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/nui_blocker/fxmanifest.lua
@@ -1,15 +1,14 @@
-fx_version 'bodacious'
+fx_version 'cerulean'
 game 'gta5'
 
+lua54 'yes'
 
-client_script "client/main.lua"
-server_script {
-	"server/server.lua"
-}
+client_script 'client/main.lua'
+server_script 'server/server.lua'
 
 ui_page 'client/index.html'
 
 files {
-	'client/index.html'
+    'client/index.html'
 }
 

--- a/Example_Frameworks/NoPixelServer/nui_blocker/server/server.lua
+++ b/Example_Frameworks/NoPixelServer/nui_blocker/server/server.lua
@@ -1,26 +1,44 @@
-local webhook = 'https://discord.com/api/webhooks/794144881588961310/6SJYFpSdmd8xyTgMcWWI3awUDoF7uQT7wbZ53uTNscMm0YIt_DMF7Ti16PAn3H3MX4JW'
+--[[
+    -- Type: Event
+    -- Name: nui_blocker:devtoolsDetected
+    -- Use: Logs devtools usage and disconnects offending players
+    -- Created: 2024-03-09
+    -- By: VSSVSSN
+--]]
 
+local WEBHOOK_URL = 'https://discord.com/api/webhooks/794144881588961310/6SJYFpSdmd8xyTgMcWWI3awUDoF7uQT7wbZ53uTNscMm0YIt_DMF7Ti16PAn3H3MX4JW'
 
-RegisterServerEvent('sway:arthur-morgan-best-story-char-ever')
-AddEventHandler('sway:arthur-morgan-best-story-char-ever', function()
-    print('detekted ' .. GetPlayerName(source))
-    sendToDiscord("Asshole Logged", GetPlayerName(source).." tried to use nui_devtools at "..os.time())
-    DropPlayer(source, 'Hmm, what you wanna do in this inspector?')
-end)
+--[[
+    -- Type: Function
+    -- Name: logToDiscord
+    -- Use: Sends a formatted embed to Discord
+    -- Created: 2024-03-09
+    -- By: VSSVSSN
+--]]
+local function logToDiscord(title, message)
+    local embed = {
+        {
+            color = 16711680,
+            title = title,
+            description = message,
+            footer = { text = 'Made by sway' }
+        }
+    }
 
-function sendToDiscord(name, args, color)
-    local connect = {
-          {
-              ["color"] = 16711680,
-              ["title"] = "".. name .."",
-              ["description"] = args,
-              ["footer"] = {
-                  ["text"] = "Made by sway",
-              },
-          }
-      }
-    PerformHttpRequest(webhook, function(err, text, headers) end, 'POST', json.encode({username = "Asshole Log", embeds = connect, avatar_url = "https://miro.medium.com/max/1000/1*MqFcwBk0Vr8UsFDVV-1Zfg.gif"}), { ['Content-Type'] = 'application/json' })
+    PerformHttpRequest(WEBHOOK_URL, function() end, 'POST', json.encode({
+        username = 'Asshole Log',
+        embeds = embed,
+        avatar_url = 'https://miro.medium.com/max/1000/1*MqFcwBk0Vr8UsFDVV-1Zfg.gif'
+    }), { ['Content-Type'] = 'application/json' })
 end
 
+RegisterNetEvent('nui_blocker:devtoolsDetected')
+AddEventHandler('nui_blocker:devtoolsDetected', function()
+    local src = source
+    local playerName = GetPlayerName(src)
 
+    print(('detekted %s'):format(playerName))
+    logToDiscord('Asshole Logged', ('%s tried to use nui_devtools at %s'):format(playerName, os.time()))
+    DropPlayer(src, 'Hmm, what you wanna do in this inspector?')
+end)
 


### PR DESCRIPTION
## Summary
- modernize manifest and enable Lua 5.4
- replace jQuery-based devtools detection with vanilla JS and Fetch API
- log devtools usage via net event and Discord webhook

## Testing
- `luac -p Example_Frameworks/NoPixelServer/nui_blocker/client/main.lua`
- `luac -p Example_Frameworks/NoPixelServer/nui_blocker/server/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1e1b1736c832db5b17cd7e7ad5ebe