### PR TITLE
refactor fsn_entfinder entity tracking

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_entfinder/fxmanifest.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_entfinder/fxmanifest.lua
@@ -1,20 +1,18 @@
---[[/	:FSN:	\]]--
-fx_version 'adamant'
+--[[/   :FSN:   \]]--
+fx_version 'cerulean'
 game 'gta5'
+lua54 'yes'
 
-client_script '@fsn_main/cl_utils.lua'
-server_script '@fsn_main/sv_utils.lua'
-client_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@mysql-async/lib/MySQL.lua'
---[[/	:FSN:	\]]--
+client_scripts {
+    '@fsn_main/cl_utils.lua',
+    '@fsn_main/server_settings/sh_settings.lua',
+    'client.lua'
+}
 
-client_script 'client.lua'
-
-exports({
+exports {
   'getVehicles',
   'getPeds',
   'getPickups',
   'getObjects',
   'getPedNearCoords'
-})
+}


### PR DESCRIPTION
## Summary
- refactor entity caching to use game pools and remove enumerator GC
- add nearest ped lookup and configurable object/pickup tracking
- modernize resource manifest and enable Lua 5.4

## Testing
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_entfinder/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c203c35cc4832d9ab684ed2566ab0d