### PR TITLE
refactor: modernize fsn builders

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_builders/fxmanifest.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_builders/fxmanifest.lua
@@ -1,23 +1,24 @@
-fx_version 'bodacious'
-games { 'gta5' }
+fx_version 'cerulean'
+game 'gta5'
 
+lua54 'yes'
 
 description 'Builders for the framework'
 
---[[/	:FSN:	\]]--
-client_scripts { 
+--[[/   :FSN:   \]]--
+client_scripts {
     '@fsn_main/cl_utils.lua',
     '@fsn_main/server_settings/sh_settings.lua'
 }
-server_scripts { 
+
+server_scripts {
     '@fsn_main/sv_utils.lua',
     '@fsn_main/server_settings/sh_settings.lua',
-    '@mysql-async/lib/MySQL.lua'
-}
---[[/	:FSN:	\]]--
-
-server_scripts { 
+    '@mysql-async/lib/MySQL.lua',
     'xml.lua',
     'schema.lua',
     'handling_builder.lua'
 }
+
+--[[/   :FSN:   \]]--
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_builders/handling_builder.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_builders/handling_builder.lua
@@ -1,27 +1,42 @@
+--[[
+    -- Type: Module
+    -- Name: handling_builder
+    -- Use: Builds handling.meta files from schema definitions
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+
 local errprefix = "^3[fsn_builders]^7 ^1ERROR:^7 "
 --[[
-	Translators
+        Translators
 ]]
 local CCarHandlingData = LoadSchema("CCarHandlingData", "ccarhandlingdata.lua")
 local CBikeHandlingData = LoadSchema("CBikeHandlingData", "cbikehandlingdata.lua")
 local CHandlingData    = LoadSchema("CHandlingData", "chandlingdata.lua")
 
+--[[
+    -- Type: Function
+    -- Name: load_file
+    -- Use: Loads a Lua handling definition file within a sandboxed environment
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 local function load_file(res, file)
-	local err = errprefix.."Failed to %s ^0'^5@"..res.."/"..file.."^0'^7"
+        local err = errprefix.."Failed to %s ^0'^5@"..res.."/"..file.."^0'^7"
 
-	local code = assert(
-		LoadResourceFile(res, file),
-		err:format("load"))
-	
-	local env = setmetatable({}, {
-		__index = function(self, key) return Schemas[key] or _G[key] end
-	})
+        local code = assert(
+                LoadResourceFile(res, file),
+                err:format("load"))
 
-	local fn = assert(
-		load(code, "@"..res.."/"..file, "t", env),
-		err:format("parse"))
+        local env = setmetatable({}, {
+                __index = function(_, key) return Schemas[key] or _G[key] end
+        })
 
-	return fn()
+        local fn = assert(
+                load(code, "@"..res.."/"..file, "t", env),
+                err:format("parse"))
+
+        return fn()
 end
 
 
@@ -30,33 +45,59 @@ end
 ]]
 local builder = {}
 
+--[[
+    -- Type: Function
+    -- Name: shouldBuild
+    -- Use: Determines if a resource contains handling metadata
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function builder.shouldBuild(res)
-	return GetNumResourceMetadata(res, "fsn_handling") > 0
+        return GetNumResourceMetadata(res, "fsn_handling") > 0
 end
 
+--[[
+    -- Type: Function
+    -- Name: build
+    -- Use: Generates the handling.meta file for a resource
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function builder.build(res, finished)
-	local xml = XML():open("CHandlingDataMgr")
-		:open("HandlingData")
+        local xml = XML():open("CHandlingDataMgr")
+                :open("HandlingData")
 
-	for i=1, GetNumResourceMetadata(res, "fsn_handling") do
-		local file = GetResourceMetadata(res, "fsn_handling", i-1)
-		xml:comment(file)
+        local count = GetNumResourceMetadata(res, "fsn_handling")
+        for i=0, count - 1 do
+                local file = GetResourceMetadata(res, "fsn_handling", i)
+                xml:comment(file)
 
-		local ok, ret = pcall(load_file, res, file)
-		if not ok then finished(false, ret) end
+                local ok, data = pcall(load_file, res, file)
+                if not ok then
+                        return finished(false, data)
+                end
 
-		for _, handling in pairs(ret) do
-			xml:append(handling)
-		end
-	end
+                for _, handling in pairs(data) do
+                        xml:append(handling)
+                end
+        end
 
-	local out = xml:close()
-		:close()
-		:serialize()
+        local out = xml:close()
+                :close()
+                :serialize()
 
-	SaveResourceFile(res, "out/handling.meta", out, #out)
-	finished(true)
+        SaveResourceFile(res, "out/handling.meta", out, #out)
+        finished(true)
 end
 
-local function factory() return builder end 
+--[[
+    -- Type: Function
+    -- Name: factory
+    -- Use: Returns the builder instance for the build task factory
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+local function factory()
+        return builder
+end
 RegisterResourceBuildTaskFactory("fsn_handling", factory)

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_builders/schema.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_builders/schema.lua
@@ -1,19 +1,35 @@
-Schemas = {}
-local meta = {}
+--[[
+    -- Type: Module
+    -- Name: Schema
+    -- Use: Provides schema loading and XML serialization utilities
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+
+local Schemas = {}
+_G.Schemas = Schemas
 
 --[[
 	This is for fancy error handling
 	TODO: Move to fsn_core
 ]]
 local errprefix = "^3[fsn_builders]^7 ^1ERROR:^7 "
-local function drop_guard(err)
-	local safe = false
 
-	local meta = {
-		__gc   = function() assert(safe, errprefix..err) end,
-		__call = function() safe = true end
-	}
-	return setmetatable({}, meta)
+--[[
+    -- Type: Function
+    -- Name: drop_guard
+    -- Use: Ensures a field definition supplies a name before the function exits
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+local function drop_guard(err)
+        local safe = false
+
+        local meta = {
+                __gc   = function() assert(safe, errprefix..err) end,
+                __call = function() safe = true end
+        }
+        return setmetatable({}, meta)
 end
 
 
@@ -24,42 +40,80 @@ end
 local types = {}
 
 
+--[[
+    -- Type: Function
+    -- Name: types.string
+    -- Use: Serializes a simple string field
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function types.string(field, val)
-	return XML():inline(field, tostring(val))
+        return XML():inline(field, tostring(val))
 end
 
+--[[
+    -- Type: Function
+    -- Name: types.float
+    -- Use: Serializes a floating point field
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function types.float(field, val)
-	val = tonumber(val)
-	val = ("%f"):format(val)
-	return XML():void(field, {value=val})
+        val = tonumber(val)
+        assert(val, errprefix.."Expected number for field "..field)
+        val = ("%f"):format(val)
+        return XML():void(field, {value=val})
 end
 
+--[[
+    -- Type: Function
+    -- Name: types.integer
+    -- Use: Serializes an integer field
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function types.integer(field, val)
-	val = tonumber(val)
-	val = ("%d"):format(math.floor(val))
-	return XML():void(field, {value=val})
+        val = tonumber(val)
+        assert(val, errprefix.."Expected number for field "..field)
+        val = ("%d"):format(math.floor(val))
+        return XML():void(field, {value=val})
 end
 
+--[[
+    -- Type: Function
+    -- Name: types.vector
+    -- Use: Serializes a three dimensional vector field
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function types.vector(field, val)
-	local attrs = {
-		x = ("%f"):format(tonumber(val.x or val[1])),
-		y = ("%f"):format(tonumber(val.y or val[2])),
-		z = ("%f"):format(tonumber(val.z or val[3]))
-	}
+        assert(type(val) == "table", errprefix.."Expected table for field "..field)
+        local attrs = {
+                x = ("%f"):format(tonumber(val.x or val[1])),
+                y = ("%f"):format(tonumber(val.y or val[2])),
+                z = ("%f"):format(tonumber(val.z or val[3]))
+        }
 
-	return XML():void(field, attrs)
+        return XML():void(field, attrs)
 end
 
+--[[
+    -- Type: Function
+    -- Name: types.SubHandlingData
+    -- Use: Serializes sub handling data entries
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function types.SubHandlingData(field, val)
-	local xml = XML():open("SubHandlingData")
-	for i=1, 3 do
-		if val[i] then
-			xml:append(val[i])
-		else
-			xml:void("Item", {type="NULL"})
-		end
-	end
-	return xml:close()
+        local xml = XML():open("SubHandlingData")
+        for i=1, 3 do
+                if val[i] then
+                        xml:append(val[i])
+                else
+                        xml:void("Item", {type="NULL"})
+                end
+        end
+        return xml:close()
 end
 
 
@@ -68,6 +122,13 @@ end
 --[[
 	Schema loading
 ]]
+--[[
+    -- Type: Function
+    -- Name: env_for_schema
+    -- Use: Creates environment for schema definition files
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 local function env_for_schema(class)
 	local cur_group = "None"
 	local cur_field
@@ -100,33 +161,50 @@ local function env_for_schema(class)
 	return setmetatable(env, { __index=Schemas })
 end
 
+--[[
+    -- Type: Function
+    -- Name: serialize
+    -- Use: Turns a table of data into XML based on class schema
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 local function serialize(class, data)
-	local xml = XML():open("Item", {type=class})
-	for f, fd in pairs(Schemas[class]) do
-		local val = data[fd.Source or f]
-			or assert(fd.Default, "No (default) value given for field "..f)
-		xml:append(fd.Type(f, val))
-	end
-	return xml:close()
+        local xml = XML():open("Item", {type=class})
+        for f, fd in pairs(Schemas[class]) do
+                local val = data[fd.Source or f]
+                        or assert(fd.Default, "No (default) value given for field "..f)
+                xml:append(fd.Type(f, val))
+        end
+        return xml:close()
 end
 
+--[[
+    -- Type: Function
+    -- Name: LoadSchema
+    -- Use: Loads and registers a schema definition file
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function LoadSchema(class, file)
-	Schemas[class] = setmetatable({}, {
-		__call = function(self, ...) return serialize(class, ...) end
-	})
+        Schemas[class] = setmetatable({}, {
+                __call = function(self, ...) return serialize(class, ...) end
+        })
 
-	-- Loading
-	local err = errprefix.."Failed to %s ^0'^5"..file.."^0'^7"
+        local res = GetCurrentResourceName()
+        local err = errprefix.."Failed to %s ^0'^5"..file.."^0'^7"
 
-	local code = assert(
-		LoadResourceFile("fsn_builders", "schemas/"..file),
-		err:format("load"))
-	
-	local fn = assert(
-		load(code, "SCHEMA: schemas/"..file, "t", env_for_schema(class)),
-		err:format("parse"))
+        local code = assert(
+                LoadResourceFile(res, "schemas/"..file),
+                err:format("load"))
 
-	assert(pcall(fn))
+        local fn = assert(
+                load(code, "SCHEMA: schemas/"..file, "t", env_for_schema(class)),
+                err:format("parse"))
 
-	return Schemas[class]
+        local ok, msg = pcall(fn)
+        assert(ok, errprefix..msg)
+
+        return Schemas[class]
 end
+
+_G.LoadSchema = LoadSchema

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_builders/xml.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_builders/xml.lua
@@ -1,12 +1,20 @@
+--[[
+    -- Type: Module
+    -- Name: XML
+    -- Use: Utility helpers for building XML documents
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+
 local ops = {}
 
 local meta = {}
 function meta:__index(op)
-	assert(ops[op], "No such function "..op.." on XML thingy")
-	return function(self, ...)
-		self.ops[#self.ops+1] = {op=op, args={...}}
-		return self
-	end
+        assert(ops[op], ("No such function %s on XML object"):format(op))
+        return function(self, ...)
+                self.ops[#self.ops+1] = {op=op, args={...}}
+                return self
+        end
 end
 
 -- XML:insert
@@ -18,63 +26,122 @@ local function append(self, xml)
 end
 
 -- XML:serialize
-local function serialize(self) 
-	local state = setmetatable({
-		indent = 0,
-		elems  = {},
-		out    = '<?xml version="1.0" encoding="UTF-8"?>\n\n'
-	}, {__index=ops})
-	for _, op in ipairs(self.ops) do
-		ops[op.op](state, table.unpack(op.args))
-	end
-	return state.out
+--[[
+    -- Type: Function
+    -- Name: serialize
+    -- Use: Converts queued operations into a formatted XML string
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+local function serialize(self)
+        local state = setmetatable({
+                indent = 0,
+                elems  = {},
+                out    = '<?xml version="1.0" encoding="UTF-8"?>\n\n'
+        }, {__index=ops})
+        for _, op in ipairs(self.ops) do
+                ops[op.op](state, table.unpack(op.args))
+        end
+        return state.out
 end
 
+--[[
+    -- Type: Function
+    -- Name: XML
+    -- Use: Factory for creating new XML builder objects
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function XML()
-	return setmetatable({
-		ops={},
-		append=append,
-		serialize=serialize
-	}, meta)
+        return setmetatable({
+                ops={},
+                append=append,
+                serialize=serialize
+        }, meta)
 end
 
 
 
 -- Serialization
+--[[
+    -- Type: Function
+    -- Name: line
+    -- Use: Appends a raw line to the output buffer
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function ops:line(line)
-	self.out = self.out..("  "):rep(self.indent)..line.."\n"
+        self.out = self.out..("  "):rep(self.indent)..line.."\n"
 end
 
+--[[
+    -- Type: Function
+    -- Name: comment
+    -- Use: Adds an XML comment to the document
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function ops:comment(msg)
-	self:line(("<!-- %s -->"):format(msg))
+        self:line(("<!-- %s -->"):format(msg))
 end
 
 -- {value="0.03"} -> 'value="0.03"'
 local function attributes(attrs)
-	local out = ""
-	for k,v in pairs(attrs or {}) do
-		out = out..(' %s="%s"'):format(tostring(k), v:gsub([["]], [[\"]]))
-	end
-	return out
+        local out = ""
+        for k,v in pairs(attrs or {}) do
+                out = out..(' %s="%s"'):format(
+                        tostring(k),
+                        tostring(v):gsub([["]], [[\"]])
+                )
+        end
+        return out
 end
 
+--[[
+    -- Type: Function
+    -- Name: void
+    -- Use: Outputs a self-closing tag with attributes
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function ops:void(tag, attrs)
-	self:line(("<%s%s />"):format(tag, attributes(attrs)))
+        self:line(("<%s%s />"):format(tag, attributes(attrs)))
 end
 
+--[[
+    -- Type: Function
+    -- Name: inline
+    -- Use: Outputs a tag containing inline content
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function ops:inline(tag, content, attrs)
-	self:line(("<%s%s>%s</%s>"):format(tag, attributes(attrs), content, tag))
+        self:line(("<%s%s>%s</%s>"):format(tag, attributes(attrs), content, tag))
 end
 
+--[[
+    -- Type: Function
+    -- Name: open
+    -- Use: Opens a new tag and increases indentation
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function ops:open(tag, attrs)
-	self:line(("<%s%s>"):format(tag, attributes(attrs)))
-	table.insert(self.elems, tag)
-	self.indent = self.indent + 1
+        self:line(("<%s%s>"):format(tag, attributes(attrs)))
+        table.insert(self.elems, tag)
+        self.indent = self.indent + 1
 end
 
+--[[
+    -- Type: Function
+    -- Name: close
+    -- Use: Closes the most recently opened tag
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function ops:close()
-	self.indent = self.indent - 1
-	local tag = table.remove(self.elems)
-	self:line(("</%s>"):format(tag))
+        self.indent = self.indent - 1
+        local tag = table.remove(self.elems)
+        self:line(("</%s>"):format(tag))
 end
 


### PR DESCRIPTION
## Summary
- modernize fxmanifest and enable Lua 5.4
- add robust XML builder utilities with detailed documentation
- refactor schema and handling builders with improved error handling and metadata loading

## Testing
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_builders/xml.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_builders/schema.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_builders/handling_builder.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c203337a44832db9e2f35bef394d75