### PR TITLE
refactor: modernize raid_clothes resource

### DIFF
--- a/Example_Frameworks/NoPixelServer/raid_clothes/client/cl_backup.lua
+++ b/Example_Frameworks/NoPixelServer/raid_clothes/client/cl_backup.lua
@@ -13,6 +13,7 @@ function GetCurrentPedFace()
 end
 
 function LoadPlayerFace(data)
+    local player = PlayerPedId()
     if data.headBlend then
         SetPlayerHeadBlend(data.headBlend)
     end
@@ -26,13 +27,14 @@ function LoadPlayerFace(data)
     end
 
     if data.hairColor then
-        SetPedHairColor(player,table.unpack(data.hairColor))
+        SetPedHairColor(player, table.unpack(data.hairColor))
     end
 
     RefreshUI()
 end
 
 function SetPlayerHeadBlend(data)
+    local player = PlayerPedId()
     SetPedHeadBlendData(player,
             tonumber(data['shapeFirst']),
             tonumber(data['shapeSecond']),
@@ -47,6 +49,7 @@ function SetPlayerHeadBlend(data)
 end
 
 function SetPlayerHeadStructure(data)
+    local player = PlayerPedId()
     for i = 1, #face_features do
         SetPedFaceFeature(player, i - 1, data[i])
     end
@@ -63,9 +66,7 @@ RegisterNUICallback('getPlayerFace', function(data, cb)
 end)
 
 RegisterNUICallback('setPlayerFace', function(data, cb)
-    player = GetPlayerPed(-1)
     LoadPlayerFace(data.face)
-
     cb('ok')
 end)
 

--- a/Example_Frameworks/NoPixelServer/raid_clothes/client/client.lua
+++ b/Example_Frameworks/NoPixelServer/raid_clothes/client/client.lua
@@ -377,7 +377,7 @@ end)
 
 
 function GetCurrentPed()
-    player = GetPlayerPed(-1)
+    player = PlayerPedId()
     return {
         model = GetEntityModel(PlayerPedId()),
         hairColor = GetPedHair(),
@@ -416,7 +416,7 @@ function SetSkin(model, setDefault)
         end
         SetPlayerModel(PlayerId(), model)
         SetModelAsNoLongerNeeded(model)
-        player = GetPlayerPed(-1)
+        player = PlayerPedId()
         FreezePedCameraRotation(player, true)
         SetPedDefaultComponentVariation(player)
         if setDefault and model ~= nil and not isCustomSkin(model) and (model == `mp_f_freemode_01` or model == `mp_m_freemode_01`) then
@@ -829,7 +829,7 @@ end)
 -- Main menu
 
 function OpenMenu(name)
-    player = GetPlayerPed(-1)
+    player = PlayerPedId()
     oldPed = GetCurrentPed()
     local isAllowed = false
     if(oldPed.model == 1885233650 or oldPed.model == -1667301416) then isAllowed = true end
@@ -870,7 +870,7 @@ end
 
 function IsNearShop(shops)
     local dstchecked = 1000
-    local plyPos = GetEntityCoords(GetPlayerPed(PlayerId()), false)
+    local plyPos = GetEntityCoords(PlayerPedId(), false)
 	for i = 1, #shops do
 		shop = shops[i]
 		local comparedst = Vdist(plyPos.x, plyPos.y, plyPos.z,shop[1], shop[2], shop[3])
@@ -923,7 +923,7 @@ Citizen.CreateThread(function()
         local nearheal = IsNearShop(healingShops)
         local neartat = IsNearShop(tattoosShops)
         local nearbarber = IsNearShop(barberShops)
-        local jailcheck = GetInteriorFromEntity(GetPlayerPed(PlayerId()))
+        local jailcheck = GetInteriorFromEntity(PlayerPedId())
 
         local StoreCost = 400;
 
@@ -1020,7 +1020,7 @@ end)
 
 RegisterNetEvent("raid_clothes:setclothes")
 AddEventHandler("raid_clothes:setclothes", function(data,alreadyExist)
-    player = GetPlayerPed(-1)
+    player = PlayerPedId()
     local function setDefault()
         Citizen.CreateThread(function()
             firstChar = true
@@ -1112,7 +1112,7 @@ end)
 
 RegisterNetEvent("raid_clothes:setpedfeatures")
 AddEventHandler("raid_clothes:setpedfeatures", function(data)
-    player = GetPlayerPed(-1)
+    player = PlayerPedId()
     if data == false then
         SetSkin(GetEntityModel(PlayerPedId()), true)
         return

--- a/Example_Frameworks/NoPixelServer/raid_clothes/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/raid_clothes/fxmanifest.lua
@@ -1,17 +1,27 @@
-resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
+fx_version 'cerulean'
+game 'gta5'
+lua54 'yes'
 
-server_script('server.lua')
-client_script('client/cl_backup.lua')
-client_script('client/clothingshop.lua')
-client_script('client/tattooshop.lua')
-client_script('client/healingspots.lua')
-client_script('client/barbershop.lua')
-client_script('client/skins.lua')
-client_script('client/client.lua')
+author 'SunnyRP'
+description 'Updated clothing resource'
 
-ui_page('client/html/index.html')
+server_scripts {
+    'server.lua'
+}
 
-files({
+client_scripts {
+    'client/cl_backup.lua',
+    'client/clothingshop.lua',
+    'client/tattooshop.lua',
+    'client/healingspots.lua',
+    'client/barbershop.lua',
+    'client/skins.lua',
+    'client/client.lua'
+}
+
+ui_page 'client/html/index.html'
+
+files {
     'client/html/index.html',
     'client/html/script.js',
     'client/html/style.css',
@@ -31,4 +41,4 @@ files({
     'client/html/webfonts/fa-solid-900.woff',
     'client/html/webfonts/fa-solid-900.woff2',
     'client/html/css/all.min.css'
-})
+}

--- a/Example_Frameworks/NoPixelServer/raid_clothes/server.lua
+++ b/Example_Frameworks/NoPixelServer/raid_clothes/server.lua
@@ -1,18 +1,32 @@
+--[[
+    -- Type: Function
+    -- Name: checkExistenceClothes
+    -- Use: Verifies if a character has clothing data stored
+    -- Created: 2024-10-30
+    -- By: VSSVSSN
+--]]
 local function checkExistenceClothes(cid, cb)
-    exports.ghmattimysql:execute("SELECT cid FROM character_current WHERE cid = @cid LIMIT 1;", {["cid"] = cid}, function(result)
+    exports.ghmattimysql:execute("SELECT cid FROM character_current WHERE cid = @cid LIMIT 1;", { cid = cid }, function(result)
         local exists = result and result[1] and true or false
         cb(exists)
     end)
 end
 
+--[[
+    -- Type: Function
+    -- Name: checkExistenceFace
+    -- Use: Verifies if a character has facial data stored
+    -- Created: 2024-10-30
+    -- By: VSSVSSN
+--]]
 local function checkExistenceFace(cid, cb)
-    exports.ghmattimysql:execute("SELECT cid FROM character_face WHERE cid = @cid LIMIT 1;", {["cid"] = cid}, function(result)
+    exports.ghmattimysql:execute("SELECT cid FROM character_face WHERE cid = @cid LIMIT 1;", { cid = cid }, function(result)
         local exists = result and result[1] and true or false
         cb(exists)
     end)
 end
 
-RegisterServerEvent("raid_clothes:insert_character_current")
+RegisterNetEvent("raid_clothes:insert_character_current")
 AddEventHandler("raid_clothes:insert_character_current",function(data)
     if not data then return end
     local src = source
@@ -43,7 +57,7 @@ AddEventHandler("raid_clothes:insert_character_current",function(data)
     end)
 end)
 
-RegisterServerEvent("raid_clothes:insert_character_face")
+RegisterNetEvent("raid_clothes:insert_character_face")
 AddEventHandler("raid_clothes:insert_character_face",function(data)
     if not data then return end
     local src = source
@@ -81,7 +95,7 @@ AddEventHandler("raid_clothes:insert_character_face",function(data)
     end)
 end)
 
-RegisterServerEvent("raid_clothes:get_character_face")
+RegisterNetEvent("raid_clothes:get_character_face")
 AddEventHandler("raid_clothes:get_character_face",function(pSrc)
     local src = (not pSrc and source or pSrc)
     local user = exports["np-base"]:getModule("Player"):GetUser(src)
@@ -107,7 +121,7 @@ AddEventHandler("raid_clothes:get_character_face",function(pSrc)
 	end)
 end)
 
-RegisterServerEvent("raid_clothes:get_character_current")
+RegisterNetEvent("raid_clothes:get_character_current")
 AddEventHandler("raid_clothes:get_character_current",function(pSrc)
     local src = (not pSrc and source or pSrc)
     local user = exports["np-base"]:getModule("Player"):GetUser(src)
@@ -127,7 +141,7 @@ AddEventHandler("raid_clothes:get_character_current",function(pSrc)
 	end)
 end)
 
-RegisterServerEvent("raid_clothes:retrieve_tats")
+RegisterNetEvent("raid_clothes:retrieve_tats")
 AddEventHandler("raid_clothes:retrieve_tats", function(pSrc)
     local src = (not pSrc and source or pSrc)
 	local user = exports["np-base"]:getModule("Player"):GetUser(src)
@@ -143,7 +157,7 @@ AddEventHandler("raid_clothes:retrieve_tats", function(pSrc)
 	end)
 end)
 
-RegisterServerEvent("raid_clothes:set_tats")
+RegisterNetEvent("raid_clothes:set_tats")
 AddEventHandler("raid_clothes:set_tats", function(tattoosList)
 	local src = source
 	local user = exports["np-base"]:getModule("Player"):GetUser(src)
@@ -152,7 +166,7 @@ AddEventHandler("raid_clothes:set_tats", function(tattoosList)
 end)
 
 
-RegisterServerEvent("raid_clothes:get_outfit")
+RegisterNetEvent("raid_clothes:get_outfit")
 AddEventHandler("raid_clothes:get_outfit",function(slot)
     if not slot then return end
     local src = source
@@ -201,7 +215,7 @@ AddEventHandler("raid_clothes:get_outfit",function(slot)
 	end)
 end)
 
-RegisterServerEvent("raid_clothes:set_outfit")
+RegisterNetEvent("raid_clothes:set_outfit")
 AddEventHandler("raid_clothes:set_outfit",function(slot, name, data)
     if not slot then return end
     local src = source
@@ -254,37 +268,34 @@ AddEventHandler("raid_clothes:set_outfit",function(slot, name, data)
 end)
 
 
-RegisterServerEvent("raid_clothes:remove_outfit")
-AddEventHandler("raid_clothes:remove_outfit",function(slot)
-
+RegisterNetEvent("raid_clothes:remove_outfit")
+AddEventHandler("raid_clothes:remove_outfit", function(slot)
     local src = source
     local user = exports["np-base"]:getModule("Player"):GetUser(src)
     local cid = user:getCurrentCharacter().id
-    local slot = slot
+    local outfitSlot = tonumber(slot)
 
-    if not cid then return end
+    if not cid or not outfitSlot then return end
 
-    exports.ghmattimysql:execute( "DELETE FROM character_outfits WHERE cid = @cid AND slot = @slot", { ['cid'] = cid,  ["slot"] = slot } )
-    TriggerClientEvent("DoLongHudText", src,"Removed slot " .. slot .. ".",1)
+    exports.ghmattimysql:execute("DELETE FROM character_outfits WHERE cid = @cid AND slot = @slot", { cid = cid, slot = outfitSlot })
+    TriggerClientEvent("DoLongHudText", src, "Removed slot " .. outfitSlot .. ".",1)
 end)
 
-RegisterServerEvent("raid_clothes:list_outfits")
-AddEventHandler("raid_clothes:list_outfits",function()
+RegisterNetEvent("raid_clothes:list_outfits")
+AddEventHandler("raid_clothes:list_outfits", function()
     local src = source
     local user = exports["np-base"]:getModule("Player"):GetUser(src)
     local cid = user:getCurrentCharacter().id
-    local slot = slot
-    local name = name
 
     if not cid then return end
 
-    exports.ghmattimysql:execute("SELECT slot, name FROM character_outfits WHERE cid = @cid", {['cid'] = cid}, function(skincheck)
-    	TriggerClientEvent("hotel:listSKINSFORCYRTHESICKFUCK",src, skincheck)
-	end)
+    exports.ghmattimysql:execute("SELECT slot, name FROM character_outfits WHERE cid = @cid", { cid = cid }, function(skincheck)
+        TriggerClientEvent("hotel:listSKINSFORCYRTHESICKFUCK", src, skincheck)
+    end)
 end)
 
 
-RegisterServerEvent("clothing:checkIfNew")
+RegisterNetEvent("clothing:checkIfNew")
 AddEventHandler("clothing:checkIfNew", function()
     local src = source
     local user = exports["np-base"]:getModule("Player"):GetUser(src)
@@ -308,7 +319,7 @@ AddEventHandler("clothing:checkIfNew", function()
                 end)
                 return
             else
-                exports.ghmattimysql:execute("SELECT * FROM characters where id = @cid", {['@cid'] = cid}, function(data)
+                exports.ghmattimysql:execute("SELECT * FROM characters where id = @cid", { cid = cid }, function(data)
                     if data[1].jail_time >= 1 then
                         print('in jail')
                         TriggerClientEvent("hotel:createRoom", src, false, false)
@@ -324,7 +335,7 @@ AddEventHandler("clothing:checkIfNew", function()
     end)
 end)
 
-RegisterServerEvent("clothing:checkMoney")
+RegisterNetEvent("clothing:checkMoney")
 AddEventHandler("clothing:checkMoney", function(menu,askingPrice)
     local src = source
     local target = exports["np-base"]:getModule("Player"):GetUser(src)


### PR DESCRIPTION
## Summary
- migrate raid_clothes to modern fxmanifest with Lua 5.4 support
- refactor server events and queries, sanitize outfit removal
- replace deprecated GetPlayerPed calls and tighten face customization logic

## Testing
- `luacheck Example_Frameworks/NoPixelServer/raid_clothes/server.lua Example_Frameworks/NoPixelServer/raid_clothes/client/*.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package)*
- `luac -p Example_Frameworks/NoPixelServer/raid_clothes/server.lua Example_Frameworks/NoPixelServer/raid_clothes/client/client.lua Example_Frameworks/NoPixelServer/raid_clothes/client/cl_backup.lua` *(fails: unexpected symbol near '`')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e21ce8c4832dbb543504e016c997