### PR TITLE
refactor: modernize fsn_ems

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/beds/client.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/beds/client.lua
@@ -60,6 +60,7 @@ AddEventHandler('fsn_ems:bed:update', function(bedid, bed)
 	--print('fsn_ems:bed Bed update for ('..bedid..') ['..tostring(bed)..']')
 end)
 
+
 function fsn_drawText3D(x,y,z, text,r,g,b)
     local onScreen,_x,_y=World3dToScreen2d(x,y,z)
     local px,py,pz=table.unpack(GetGameplayCamCoords())
@@ -79,9 +80,9 @@ function fsn_drawText3D(x,y,z, text,r,g,b)
     end
 end
 
-Citizen.CreateThread(function()
+CreateThread(function()
 	while true do
-		Citizen.Wait(10000)
+		Wait(10000)
 		if inbed then
 			local newhealth =GetEntityHealth(PlayerPedId())+10 
 			if newhealth >= 200 then
@@ -98,7 +99,7 @@ Citizen.CreateThread(function()
 	end
 end)
 
-Citizen.CreateThread(function()
+CreateThread(function()
 	local blip = AddBlipForCoord(296.18298339844,-584.42895507813,42.720436096191)
 	SetBlipSprite(blip, 80)
 	BeginTextCommandSetBlipName("STRING")
@@ -106,7 +107,7 @@ Citizen.CreateThread(function()
 	EndTextCommandSetBlipName(blip)
 	SetBlipAsShortRange(blip, true)
 	while true do
-	Citizen.Wait(0)
+	Wait(0)
 		if inbed then
 			if beds[mybed].occupied[3] then
 				fsn_drawText3D(beds[mybed].enter.x, beds[mybed].enter.y, beds[mybed].enter.z-0.3, "You are restrained to the bed.", 255, 0, 0)
@@ -115,11 +116,11 @@ Citizen.CreateThread(function()
 				if IsControlJustPressed(0, 51) then
 					TriggerServerEvent('fsn_ems:bed:occupy', mybed)
 					DoScreenFadeOut(1000)
-					Citizen.Wait(1010)
+					Wait(1010)
 					SetEntityCoords(PlayerPedId(), beds[mybed].enter.x, beds[mybed].enter.y, beds[mybed].enter.z)
 					inbed = false
 					mybed = 0
-					Citizen.Wait(1500)
+					Wait(1500)
 					DoScreenFadeIn(2000)
 				end
 			end
@@ -143,13 +144,13 @@ Citizen.CreateThread(function()
 									TriggerEvent('fsn_ems:reviveMe')
 								end
 								DoScreenFadeOut(1000)
-								Citizen.Wait(1010)
+								Wait(1010)
 								SetEntityCoords(PlayerPedId(), v.bed.x, v.bed.y, v.bed.z)
 								SetEntityHeading(PlayerPedId(), v.bed.h)
 								ExecuteCommand("e sleep")
 								inbed = true
 								mybed = k
-								Citizen.Wait(1500)
+								Wait(1500)
 								DoScreenFadeIn(2000)
 							end
 						end
@@ -176,7 +177,7 @@ Citizen.CreateThread(function()
 								if IsControlJustPressed(0, 51) then
 									while not HasAnimDictLoaded('mp_arresting') do
 										RequestAnimDict('mp_arresting')
-										Citizen.Wait(5)
+										Wait(5)
 									end
 									TaskPlayAnim(PlayerPedId(), 'mp_arresting', 'a_arrest_on_floor', 8.0, 1.0, -1, 16, 0, 0, 0, 0)
 									TriggerServerEvent('fsn_ems:bed:restraintoggle', k)
@@ -186,7 +187,7 @@ Citizen.CreateThread(function()
 								if IsControlJustPressed(0, 51) then
 									while not HasAnimDictLoaded('mp_arresting') do
 										RequestAnimDict('mp_arresting')
-										Citizen.Wait(5)
+										Wait(5)
 									end
 									TaskPlayAnim(PlayerPedId(), 'mp_arresting', 'a_arrest_on_floor', 8.0, 1.0, -1, 16, 0, 0, 0, 0)
 									TriggerServerEvent('fsn_ems:bed:restraintoggle', k)
@@ -208,13 +209,13 @@ Citizen.CreateThread(function()
 								TriggerEvent('fsn_ems:reviveMe')
 							end
 							DoScreenFadeOut(1000)
-							Citizen.Wait(1010)
+							Wait(1010)
 							SetEntityCoords(PlayerPedId(), v.bed.x, v.bed.y, v.bed.z)
 							SetEntityHeading(PlayerPedId(), v.bed.h)
 							ExecuteCommand("e sleep")
 							inbed = true
 							mybed = k
-							Citizen.Wait(1500)
+							Wait(1500)
 							DoScreenFadeIn(2000)
 						end
 					end

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/beds/server.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/beds/server.lua
@@ -51,30 +51,25 @@ local beds = {
 	},
 }
 
-RegisterNetEvent('fsn_ems:bed:occupy')
-RegisterNetEvent('fsn_ems:bed:leave')
-RegisterNetEvent('fsn_ems:bed:restraintoggle')
-RegisterNetEvent('fsn_ems:bed:health')
-
-AddEventHandler('fsn_ems:bed:health', function(bed, current, maximum)
-	beds[bed].occupied[4][1] = current
-	beds[bed].occupied[4][2] = maximum
-	TriggerClientEvent('fsn_ems:bed:update', -1, bed, beds[bed])
+RegisterNetEvent('fsn_ems:bed:health', function(bed, current, maximum)
+    beds[bed].occupied[4][1] = current
+    beds[bed].occupied[4][2] = maximum
+    TriggerClientEvent('fsn_ems:bed:update', -1, bed, beds[bed])
 end)
 
-AddEventHandler('fsn_ems:bed:restraintoggle', function(bed)
-	beds[bed].occupied[3] = not beds[bed].occupied[3]
-	TriggerClientEvent('fsn_ems:bed:update', -1, bed, beds[bed])
+RegisterNetEvent('fsn_ems:bed:restraintoggle', function(bed)
+    beds[bed].occupied[3] = not beds[bed].occupied[3]
+    TriggerClientEvent('fsn_ems:bed:update', -1, bed, beds[bed])
 end)
 
-AddEventHandler('fsn_ems:bed:occupy', function(bed)
-	beds[bed].occupied[1] = not beds[bed].occupied[1]
-	beds[bed].occupied[2] = source
-	TriggerClientEvent('fsn_ems:bed:update', -1, bed, beds[bed])
+RegisterNetEvent('fsn_ems:bed:occupy', function(bed)
+    beds[bed].occupied[1] = not beds[bed].occupied[1]
+    beds[bed].occupied[2] = source
+    TriggerClientEvent('fsn_ems:bed:update', -1, bed, beds[bed])
 end)
 
-AddEventHandler('fsn_ems:bed:leave', function(bed)
-	beds[bed].occupied[1] = not beds[bed].occupied[1]
-	beds[bed].occupied[2] = 0
-	TriggerClientEvent('fsn_ems:bed:update', -1, bed, beds[bed])
+RegisterNetEvent('fsn_ems:bed:leave', function(bed)
+    beds[bed].occupied[1] = not beds[bed].occupied[1]
+    beds[bed].occupied[2] = 0
+    TriggerClientEvent('fsn_ems:bed:update', -1, bed, beds[bed])
 end)

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/blip.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/blip.lua
@@ -4,17 +4,17 @@ local blips = {
      {title="Care Center", colour=4, id=80, x = -254.430, y = 6320.478, z = 37.617}
   }
       
-Citizen.CreateThread(function()
-
+CreateThread(function()
     for _, info in pairs(blips) do
-      info.blip = AddBlipForCoord(info.x, info.y, info.z)
-      SetBlipSprite(info.blip, info.id)
-      SetBlipDisplay(info.blip, 4)
-      SetBlipScale(info.blip, 1.0)
-      SetBlipColour(info.blip, info.colour)
-      SetBlipAsShortRange(info.blip, true)
-	  BeginTextCommandSetBlipName("STRING")
-      AddTextComponentString(info.title)
-      EndTextCommandSetBlipName(info.blip)
+        local blip = AddBlipForCoord(info.x, info.y, info.z)
+        SetBlipSprite(blip, info.id)
+        SetBlipDisplay(blip, 4)
+        SetBlipScale(blip, 1.0)
+        SetBlipColour(blip, info.colour)
+        SetBlipAsShortRange(blip, true)
+        BeginTextCommandSetBlipName('STRING')
+        AddTextComponentString(info.title)
+        EndTextCommandSetBlipName(blip)
     end
 end)
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/cl_advanceddamage.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/cl_advanceddamage.lua
@@ -7,6 +7,7 @@ RegisterNetEvent('fsn_ems:ad:stopBleeding')
 AddEventHandler('fsn_ems:ad:stopBleeding', function()
 	isBleeding = false
 end)
+
 local advanceBleedTimer = 0
 local blackoutTimer = 0
 
@@ -343,7 +344,7 @@ AddEventHandler('fsn_ems:set:WalkType', function(wt)
 	if currentwalktype ~= 0 then
 		RequestAnimSet(currentwalktype)
 		while not HasAnimSetLoaded(currentwalktype) do
-			Citizen.Wait(0)
+			Wait(0)
 			print('loading animset: '..currentwalktype)
 		end
 		SetPedMovementClipset(PlayerPedId(), currentwalktype, true)
@@ -356,8 +357,8 @@ local crouching = false
 function isCrouching()
 	return crouching 
 end
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
+CreateThread(function()
+	while true do Wait(0)
 		if IsControlJustPressed(0, 36) then
 			if crouching then
 				ResetPedMovementClipset(PlayerPedId(), 0, 0)
@@ -365,7 +366,7 @@ Citizen.CreateThread(function()
 				if not HasAnimSetLoaded( "move_ped_crouched" ) then
 					RequestAnimSet( "move_ped_crouched" )
 					while ( not HasAnimSetLoaded( "move_ped_crouched" ) ) do
-						Citizen.Wait(0)
+						Wait(0)
 						print('loading clipset: move_ped_crouched')
 					end
 				end
@@ -379,13 +380,13 @@ function ProcessRunStuff(ped)
     if IsInjuryCausingLimp() and not (onPainKiller > 0)  then
         RequestAnimSet("move_m@injured")
         while not HasAnimSetLoaded("move_m@injured") do
-            Citizen.Wait(0)
+            Wait(0)
         end
 		if crouching then
 			if not HasAnimSetLoaded( "move_ped_crouched" ) then
 				RequestAnimSet( "move_ped_crouched" )
 				while ( not HasAnimSetLoaded( "move_ped_crouched" ) ) do
-					Citizen.Wait(0)
+					Wait(0)
 					print('loading clipset: move_ped_crouched')
 				end
 			end
@@ -416,7 +417,7 @@ function ProcessRunStuff(ped)
 			if not HasAnimSetLoaded( "move_ped_crouched" ) then
 				RequestAnimSet( "move_ped_crouched" )
 				while ( not HasAnimSetLoaded( "move_ped_crouched" ) ) do
-					Citizen.Wait(0)
+					Wait(0)
 					print('loading clipset: move_ped_crouched')
 				end
 			end
@@ -426,7 +427,7 @@ function ProcessRunStuff(ped)
 				if not HasAnimSetLoaded(currentwalktype) then
 					RequestAnimSet(currentwalktype)
 					while not HasAnimSetLoaded(currentwalktype) do
-						Citizen.Wait(0)
+						Wait(0)
 						print('loading animset: '..currentwalktype)
 					end
 				end
@@ -491,7 +492,7 @@ function ProcessDamage(ped)
                         
                         DoScreenFadeOut(100)
                         while not IsScreenFadedOut() do
-                            Citizen.Wait(0)
+                            Wait(0)
                         end
 
                         if not IsPedRagdoll(ped) and IsPedOnFoot(ped) and not IsPedSwimming(ped) then
@@ -499,7 +500,7 @@ function ProcessDamage(ped)
                             SetPedToRagdoll(ped, 5000, 1, 2)
                         end
 
-                        Citizen.Wait(5000)
+                        Wait(5000)
                         DoScreenFadeIn(250)
                     end
                     headCount = 0
@@ -664,7 +665,7 @@ AddEventHandler('mythic_hospital:client:UseAdrenaline', function(tier)
 	TriggerEvent('fsn_evidence:ped:updateDamage', BodyParts)
 end)  
     
-Citizen.CreateThread(function()
+CreateThread(function()
     local player = PlayerPedId()
 	while true do
 		if not IsEntityDead(player) and not (#injured == 0) then
@@ -693,7 +694,7 @@ Citizen.CreateThread(function()
 						
 					DoScreenFadeOut(500)
 					while not IsScreenFadedOut() do
-						Citizen.Wait(0)
+						Wait(0)
 					end
 			
 					if not IsPedRagdoll(player) and IsPedOnFoot(player) and not IsPedSwimming(player) then
@@ -701,7 +702,7 @@ Citizen.CreateThread(function()
 						SetPedToRagdollWithFall(PlayerPedId(), 10000, 12000, 1, GetEntityForwardVector(player), 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 					end
 			
-					Citizen.Wait(5000)
+					Wait(5000)
 					DoScreenFadeIn(500)
 					blackoutTimer = 0
 				end
@@ -740,11 +741,11 @@ Citizen.CreateThread(function()
 			end
 		end
 
-		Citizen.Wait(30000)
+		Wait(30000)
 	end
 end)
 
-Citizen.CreateThread(function()
+CreateThread(function()
     local player = PlayerPedId()
     
     while true do
@@ -791,12 +792,12 @@ Citizen.CreateThread(function()
 
         playerHealth = health
         playerArmour = armour
-        Citizen.Wait(333)
+        Wait(333)
 
 		ProcessRunStuff(player)
-		Citizen.Wait(333)
+		Wait(333)
 
 		ProcessDamage(player)
-		Citizen.Wait(333)
+		Wait(333)
 	end
 end)

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/cl_carrydead.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/cl_carrydead.lua
@@ -13,7 +13,7 @@ carried_id = false
 function loadAnim( dict )
     while ( not HasAnimDictLoaded( dict ) ) do
         RequestAnimDict( dict )
-        Citizen.Wait( 5 )
+        Wait( 5 )
     end
 end
 
@@ -49,8 +49,8 @@ AddEventHandler('fsn_ems:carry:end', function(carryingid)
 	SetPedCanRagdoll(PlayerPedId(), true)
 end)
 
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
+CreateThread(function()
+	while true do Wait(0)
 		if carried then 
 			local ped = GetPlayerPed(GetPlayerFromServerId(carried_id))
 			loadAnim( "amb@world_human_bum_slumped@male@laying_on_left_side@base" ) 
@@ -67,10 +67,10 @@ Citizen.CreateThread(function()
 	end
 end)
 
-DecorRegister("fsn_ems:dead")
+DecorRegister("fsn_ems:dead", 2)
 DecorSetBool(PlayerPedId(), "fsn_ems:dead", false)
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
+CreateThread(function()
+	while true do Wait(0)
 		if fsn_IsDead() then
 			DecorSetBool(PlayerPedId(), "fsn_ems:dead", true)
 		else
@@ -117,3 +117,4 @@ end)
 
 -- other shit
 DetachEntity(PlayerPedId())
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/cl_volunteering.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/cl_volunteering.lua
@@ -3,19 +3,17 @@ local volunteer_ems = {}
 
 local whitelisted = true
 
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
-		if GetDistanceBetweenCoords(volspot.x,volspot.y,volspot.z,GetEntityCoords(PlayerPedId()),false) < 10 then
-			DrawMarker(25,volspot.x, volspot.y, volspot.z - 0.95, 0, 0, 0, 0, 0, 0, 1.0, 1.0, 1.0, 255, 255, 255, 150, 0, 0, 2, 0, 0, 0, 0)
-			if GetDistanceBetweenCoords(volspot.x,volspot.y,volspot.z,GetEntityCoords(PlayerPedId()),false) < 1 then
-				Util.DrawText3D(volspot.x, volspot.y, volspot.z, '[E] ~g~Volunteer~w~ as ~r~EMS', {255,255,255,200}, 0.25)
-			
-				if #volunteer_ems < 4 then
-					
-				else
-				
-				end
-			end
-		end
-	end
+CreateThread(function()
+    while true do
+        Wait(0)
+        if GetDistanceBetweenCoords(volspot.x, volspot.y, volspot.z, GetEntityCoords(PlayerPedId()), false) < 10 then
+            DrawMarker(25, volspot.x, volspot.y, volspot.z - 0.95, 0, 0, 0, 0, 0, 0, 1.0, 1.0, 1.0, 255, 255, 255, 150, 0, 0, 2, 0, 0, 0, 0)
+            if GetDistanceBetweenCoords(volspot.x, volspot.y, volspot.z, GetEntityCoords(PlayerPedId()), false) < 1 then
+                Util.DrawText3D(volspot.x, volspot.y, volspot.z, '[E] ~g~Volunteer~w~ as ~r~EMS', {255,255,255,200}, 0.25)
+                if #volunteer_ems < 4 then
+                    -- Placeholder for volunteer interaction
+                end
+            end
+        end
+    end
 end)

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/client.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/client.lua
@@ -21,9 +21,9 @@ function drawTxt(text,font,centre,x,y,scale,r,g,b,a)
   DrawText(x , y)
 end
 
-Citizen.CreateThread(function()
+CreateThread(function()
   while true do
-    Citizen.Wait(0)
+    Wait(0)
     if IsEntityDead(PlayerPedId()) then
       SetEntityHealth(PlayerPedId(), 150)
       TriggerEvent('fsn_ems:killMe')
@@ -31,7 +31,7 @@ Citizen.CreateThread(function()
   end
 end)
 
-currenttime = 0
+local currenttime = 0
 local deathtime = currenttime
 local amidead = false
 local canRespawn = false
@@ -72,7 +72,7 @@ AddEventHandler('fsn_ems:reviveMe', function()
 end)
 
 
-DecorRegister("deadPly")
+DecorRegister("deadPly", 2)
 RegisterNetEvent('fsn_ems:killMe')
 AddEventHandler('fsn_ems:killMe', function()
   if not amidead then
@@ -105,9 +105,9 @@ AddEventHandler('fsn_ems:killMe', function()
 end)
 
 -- thread to check if im dead
-Citizen.CreateThread(function()
+CreateThread(function()
   while true do
-    Citizen.Wait(0)
+    Wait(0)
     if amidead then
       SetPedToRagdoll(PlayerPedId(), 1, 1000, 0, 0, 0, 0)
       local def = deathtime + 300
@@ -130,9 +130,9 @@ Citizen.CreateThread(function()
 end)
 
 -- thread to check if im dead
-Citizen.CreateThread(function()
+CreateThread(function()
   while true do
-    Citizen.Wait(1000)
+    Wait(1000)
     currenttime = currenttime + 1
   end
 end)
@@ -159,7 +159,7 @@ function fsn_Airlift()
     TriggerEvent('fsn_needs:stress:remove', 100)
     TriggerEvent('mythic_hospital:client:ResetLimbs') -- reset limbs/limp
     TriggerEvent('mythic_hospital:client:RemoveBleed') -- remove bleed
-    Citizen.Wait(2000)
+    Wait(2000)
     DoScreenFadeIn(1500)
     ClearPedBloodDamage(PlayerPedId())
     if #onduty_ems > 0 then
@@ -235,9 +235,9 @@ local clockInStations = {
 {x = 1191.9343261719, y = -1474.7747802734, z = 34.859516143799},
 {x = 310.27493286133, y = -599.16485595703, z = 43.291816711426}
 }
-Citizen.CreateThread(function()
+CreateThread(function()
   while true do
-    Citizen.Wait(0)
+    Wait(0)
 	SetPlayerHealthRechargeMultiplier(PlayerId(), 0.0)
     for k, hosp in pairs(clockInStations) do
       if GetDistanceBetweenCoords(hosp.x,hosp.y,hosp.z,GetEntityCoords(PlayerPedId()), true) < 10 and amiems then
@@ -276,37 +276,37 @@ local disp_id = 0
 local last_disp = 0
 RegisterNetEvent('fsn_jobs:ems:request')
 AddEventHandler('fsn_jobs:ems:request', function(tbl)
+  local x, y, z = tbl.x, tbl.y, tbl.z
   if exports.fsn_police:fsn_PDDuty() then
     if #onduty_ems < 2 then
       TriggerEvent('fsn_police:dispatchcall', tbl, 9)
     end
-    local var1, var2 = GetStreetNameAtCoord(x, y, z, Citizen.ResultAsInteger(), Citizen.ResultAsInteger())
-    local sname = GetStreetNameFromHashKey(var1)
+    local streetHash = GetStreetNameAtCoord(x, y, z)
+    local sname = GetStreetNameFromHashKey(streetHash)
     TriggerEvent('chatMessage', '', {255,255,255}, '^1^*:DISPATCH:^0^r (10-47) EMS requested @ ^4'..sname)
   end
   if emsonduty then
-    local x = tbl.x
-    local y = tbl.y
-    local var1, var2 = GetStreetNameAtCoord(x, y, z, Citizen.ResultAsInteger(), Citizen.ResultAsInteger())
-    local sname = GetStreetNameFromHashKey(var1)
+    local streetHash = GetStreetNameAtCoord(x, y, z)
+    local sname = GetStreetNameFromHashKey(streetHash)
     TriggerEvent('chatMessage', '', {255,255,255}, '^1^*:DISPATCH:^0^r (10-47) EMS requested @ ^4'..sname)
-    disp_id = #dispatch_calls+1
+    disp_id = #dispatch_calls + 1
     last_disp = currenttime
     table.insert(dispatch_calls, disp_id, {
       type = 'ems call',
       cx = x,
-      cy = y
+      cy = y,
+      cz = z
     })
-    SetNotificationTextEntry("STRING");
-    AddTextComponentString('Location: ~y~'..sname);
-    SetNotificationMessage("CHAR_DEFAULT", "CHAR_DEFAULT", true, 1, "DISPATCH", "");
-    DrawNotification(false, true);
-	TriggerEvent("fsn_main:blip:add", "ems", "ALERT: EMS Request", 310, x, y, z)
+    SetNotificationTextEntry("STRING")
+    AddTextComponentString('Location: ~y~'..sname)
+    SetNotificationMessage("CHAR_DEFAULT", "CHAR_DEFAULT", true, 1, "DISPATCH", "")
+    DrawNotification(false, true)
+    TriggerEvent("fsn_main:blip:add", "ems", "ALERT: EMS Request", 310, x, y, z)
   end
 end)
-Citizen.CreateThread(function()
+CreateThread(function()
    while true do
-     Citizen.Wait(0)
+     Wait(0)
      if disp_id ~= 0 then
        if last_disp + 10 > currenttime then
          SetTextComponentFormat("STRING")
@@ -334,9 +334,9 @@ local hospitals = {
 }
 local healing = false
 local healstart = 0
-Citizen.CreateThread(function()
+CreateThread(function()
   while true do
-    Citizen.Wait(0)
+    Wait(0)
     for k, hosp in pairs(hospitals) do
       if GetDistanceBetweenCoords(hosp.x,hosp.y,hosp.z,GetEntityCoords(PlayerPedId()), true) < 10 and not healing then
         DrawMarker(1,hosp.x,hosp.y,hosp.z-1,0,0,0,0,0,0,1.001,1.0001,0.4001,0,155,255,175,0,0,0,0)
@@ -364,21 +364,21 @@ Citizen.CreateThread(function()
   end
 end)
 
-Citizen.CreateThread(function()
+CreateThread(function()
   while true do
-    Citizen.Wait(0)
+    Wait(0)
 	if pulsing then
 		DoScreenFadeOut(1000)
-		Citizen.Wait(1500)
+		Wait(1500)
 		DoScreenFadeIn(1000)
-		Citizen.Wait(20000)
+		Wait(20000)
 	end
   end
 end)
 
-Citizen.CreateThread(function()
+CreateThread(function()
   while true do
-    Citizen.Wait(0)
+    Wait(0)
 	SetPlayerHealthRechargeMultiplier(PlayerId(), 0.0)
 	if GetEntityHealth(PlayerPedId()) < 130 then
 		if not bandw then

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/debug_kng.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/debug_kng.lua
@@ -1,15 +1,19 @@
-local realWait = Citizen.Wait
+local realWait = Wait
 
-function newWait(msec)
-    local info = debug.getinfo(2,"nSl")
+local function debugWait(msec)
+    local info = debug.getinfo(2, 'nSl')
     local msg = ("%s:%d (%s[%d-%d])"):format(
-        info.source, info.currentline, info.name,
-        info.linedefined, info.lastlinedefined
+        info.source,
+        info.currentline,
+        info.name,
+        info.linedefined,
+        info.lastlinedefined
     )
-    print("Yielding @ "..msg)
+    print("Yielding @ " .. msg)
     realWait(msec)
-    print("Resuming @ "..msg)
+    print("Resuming @ " .. msg)
 end
 
-Citizen.Wait = newWait
-Wait = newWait
+Wait = debugWait
+Citizen.Wait = debugWait
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/fxmanifest.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/fxmanifest.lua
@@ -1,31 +1,39 @@
---[[/	:FSN:	\]]--
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'gta5'
 
-client_script '@fsn_main/cl_utils.lua'
-server_script '@fsn_main/sv_utils.lua'
-client_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@mysql-async/lib/MySQL.lua'
---[[/	:FSN:	\]]--
+lua54 'yes'
 
-client_script 'client.lua'
-client_script 'cl_advanceddamage.lua'
-client_script 'cl_volunteering.lua'
-client_script 'cl_carrydead.lua'
-client_script 'beds/client.lua'
-client_script 'blip.lua'
+shared_scripts {
+    '@fsn_main/server_settings/sh_settings.lua'
+}
 
-server_script 'server.lua'
-server_script 'sv_carrydead.lua'
-server_script 'beds/server.lua'
+client_scripts {
+    '@fsn_main/cl_utils.lua',
+    'client.lua',
+    'cl_advanceddamage.lua',
+    'cl_volunteering.lua',
+    'cl_carrydead.lua',
+    'beds/client.lua',
+    'blip.lua'
+}
 
-exports({
-  'fsn_IsDead',
-  'fsn_EMSDuty',
-  'fsn_getEMSLevel',
-  'fsn_Airlift',
-  'ems_isBleeding',
-  'isCrouching',
-  'carryingWho'
-})
+server_scripts {
+    '@fsn_main/sv_utils.lua',
+    '@mysql-async/lib/MySQL.lua',
+    'server.lua',
+    'sv_carrydead.lua',
+    'beds/server.lua'
+}
+
+client_exports {
+    'fsn_IsDead',
+    'fsn_EMSDuty',
+    'fsn_getEMSLevel',
+    'fsn_Airlift',
+    'ems_isBleeding',
+    'isCrouching',
+    'carryingWho'
+}
+
+--[[/   :FSN:   \]]--
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/server.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/server.lua
@@ -1,41 +1,40 @@
- local onduty_ems = {}
+local ondutyEMS = {}
 
- RegisterServerEvent('fsn_ems:update')
- RegisterServerEvent('fsn_ems:onDuty')
- AddEventHandler('fsn_ems:onDuty', function(emslevel)
-   if emslevel > 2 then
-     table.insert(onduty_ems, {ply_id = source, ply_lvl = emslevel})
-     TriggerClientEvent('fsn_ems:update', -1, onduty_ems)
-     TriggerEvent('fsn_ems:update', onduty_ems)
-     print(':fsn_ems: '..source..' has clocked on duty at level '..emslevel)
-   else
-     print(':fsn_ems: '..source..' has clocked in as police, but is not high enough level to contribute.')
-   end
- end)
+RegisterNetEvent('fsn_ems:onDuty', function(level)
+    if level > 2 then
+        table.insert(ondutyEMS, {ply_id = source, ply_lvl = level})
+        TriggerClientEvent('fsn_ems:update', -1, ondutyEMS)
+        TriggerEvent('fsn_ems:update', ondutyEMS)
+        print((':fsn_ems: %s has clocked on duty at level %s'):format(source, level))
+    else
+        print((':fsn_ems: %s has clocked in as police, but is not high enough level to contribute.'):format(source))
+    end
+end)
 
- RegisterServerEvent('fsn_ems:offDuty')
- AddEventHandler('fsn_ems:offDuty', function()
-   for k, v in pairs(onduty_ems) do
-     if v.ply_id == source then
-       table.remove(onduty_ems, k)
-       print(':fsn_ems: '..source..' has clocked out.')
-     end
-   end
-   TriggerClientEvent('fsn_ems:update', -1, onduty_ems)
-   TriggerEvent('fsn_ems:update', onduty_ems)
- end)
+RegisterNetEvent('fsn_ems:offDuty', function()
+    for k, v in pairs(ondutyEMS) do
+        if v.ply_id == source then
+            table.remove(ondutyEMS, k)
+            print((':fsn_ems: %s has clocked out.'):format(source))
+            break
+        end
+    end
+    TriggerClientEvent('fsn_ems:update', -1, ondutyEMS)
+    TriggerEvent('fsn_ems:update', ondutyEMS)
+end)
 
- AddEventHandler('playerDropped', function()
-   for k, v in pairs(onduty_ems) do
-     if v.ply_id == source then
-       table.remove(onduty_ems, k)
-       print(':fsn_ems: '..source..' has clocked out and disconnected.')
-     end
-   end
-   TriggerClientEvent('fsn_ems:update', -1, onduty_ems)
- end)
+AddEventHandler('playerDropped', function()
+    for k, v in pairs(ondutyEMS) do
+        if v.ply_id == source then
+            table.remove(ondutyEMS, k)
+            print((':fsn_ems: %s has clocked out and disconnected.'):format(source))
+            break
+        end
+    end
+    TriggerClientEvent('fsn_ems:update', -1, ondutyEMS)
+end)
 
- RegisterServerEvent('fsn_ems:requestUpdate')
- AddEventHandler('fsn_ems:requestUpdate', function()
-   TriggerClientEvent('fsn_ems:update', source, onduty_ems)
- end)
+RegisterNetEvent('fsn_ems:requestUpdate', function()
+    TriggerClientEvent('fsn_ems:update', source, ondutyEMS)
+end)
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/sv_carrydead.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_ems/sv_carrydead.lua
@@ -1,21 +1,18 @@
-local carrycarried = {}
-RegisterServerEvent('fsn_ems:carry:start')
-AddEventHandler('fsn_ems:carry:start', function(deaded)
-	print(source..' is trying to carry '..deaded)
-	if carrycarried[source] or carrycarried[deaded] then return end -- already being carried/carrying
-	print('carrying')
-	carrycarried[source] = true
-	carrycarried[deaded] = true
-	TriggerClientEvent('fsn_ems:carry:start', source, deaded)
-	TriggerClientEvent('fsn_ems:carried:start', deaded, source)
+local carryState = {}
+
+RegisterNetEvent('fsn_ems:carry:start', function(target)
+    if carryState[source] or carryState[target] then return end
+    carryState[source] = true
+    carryState[target] = true
+    TriggerClientEvent('fsn_ems:carry:start', source, target)
+    TriggerClientEvent('fsn_ems:carried:start', target, source)
 end)
 
-RegisterServerEvent('fsn_ems:carry:end')
-AddEventHandler('fsn_ems:carry:end', function(deaded)
-	if not carrycarried[source] or not carrycarried[deaded] then return end -- not being carried/carrying
-	carrycarried[source] = nil
-	carrycarried[deaded] = nil
-	TriggerClientEvent('fsn_ems:carry:end', source, deaded)
-	TriggerClientEvent('fsn_ems:carried:end', deaded, source)
+RegisterNetEvent('fsn_ems:carry:end', function(target)
+    if not carryState[source] or not carryState[target] then return end
+    carryState[source] = nil
+    carryState[target] = nil
+    TriggerClientEvent('fsn_ems:carry:end', source, target)
+    TriggerClientEvent('fsn_ems:carried:end', target, source)
 end)
-print'ass'
+


### PR DESCRIPTION
## Summary
- modernize fxmanifest and exports
- refactor EMS scripts to use CreateThread/Wait and cleaned events
- fix EMS dispatch request coordinates and dead ped decor usage

## Testing
- `find Example_Frameworks/FiveM-FSN-Framework/fsn_ems -name "*.lua" ! -name "cl_advanceddamage.lua" -print0 | xargs -0 -n 1 luac -p`
- `find Example_Frameworks/FiveM-FSN-Framework/fsn_ems -name "*.lua" -print0 | xargs -0 -n 1 luac -p` *(fails: unexpected symbol near '`')*


------
https://chatgpt.com/codex/tasks/task_e_68c203ba5284832d870629e50499b6c2