### PR TITLE
refactor: modernize rconlog

### DIFF
--- a/Example_Frameworks/NoPixelServer/rconlog/fxmanifest.lua
+++ b/Example_Frameworks/NoPixelServer/rconlog/fxmanifest.lua
@@ -1,15 +1,14 @@
--- This resource is part of the default Cfx.re asset pack (cfx-server-data)
 -- Altering or recreating for local use only is strongly discouraged.
 
-version '1.0.0'
+fx_version 'cerulean'
+games { 'gta5', 'rdr3' }
+
 author 'Cfx.re <root@cfx.re>'
 description 'Handles old-style server player management commands.'
+version '1.0.0'
 repository 'https://github.com/citizenfx/cfx-server-data'
 
 client_script 'rconlog_client.lua'
 server_script 'rconlog_server.lua'
-
-fx_version 'adamant'
-games { 'gta5', 'rdr3' }
 
 rdr3_warning 'I acknowledge that this is a prerelease build of RedM, and I am aware my resources *will* become incompatible once RedM ships.'

--- a/Example_Frameworks/NoPixelServer/rconlog/rconlog_client.lua
+++ b/Example_Frameworks/NoPixelServer/rconlog/rconlog_client.lua
@@ -1,25 +1,35 @@
-RegisterNetEvent('rlUpdateNames')
-
-AddEventHandler('rlUpdateNames', function()
+--[[
+    -- Type: Event
+    -- Name: rlUpdateNames
+    -- Use: Sends active player identifiers and names to the server
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('rlUpdateNames', function()
     local names = {}
 
-    for i = 0, 31 do
-        if NetworkIsPlayerActive(i) then
-            names[GetPlayerServerId(i)] = { id = i, name = GetPlayerName(i) }
-        end
+    for _, player in ipairs(GetActivePlayers()) do
+        names[GetPlayerServerId(player)] = { id = player, name = GetPlayerName(player) }
     end
 
     TriggerServerEvent('rlUpdateNamesResult', names)
 end)
 
-Citizen.CreateThread(function()
-	while true do
-		Wait(0)
+--[[
+    -- Type: Thread
+    -- Name: SessionWatcher
+    -- Use: Notifies the server when the client session becomes active
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
+CreateThread(function()
+    while true do
+        Wait(500)
 
-		if NetworkIsSessionStarted() then
-			TriggerServerEvent('rlPlayerActivated')
-
-			return
-		end
-	end
+        if NetworkIsSessionStarted() then
+            TriggerServerEvent('rlPlayerActivated')
+            break
+        end
+    end
 end)
+

--- a/Example_Frameworks/NoPixelServer/rconlog/rconlog_server.lua
+++ b/Example_Frameworks/NoPixelServer/rconlog/rconlog_server.lua
@@ -1,39 +1,60 @@
-RconLog({ msgType = 'serverStart', hostname = 'lovely', maxplayers = 32 })
-
-RegisterServerEvent('rlPlayerActivated')
-
 local names = {}
 
-AddEventHandler('rlPlayerActivated', function()
-    RconLog({ msgType = 'playerActivated', netID = source, name = GetPlayerName(source), guid = GetPlayerIdentifiers(source)[1], ip = GetPlayerEP(source) })
+RconLog({
+    msgType = 'serverStart',
+    hostname = GetConvar('sv_hostname', 'unknown'),
+    maxplayers = GetConvarInt('sv_maxclients', 32)
+})
 
-    names[source] = { name = GetPlayerName(source), id = source }
+--[[
+    -- Type: Event
+    -- Name: rlPlayerActivated
+    -- Use: Registers when a player joins the session
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('rlPlayerActivated', function()
+    local src = source
 
-	if GetHostId() then
-		TriggerClientEvent('rlUpdateNames', GetHostId())
-	end
+    RconLog({
+        msgType = 'playerActivated',
+        netID = src,
+        name = GetPlayerName(src),
+        guid = GetPlayerIdentifiers(src)[1],
+        ip = GetPlayerEndpoint(src)
+    })
+
+    names[src] = { name = GetPlayerName(src), id = src }
+
+    local hostId = tonumber(GetHostId())
+    if hostId then
+        TriggerClientEvent('rlUpdateNames', hostId)
+    end
 end)
 
-RegisterServerEvent('rlUpdateNamesResult')
-
-AddEventHandler('rlUpdateNamesResult', function(res)
-    if source ~= tonumber(GetHostId()) then
-        print('bad guy')
+--[[
+    -- Type: Event
+    -- Name: rlUpdateNamesResult
+    -- Use: Receives updated player name data from the host
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('rlUpdateNamesResult', function(res)
+    local src = source
+    if src ~= tonumber(GetHostId()) then
+        print('rlUpdateNamesResult: invalid source')
         return
     end
 
     for id, data in pairs(res) do
-        if data then
-            if data.name then
-                if not names[id] then
-                    names[id] = data
-                end
+        if data and data.name then
+            if not names[id] then
+                names[id] = data
+            end
 
-                if names[id].name ~= data.name or names[id].id ~= data.id then
-                    names[id] = data
-
-                    RconLog({ msgType = 'playerRenamed', netID = id, name = data.name })
-                end
+            if names[id].name ~= data.name or names[id].id ~= data.id then
+                names[id] = data
+                RconLog({ msgType = 'playerRenamed', netID = id, name = data.name })
             end
         else
             names[id] = nil
@@ -41,44 +62,76 @@ AddEventHandler('rlUpdateNamesResult', function(res)
     end
 end)
 
-AddEventHandler('playerDropped', function()
-    RconLog({ msgType = 'playerDropped', netID = source, name = GetPlayerName(source) })
-
-    names[source] = nil
+--[[
+    -- Type: Event
+    -- Name: playerDropped
+    -- Use: Logs when a player disconnects
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
+AddEventHandler('playerDropped', function(reason)
+    local src = source
+    RconLog({ msgType = 'playerDropped', netID = src, name = GetPlayerName(src), reason = reason })
+    names[src] = nil
 end)
 
+--[[
+    -- Type: Event
+    -- Name: chatMessage
+    -- Use: Logs chat messages to RCON
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
 AddEventHandler('chatMessage', function(netID, name, message)
     RconLog({ msgType = 'chatMessage', netID = netID, name = name, message = message, guid = GetPlayerIdentifiers(netID)[1] })
 end)
 
--- NOTE: DO NOT USE THIS METHOD FOR HANDLING COMMANDS
--- This resource has not been updated to use newer methods such as RegisterCommand.
-AddEventHandler('rconCommand', function(commandName, args)
-    if commandName == 'status' then
-        for netid, data in pairs(names) do
-            local guid = GetPlayerIdentifiers(netid)
+--[[
+    -- Type: Command
+    -- Name: status
+    -- Use: Prints list of connected players with identifiers
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
+RegisterCommand('status', function(source, args, raw)
+    if source ~= 0 then return end
 
-            if guid and guid[1] and data then
-                local ping = GetPlayerPing(netid)
-
-                RconPrint(netid .. ' ' .. guid[1] .. ' ' .. data.name .. ' ' .. GetPlayerEP(netid) .. ' ' .. ping .. "\n")
-            end
+    for netid, data in pairs(names) do
+        local guid = GetPlayerIdentifiers(netid)
+        if guid and guid[1] and data then
+            local ping = GetPlayerPing(netid)
+            RconPrint(('%s %s %s %s %s\n'):format(netid, guid[1], data.name, GetPlayerEndpoint(netid), ping))
         end
-
-        CancelEvent()
-    elseif commandName:lower() == 'clientkick' then
-        local playerId = table.remove(args, 1)
-        local msg = table.concat(args, ' ')
-
-        DropPlayer(playerId, msg)
-
-        CancelEvent()
-    elseif commandName:lower() == 'tempbanclient' then
-        local playerId = table.remove(args, 1)
-        local msg = table.concat(args, ' ')
-
-        TempBanPlayer(playerId, msg)
-
-        CancelEvent()
     end
-end)
+end, true)
+
+--[[
+    -- Type: Command
+    -- Name: clientkick
+    -- Use: Kicks a player from the server
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
+RegisterCommand('clientkick', function(source, args)
+    if source ~= 0 then return end
+
+    local playerId = table.remove(args, 1)
+    local msg = table.concat(args, ' ')
+    DropPlayer(playerId, msg)
+end, true)
+
+--[[
+    -- Type: Command
+    -- Name: tempbanclient
+    -- Use: Temporarily bans a player from the server
+    -- Created: 2025-02-14
+    -- By: VSSVSSN
+--]]
+RegisterCommand('tempbanclient', function(source, args)
+    if source ~= 0 then return end
+
+    local playerId = table.remove(args, 1)
+    local msg = table.concat(args, ' ')
+    TempBanPlayer(playerId, msg)
+end, true)
+


### PR DESCRIPTION
## Summary
- modernize fxmanifest and enable cerulean build
- refactor client logic for unlimited player slots and cleaner session detection
- overhaul server rcon logging and command handling

## Testing
- `luac -p Example_Frameworks/NoPixelServer/rconlog/rconlog_client.lua`
- `luac -p Example_Frameworks/NoPixelServer/rconlog/rconlog_server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c1e226c8c8832d897a11307b70f2b7