### PR TITLE
refactor: overhaul activities module

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/fishing/client.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/fishing/client.lua
@@ -1,1 +1,139 @@
--- To do - Crutchie
+-- luacheck: globals Util vector3 AddBlipForCoord SetBlipHighDetail SetBlipSprite
+-- luacheck: globals SetBlipDisplay SetBlipScale SetBlipColour
+-- luacheck: globals SetBlipAsShortRange BeginTextCommandSetBlipName
+-- luacheck: globals AddTextComponentString
+-- luacheck: globals EndTextCommandSetBlipName
+-- luacheck: globals exports ClearPedTasksImmediately TaskStartScenarioInPlace Wait CreateThread
+-- luacheck: globals PlayerPedId GetEntityCoords
+-- luacheck: globals IsControlJustPressed IsDisabledControlJustPressed TriggerEvent RegisterNetEvent AddEventHandler
+--[[
+    -- Type: Module
+    -- Name: Fishing Activity
+    -- Use: Allows players to fish at designated locations
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local fishStartKey = Util.GetKeyNumber("E")
+local fishEndKey   = Util.GetKeyNumber("DELETE")
+
+local DRAW_TEXT_DIST = 2.0
+local CHECK_DIST     = 15.0
+local FISHING_SPOTS  = {
+    vector3(-3426.1, 973.7, 8.35),
+    vector3(-1512.0, 1500.0, 111.0) -- sample second spot
+}
+
+local fishing = false
+local currentRod = nil
+
+local Blips = {
+    FishingPier = {
+        Zone    = 'Fishing Pier',
+        Sprite  = 68,
+        Scale   = 0.8,
+        Display = 4,
+        Color   = 3,
+        Pos     = { x = -3426.1, y = 973.7, z = 8.35 }
+    }
+}
+
+--[[
+    -- Type: Function
+    -- Name: createBlips
+    -- Use: Generates map blips for fishing spots
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function createBlips()
+    for _, val in pairs(Blips) do
+        local blip = AddBlipForCoord(val.Pos.x, val.Pos.y, val.Pos.z)
+        SetBlipHighDetail(blip, true)
+        SetBlipSprite(blip, val.Sprite)
+        SetBlipDisplay(blip, val.Display)
+        SetBlipScale(blip, val.Scale)
+        SetBlipColour(blip, val.Color)
+        SetBlipAsShortRange(blip, true)
+        BeginTextCommandSetBlipName("STRING")
+        AddTextComponentString(val.Zone)
+        EndTextCommandSetBlipName(blip)
+    end
+end
+
+--[[
+    -- Type: Function
+    -- Name: getNearestSpot
+    -- Use: Returns the closest fishing spot to the player
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function getNearestSpot(playerPos)
+    local nearestDist, nearestPos
+    for _, v in ipairs(FISHING_SPOTS) do
+        local curDist = Util.GetVecDist(playerPos, v)
+        if not nearestDist or curDist < nearestDist then
+            nearestDist = curDist
+            nearestPos  = v
+        end
+    end
+    return nearestDist, nearestPos
+end
+
+--[[
+    -- Type: Function
+    -- Name: cancelFishing
+    -- Use: Ends the fishing session immediately
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function cancelFishing(ped)
+    exports['mythic_notify']:DoCustomHudText('inform', 'You stopped fishing.', 3000)
+    fishing = false
+    if currentRod then
+        ClearPedTasksImmediately(ped)
+        currentRod = nil
+    end
+end
+
+--[[
+    -- Type: Function
+    -- Name: startFishing
+    -- Use: Plays the fishing scenario and grants a reward
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function startFishing(ped)
+    exports['mythic_notify']:DoCustomHudText('inform', 'Casting your line...', 1000)
+    TaskStartScenarioInPlace(ped, 'world_human_stand_fishing', 0, true)
+    currentRod = ped
+    Wait(math.random(10000, 15000))
+    exports['mythic_notify']:DoCustomHudText('inform', 'You caught a fish!', 3000)
+    ClearPedTasksImmediately(ped)
+    currentRod = nil
+end
+
+CreateThread(function()
+    createBlips()
+    while true do
+        local sleep = 500
+        local ped = PlayerPedId()
+        local playerPos = GetEntityCoords(ped)
+        local dist, nearestPos = getNearestSpot(playerPos)
+        if dist < CHECK_DIST then
+            sleep = 0
+            if not fishing and dist < DRAW_TEXT_DIST then
+                Util.DrawText3D(nearestPos.x, nearestPos.y, nearestPos.z, 'Press ~g~[ E ] ~s~ to fish')
+                if IsControlJustPressed(0, fishStartKey) or IsDisabledControlJustPressed(0, fishStartKey) then
+                    fishing = true
+                    startFishing(ped)
+                    fishing = false
+                end
+            elseif fishing and dist < DRAW_TEXT_DIST then
+                Util.DrawText3D(nearestPos.x, nearestPos.y, nearestPos.z, 'Press ~r~[ DELETE ] ~s~ to stop fishing')
+                if IsControlJustPressed(0, fishEndKey) or IsDisabledControlJustPressed(0, fishEndKey) then
+                    cancelFishing(ped)
+                end
+            end
+        end
+        Wait(sleep)
+    end
+end)

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/fxmanifest.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/fxmanifest.lua
@@ -1,25 +1,18 @@
-fx_version 'bodacious'
-games { 'gta5' }
+-- luacheck: globals fx_version game author description version shared_scripts client_scripts
+fx_version 'cerulean'
+game 'gta5'
 
 author 'iTzCrutchie'
 description 'Activities for the server'
-version '0.0.1'
+version '0.1.0'
 
---[[/	:FSN:	\]]--
-client_scripts { 
-    '@fsn_main/cl_utils.lua',
+shared_scripts {
     '@fsn_main/server_settings/sh_settings.lua'
 }
-server_scripts { 
-    '@fsn_main/sv_utils.lua',
-    '@fsn_main/server_settings/sh_settings.lua',
-    '@mysql-async/lib/MySQL.lua'
-}
---[[/	:FSN:	\]]--
 
 client_scripts {
-
-    -- Yoga
+    '@fsn_main/cl_utils.lua',
     'yoga/client.lua',
-
+    'fishing/client.lua',
+    'hunting/client.lua'
 }

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/hunting/client.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/hunting/client.lua
@@ -1,1 +1,135 @@
--- to do I noticed on in fsn_jobs but might move hunting to activities instead. still debating -Crutchie
+-- luacheck: globals Util vector3 AddBlipForCoord SetBlipHighDetail SetBlipSprite
+-- luacheck: globals SetBlipDisplay SetBlipScale SetBlipColour
+-- luacheck: globals SetBlipAsShortRange BeginTextCommandSetBlipName
+-- luacheck: globals AddTextComponentString
+-- luacheck: globals EndTextCommandSetBlipName
+-- luacheck: globals exports ClearPedTasksImmediately TaskStartScenarioInPlace Wait CreateThread
+-- luacheck: globals PlayerPedId GetEntityCoords
+-- luacheck: globals IsControlJustPressed IsDisabledControlJustPressed TriggerEvent RegisterNetEvent AddEventHandler
+-- luacheck: globals GetHashKey RequestModel HasModelLoaded GetOffsetFromEntityInWorldCoords
+-- luacheck: globals CreatePed TaskWanderStandard SetEntityAsMissionEntity DoesEntityExist DeleteEntity IsEntityDead
+--[[
+    -- Type: Module
+    -- Name: Hunting Activity
+    -- Use: Spawns a target animal for players to hunt
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local huntStartKey = Util.GetKeyNumber("E")
+local huntEndKey   = Util.GetKeyNumber("DELETE")
+
+local DRAW_TEXT_DIST = 3.0
+local CHECK_DIST     = 30.0
+local HUNT_LOCATION  = vector3(-1123.5, 4875.7, 218.0)
+
+local hunting = false
+local targetAnimal
+
+local Blips = {
+    HuntingGround = {
+        Zone    = 'Hunting Grounds',
+        Sprite  = 141,
+        Scale   = 0.8,
+        Display = 4,
+        Color   = 1,
+        Pos     = { x = HUNT_LOCATION.x, y = HUNT_LOCATION.y, z = HUNT_LOCATION.z }
+    }
+}
+
+--[[
+    -- Type: Function
+    -- Name: createBlips
+    -- Use: Generates map blip for hunting area
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function createBlips()
+    for _, val in pairs(Blips) do
+        local blip = AddBlipForCoord(val.Pos.x, val.Pos.y, val.Pos.z)
+        SetBlipHighDetail(blip, true)
+        SetBlipSprite(blip, val.Sprite)
+        SetBlipDisplay(blip, val.Display)
+        SetBlipScale(blip, val.Scale)
+        SetBlipColour(blip, val.Color)
+        SetBlipAsShortRange(blip, true)
+        BeginTextCommandSetBlipName("STRING")
+        AddTextComponentString(val.Zone)
+        EndTextCommandSetBlipName(blip)
+    end
+end
+
+--[[
+    -- Type: Function
+    -- Name: spawnAnimal
+    -- Use: Spawns the deer target for hunting
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function spawnAnimal(ped)
+    local model = GetHashKey('a_c_deer')
+    RequestModel(model)
+    while not HasModelLoaded(model) do Wait(0) end
+    local spawnPos = GetOffsetFromEntityInWorldCoords(ped, 0.0, 30.0, 0.0)
+    targetAnimal = CreatePed(28, model, spawnPos.x, spawnPos.y, spawnPos.z, 0.0, true, true)
+    TaskWanderStandard(targetAnimal, 10.0, 10)
+    SetEntityAsMissionEntity(targetAnimal, true, true)
+end
+
+--[[
+    -- Type: Function
+    -- Name: cancelHunt
+    -- Use: Cancels the hunt and cleans up
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function cancelHunt()
+    exports['mythic_notify']:DoCustomHudText('inform', 'Hunt canceled.', 3000)
+    hunting = false
+    if DoesEntityExist(targetAnimal) then
+        DeleteEntity(targetAnimal)
+    end
+end
+
+--[[
+    -- Type: Function
+    -- Name: startHunt
+    -- Use: Initiates the hunting session
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function startHunt(ped)
+    exports['mythic_notify']:DoCustomHudText('inform', 'Hunt started. Track and kill the animal.', 3000)
+    spawnAnimal(ped)
+    hunting = true
+end
+
+CreateThread(function()
+    createBlips()
+    while true do
+        local sleep = 500
+        local ped = PlayerPedId()
+        local playerPos = GetEntityCoords(ped)
+        local dist = Util.GetVecDist(playerPos, HUNT_LOCATION)
+        if dist < CHECK_DIST then
+            sleep = 0
+            if not hunting and dist < DRAW_TEXT_DIST then
+                Util.DrawText3D(HUNT_LOCATION.x, HUNT_LOCATION.y, HUNT_LOCATION.z, 'Press ~g~[ E ] ~s~ to hunt')
+                if IsControlJustPressed(0, huntStartKey) or IsDisabledControlJustPressed(0, huntStartKey) then
+                    startHunt(ped)
+                end
+            elseif hunting then
+                if DoesEntityExist(targetAnimal) then
+                    if IsEntityDead(targetAnimal) then
+                        exports['mythic_notify']:DoCustomHudText('success', 'Animal down! You collected meat.', 3000)
+                        DeleteEntity(targetAnimal)
+                        hunting = false
+                    end
+                end
+                if IsControlJustPressed(0, huntEndKey) or IsDisabledControlJustPressed(0, huntEndKey) then
+                    cancelHunt()
+                end
+            end
+        end
+        Wait(sleep)
+    end
+end)

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/yoga/client.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_activities/yoga/client.lua
@@ -1,147 +1,153 @@
+-- luacheck: globals Util vector3 AddBlipForCoord SetBlipHighDetail SetBlipSprite
+-- luacheck: globals SetBlipDisplay SetBlipScale SetBlipColour
+-- luacheck: globals SetBlipAsShortRange BeginTextCommandSetBlipName
+-- luacheck: globals AddTextComponentString
+-- luacheck: globals EndTextCommandSetBlipName
+-- luacheck: globals exports ClearPedTasksImmediately TaskStartScenarioInPlace Wait CreateThread
+-- luacheck: globals PlayerPedId GetEntityCoords
+-- luacheck: globals IsControlJustPressed IsDisabledControlJustPressed TriggerEvent RegisterNetEvent AddEventHandler
+--[[
+    -- Type: Module
+    -- Name: Yoga Activity
+    -- Use: Allows players to perform yoga to reduce stress
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
 local yogaStartKey = Util.GetKeyNumber("E")
-local yogaEndKey = Util.GetKeyNumber("DELETE")
+local yogaEndKey   = Util.GetKeyNumber("DELETE")
 
-local doingYoga
-local drawTextDist = 2.0
-local distance = 10.0
-local yogaLocation = vector3(-1217.31, -1543.11, 4.72)
-local yogaSpots = {
-
-	[1] = vector3(-1217.31, -1543.11, 4.72),
-	[2] = vector3(-1223.25, -1546.05, 4.72),
-	[3] = vector3(-1228.80, -1549.44, 4.72)  
-
+local DRAW_TEXT_DIST = 2.0
+local CHECK_DIST     = 10.0
+local YOGA_LOCATION  = vector3(-1217.31, -1543.11, 4.72)
+local YOGA_SPOTS     = {
+    vector3(-1217.31, -1543.11, 4.72),
+    vector3(-1223.25, -1546.05, 4.72),
+    vector3(-1228.80, -1549.44, 4.72)
 }
+
+local doingYoga = false
 
 local Blips = {
-    
     YogaBliss = {
-		Zone = 'Yoga Bliss',
-		Sprite = 480,
-		Scale = 1.0,
-		Display = 4,
-		Color = 7,
-		Pos = {x = -1224.85, y = -1547.37, z = 4.62 },
-    },
-    
+        Zone    = 'Yoga Bliss',
+        Sprite  = 480,
+        Scale   = 1.0,
+        Display = 4,
+        Color   = 7,
+        Pos     = { x = -1224.85, y = -1547.37, z = 4.62 }
+    }
 }
 
--- Draw the blips
-Citizen.CreateThread(function()
-    
-    for key, val in pairs(Blips) do
+--[[
+    -- Type: Function
+    -- Name: createBlips
+    -- Use: Generates map blips for yoga locations
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function createBlips()
+    for _, val in pairs(Blips) do
         local blip = AddBlipForCoord(val.Pos.x, val.Pos.y, val.Pos.z)
-        SetBlipHighDetail           (blip, true)
-        SetBlipSprite               (blip, val.Sprite)
-        SetBlipDisplay              (blip, val.Display)
-        SetBlipScale                (blip, val.Scale)
-        SetBlipColour               (blip, val.Color)
-        SetBlipAsShortRange         (blip, true)
-        BeginTextCommandSetBlipName ("STRING")
-        AddTextComponentString      (val.Zone)
-        EndTextCommandSetBlipName   (blip)
+        SetBlipHighDetail(blip, true)
+        SetBlipSprite(blip, val.Sprite)
+        SetBlipDisplay(blip, val.Display)
+        SetBlipScale(blip, val.Scale)
+        SetBlipColour(blip, val.Color)
+        SetBlipAsShortRange(blip, true)
+        BeginTextCommandSetBlipName("STRING")
+        AddTextComponentString(val.Zone)
+        EndTextCommandSetBlipName(blip)
     end
+end
 
-end)
-
--- Lets start some YOGA
-Citizen.CreateThread(function()
-    
-    while true do
-        Citizen.Wait(0)
-		local playerPed = PlayerPedId()
-		local playerPos = GetEntityCoords(playerPed)
-		local nearestDist, nearestPos = PositionCheck(playerPos)
-        local dist = Util.GetVecDist(playerPos, yogaLocation)
-
-        if dist < distance then
-            nearestDist,nearestPos = PositionCheck(playerPos)
-
-            if nearestDist < drawTextDist then
-                Util.DrawText3D(nearestPos.x, nearestPos.y, nearestPos.z, 'Press ~g~[ E ] ~s~ to begin yoga', {255, 0, 0, 255}, 0.2)
-                if (IsControlJustPressed(0, yogaStartKey, IsDisabledControlJustPressed(0, yogaStartKey))) then
-                    doingYoga = true
-                    DoYoga(playerPed)
-                end
-            end
+--[[
+    -- Type: Function
+    -- Name: getNearestSpot
+    -- Use: Returns the closest yoga spot to the player
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function getNearestSpot(playerPos)
+    local nearestDist, nearestPos
+    for _, v in ipairs(YOGA_SPOTS) do
+        local curDist = Util.GetVecDist(playerPos, v)
+        if not nearestDist or curDist < nearestDist then
+            nearestDist = curDist
+            nearestPos  = v
         end
     end
-end)
+    return nearestDist, nearestPos
+end
 
--- Cancel Yoga
-Citizen.CreateThread(function()
-
-    while true do
-        Citizen.Wait(0)
-		local playerPed = PlayerPedId()
-		local playerPos = GetEntityCoords(playerPed)
-		local nearestDist,nearestPos = PositionCheck(playerPos)
-        local dist = Util.GetVecDist(playerPos, yogaLocation)
-
-        if dist < distance then
-            nearestDist,nearestPos = PositionCheck(playerPos)
-
-            if nearestDist < drawTextDist then
-                if doingYoga then
-                    Util.DrawText3D(nearestPos.x, nearestPos.y, nearestPos.z, 'Press ~r~[ DELETE ] ~s~ to cancel yoga', {255, 0, 0, 255}, 0.2)
-                    if (IsControlJustPressed(0, yogaEndKey, IsDisabledControlJustPressed(0, yogaEndKey))) then
-                        doingYoga = false
-                        cancelledYoga(playerPed)
-                    end
-                end
-            end
-        end
-    end
-end)
-
-function cancelledYoga(playerPed)
-    
-    exports['mythic_notify']:DoCustomHudText('inform', 'You ended your yoga session early and now are resting for 15 seconds.', 3000)
-
+--[[
+    -- Type: Function
+    -- Name: cancelYoga
+    -- Use: Ends the yoga session immediately
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function cancelYoga(ped)
+    exports['mythic_notify']:DoCustomHudText('inform', 'You ended yoga early and need 15s rest.', 3000)
     doingYoga = false
-    ClearPedTasksImmediately(playerPed)
-
+    ClearPedTasksImmediately(ped)
 end
 
-function PositionCheck(playerPos)
-
-	local nearestDist,nearestPos
-	
-	for k,v in pairs(yogaSpots) do
-		local curDist = Util.GetVecDist(playerPos, v.xyz)
-		if not nearestDist or curDist < nearestDist then
-			nearestDist = curDist
-			nearestPos = v
-		end
-	end
-	
-	if not nearestDist then return false; end
-	return nearestDist,nearestPos
-	
+--[[
+    -- Type: Function
+    -- Name: startYoga
+    -- Use: Plays the yoga scenario and handles stress relief
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
+local function startYoga(ped)
+    exports['mythic_notify']:DoCustomHudText('inform', 'Preparing the exercise...', 1000)
+    Wait(1000)
+    TaskStartScenarioInPlace(ped, 'world_human_yoga', 0, true)
+    Wait(15000)
+    TriggerEvent('fsn_yoga:checkStress')
+    ClearPedTasksImmediately(ped)
 end
 
-function DoYoga(playerPed)
+CreateThread(function()
+    createBlips()
+    while true do
+        local sleep = 500
+        local ped = PlayerPedId()
+        local playerPos = GetEntityCoords(ped)
+        local dist = Util.GetVecDist(playerPos, YOGA_LOCATION)
+        if dist < CHECK_DIST then
+            sleep = 0
+            local nearestDist, nearestPos = getNearestSpot(playerPos)
+            if not doingYoga and nearestDist < DRAW_TEXT_DIST then
+                Util.DrawText3D(nearestPos.x, nearestPos.y, nearestPos.z, 'Press ~g~[ E ] ~s~ to begin yoga')
+                if IsControlJustPressed(0, yogaStartKey) or IsDisabledControlJustPressed(0, yogaStartKey) then
+                    doingYoga = true
+                    startYoga(ped)
+                end
+            elseif doingYoga and nearestDist < DRAW_TEXT_DIST then
+                Util.DrawText3D(nearestPos.x, nearestPos.y, nearestPos.z, 'Press ~r~[ DELETE ] ~s~ to cancel yoga')
+                if IsControlJustPressed(0, yogaEndKey) or IsDisabledControlJustPressed(0, yogaEndKey) then
+                    cancelYoga(ped)
+                end
+            end
+        end
+        Wait(sleep)
+    end
+end)
 
-	local playerPos = GetEntityCoords(playerPed)
-
-	exports['mythic_notify']:DoCustomHudText('inform', 'Preparing the exercise...', 1000)
-	
-	Citizen.Wait(1000)
-	TaskStartScenarioInPlace(playerPed, "world_human_yoga", 0, true)
-	Citizen.Wait(15000)
-	TriggerEvent('fsn_yoga:checkStress')
-	ClearPedTasksImmediately(playerPed)
-
-end
-
+--[[
+    -- Type: Event
+    -- Name: fsn_yoga:checkStress
+    -- Use: Removes stress after a completed yoga session
+    -- Created: 2024-06-03
+    -- By: VSSVSSN
+--]]
 RegisterNetEvent('fsn_yoga:checkStress')
 AddEventHandler('fsn_yoga:checkStress', function()
-	local playerPed = PlayerPedId()
-	
-	if doingYoga then
-		TriggerEvent('fsn_needs:stress:remove', 10)
-		doingYoga = false
-	else
-		doingYoga = false
-	end
+    if doingYoga then
+        TriggerEvent('fsn_needs:stress:remove', 10)
+        doingYoga = false
+    else
+        doingYoga = false
+    end
 end)


### PR DESCRIPTION
## Summary
- modernize fsn_activities manifest and register fishing and hunting scripts
- refactor yoga logic and fix control handling
- add basic fishing and hunting mini-games with blips and notifications

## Testing
- `luacheck Example_Frameworks/FiveM-FSN-Framework/fsn_activities`


------
https://chatgpt.com/codex/tasks/task_e_68c202e041d0832d8ec1a379c405546e