### PR TITLE
Refactor FSN evidence resource

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/__descriptions.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/__descriptions.lua
@@ -1,95 +1,111 @@
 -- export for getting description of current clothing!
-local ped = PlayerPedId()
-local ready = false
 
+--[[
+    -- Type: Function
+    -- Name: getSex
+    -- Use: Determines the player's character sex based on model
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function getSex()
-	local sex = false
-	if GetEntityModel(ped) == GetHashKey('mp_m_freemode_01') then
-		sex = 'm'
-	elseif GetEntityModel(ped) == GetHashKey('mp_f_freemode_01') then
-		sex = 'f'
-	end
-	return sex
+    local ped = PlayerPedId()
+    local sex = false
+    if GetEntityModel(ped) == GetHashKey('mp_m_freemode_01') then
+        sex = 'm'
+    elseif GetEntityModel(ped) == GetHashKey('mp_f_freemode_01') then
+        sex = 'f'
+    end
+    return sex
 end
 
+--[[
+    -- Type: Function
+    -- Name: getJacket
+    -- Use: Retrieves localized jacket description
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function getJacket()
-	local sex = getSex()
-	local jacket = false
-	local comp = {
-		GetPedDrawableVariation(PlayerPedId(), 11),
-		GetPedTextureVariation(PlayerPedId(), 11),
-	}
+    local sex = getSex()
+    local jacket
+    local comp = {
+        GetPedDrawableVariation(PlayerPedId(), 11),
+        GetPedTextureVariation(PlayerPedId(), 11)
+    }
 
-	if sex then
-		if sex == 'm' then
-			--print(comp[1]..comp[2])
-			jacket = tostring(MALE.tops[tostring(comp[1])][tostring(comp[2])].Localized)
-		elseif sex == 'f' then
-			jacket = tostring(FEMALE.tops[tostring(comp[1])][tostring(comp[2])].Localized)
-		end
-	end
+    if sex then
+        if sex == 'm' then
+            jacket = tostring(MALE.tops[tostring(comp[1])][tostring(comp[2])].Localized)
+        elseif sex == 'f' then
+            jacket = tostring(FEMALE.tops[tostring(comp[1])][tostring(comp[2])].Localized)
+        end
+    end
 
-	if not jacket then jacket = "I can't remember" end
-	return jacket
+    return jacket or "I can't remember"
 end
 
+--[[
+    -- Type: Function
+    -- Name: getTop
+    -- Use: Retrieves localized undershirt description
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function getTop()
-	local sex = getSex()
-	local top = false
-	local comp = {
-		GetPedDrawableVariation(PlayerPedId(), 3),
-		GetPedTextureVariation(PlayerPedId(), 3),
-	}
+    local sex = getSex()
+    local top
+    local comp = {
+        GetPedDrawableVariation(PlayerPedId(), 3),
+        GetPedTextureVariation(PlayerPedId(), 3)
+    }
 
-	if sex then
-		if sex == 'm' then
-			--print(comp[1]..comp[2])
-			top = tostring(MALE.undershirts[tostring(comp[1])][tostring(comp[2])].Localized)
-		elseif sex == 'f' then
-			top = tostring(FEMALE.undershirts[tostring(comp[1])][tostring(comp[2])].Localized)
-		end
-	end
+    if sex then
+        if sex == 'm' then
+            top = tostring(MALE.undershirts[tostring(comp[1])][tostring(comp[2])].Localized)
+        elseif sex == 'f' then
+            top = tostring(FEMALE.undershirts[tostring(comp[1])][tostring(comp[2])].Localized)
+        end
+    end
 
-	if not top then top = "I can't remember" end
-	return top
+    return top or "I can't remember"
 end
 
+--[[
+    -- Type: Function
+    -- Name: getPants
+    -- Use: Retrieves localized pants description
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
 function getPants()
-	local sex = getSex()
-	local pants = false
-	local comp = {
-		GetPedDrawableVariation(PlayerPedId(), 3),
-		GetPedTextureVariation(PlayerPedId(), 3),
-	}
+    local sex = getSex()
+    local pants
+    local comp = {
+        GetPedDrawableVariation(PlayerPedId(), 4),
+        GetPedTextureVariation(PlayerPedId(), 4)
+    }
 
-	if sex then
-		if sex == 'm' then
-			--print(comp[1]..comp[2])
-			pants = tostring(MALE.pants[tostring(comp[1])][tostring(comp[2])].Localized)
-		elseif sex == 'f' then
-			pants = tostring(FEMALE.pants[tostring(comp[1])][tostring(comp[2])].Localized)
-		end
-	end
+    if sex then
+        if sex == 'm' then
+            pants = tostring(MALE.pants[tostring(comp[1])][tostring(comp[2])].Localized)
+        elseif sex == 'f' then
+            pants = tostring(FEMALE.pants[tostring(comp[1])][tostring(comp[2])].Localized)
+        end
+    end
 
-	if not pants then pants = "I can't remember" end
-	return pants
+    return pants or "I can't remember"
 end
 
-Citizen.CreateThread(function()
-	while not MALE.tops do
-		Citizen.Wait(1)
-	end
-	ready = true
+CreateThread(function()
+    while not MALE.tops do
+        Wait(1)
+    end
 end)
 
 RegisterCommand('evi_clothing', function()
-	local sex = "Sex: "..getSex()
-	local jacket = "Jacket: "..getJacket()
-	local top = "Top: "..getTop()
-	local pants = "Pants: "..getPants()
-
-	print(sex)
-	print(jacket)
-	print(top)
-	print(pants)
+    print("Sex: "..getSex())
+    print("Jacket: "..getJacket())
+    print("Top: "..getTop())
+    print("Pants: "..getPants())
 end)
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/casings/cl_casings.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/casings/cl_casings.lua
@@ -1,30 +1,28 @@
-local wep
+local currentWeapon
 
-RegisterNetEvent('fsn_evidence:weaponInfo')
-AddEventHandler('fsn_evidence:weaponInfo', function(weapon)
-	if weapon ~= nil then
-		wep = weapon
-	end
+--[[
+    -- Type: Event Handler
+    -- Name: fsn_evidence:weaponInfo
+    -- Use: Stores weapon information for casing drops
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_evidence:weaponInfo', function(weapon)
+    if weapon then
+        currentWeapon = weapon
+    end
 end)
 
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
-		if IsPedShooting(PlayerPedId()) and exports["fsn_criminalmisc"]:HoldingWeapon() and not exports["fsn_police"]:fsn_PDDuty() then
-			--print(wep)
-			local pos = GetEntityCoords(PlayerPedId())
-			local coords = {
-			 x = pos.x,
-			 y = pos.y,
-			 z = pos.z
-			}
-			if wep ~= nil then
-				TriggerServerEvent('fsn_evidence:drop:casing',wep,pos)
-			end
-			if wep.isAuto then
-				Citizen.Wait(500)
-			else
-				Citizen.Wait(1000)
-			end
-		end
-	end
+CreateThread(function()
+    while true do
+        Wait(0)
+        if IsPedShooting(PlayerPedId()) and exports['fsn_criminalmisc']:HoldingWeapon() and not exports['fsn_police']:fsn_PDDuty() then
+            local pos = GetEntityCoords(PlayerPedId())
+            if currentWeapon then
+                TriggerServerEvent('fsn_evidence:drop:casing', currentWeapon, pos)
+            end
+            Wait(currentWeapon and currentWeapon.isAuto and 500 or 1000)
+        end
+    end
 end)
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/cl_evidence.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/cl_evidence.lua
@@ -1,142 +1,151 @@
 local evidence = {}
-RegisterNetEvent('fsn_evidence:receive')
-AddEventHandler('fsn_evidence:receive', function(tbl)
-	evidence = tbl
+
+--[[
+    -- Type: Event Handler
+    -- Name: fsn_evidence:receive
+    -- Use: Updates local evidence list from the server
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_evidence:receive', function(tbl)
+    evidence = tbl
 end)
 
-local collecting = false
-local destroying = false
-local id = 0
-local start = 0
-local tiime = 4000
+local collecting, destroying = false, false
+local actionId, actionStart = 0, 0
+local actionDuration = 4000
+
 Util.Tick(function()
-	if collecting then
-		if start + tiime < GetGameTimer() then
-			TriggerServerEvent('fsn_evidence:collect', id)
-			start = 0
-			FreezeEntityPosition(PlayerPedId(),false)
-			ClearPedTasks(PlayerPedId())
-			collecting = false
-		else
-			FreezeEntityPosition(PlayerPedId(),true)
-		
-		end
-	elseif destroying then
-		if start + tiime < GetGameTimer() then
-			TriggerServerEvent('fsn_evidence:destroy', id)
-			start = 0
-			FreezeEntityPosition(PlayerPedId(),false)
-			ClearPedTasks(PlayerPedId())
-			destroying = false
-		else
-			FreezeEntityPosition(PlayerPedId(),true)
-			
-			local dict = 'weapons@first_person@aim_rng@generic@projectile@thermal_charge@'
-			local anim = 'plant_floor'
-			if not HasAnimDictLoaded(dict) then
-				RequestAnimDict(dict)
-				while not HasAnimDictLoaded(dict) do
-					Wait(0)
-				end
-			end
-			if not IsEntityPlayingAnim(PlayerPedId(), dict, anim, 3) and not IsPedRagdoll(PlayerPedId()) then
-				TaskPlayAnim(PlayerPedId(), dict, anim, 8.0, 1.0, -1, 49, 1.0, 0, 0, 0)
-			end
-		end
-	end
+    local ped = PlayerPedId()
+    if collecting then
+        if actionStart + actionDuration < GetGameTimer() then
+            TriggerServerEvent('fsn_evidence:collect', actionId)
+            actionStart = 0
+            FreezeEntityPosition(ped, false)
+            ClearPedTasks(ped)
+            collecting = false
+        else
+            FreezeEntityPosition(ped, true)
+        end
+    elseif destroying then
+        if actionStart + actionDuration < GetGameTimer() then
+            TriggerServerEvent('fsn_evidence:destroy', actionId)
+            actionStart = 0
+            FreezeEntityPosition(ped, false)
+            ClearPedTasks(ped)
+            destroying = false
+        else
+            FreezeEntityPosition(ped, true)
+
+            local dict = 'weapons@first_person@aim_rng@generic@projectile@thermal_charge@'
+            local anim = 'plant_floor'
+            if not HasAnimDictLoaded(dict) then
+                RequestAnimDict(dict)
+                while not HasAnimDictLoaded(dict) do
+                    Wait(0)
+                end
+            end
+            if not IsEntityPlayingAnim(ped, dict, anim, 3) and not IsPedRagdoll(ped) then
+                TaskPlayAnim(ped, dict, anim, 8.0, 1.0, -1, 49, 1.0, false, false, false)
+            end
+        end
+    end
 end)
 
 local displaying = false
-RegisterNetEvent('fsn_evidence:display')
-AddEventHandler('fsn_evidence:display', function(tbl)
-	displaying = tbl
+
+--[[
+    -- Type: Event Handler
+    -- Name: fsn_evidence:display
+    -- Use: Displays evidence details on screen
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_evidence:display', function(tbl)
+    displaying = tbl
 end)
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
-		if displaying then
-			if displaying.e_type == 'blood' then
-				Util.DrawText3D(displaying.loc.x, displaying.loc.y, displaying.loc.z, '~r~Blood~w~\nDNA MARKUP: '..displaying.details.dnastring..'\n\n[LALT+E] Close', {255,255,255,240}, 0.25)
-			end
-			if displaying.e_type == 'casing' then
-				Util.DrawText3D(displaying.loc.x, displaying.loc.y, displaying.loc.z, '~r~'..displaying.details.ammoType..' Casing~w~\nMarking: '..displaying.details.serial..'\n\n[LALT+E] Close', {255,255,255,240}, 0.25)
-			end
-			if IsControlPressed(0, 19) then
-				if IsControlJustPressed(0, 38) then
-					displaying = false
-				end
-			end
-		end
-		for k, e in ipairs(evidence) do
-			if e.e_type == 'blood' then
-				if e.loc and GetDistanceBetweenCoords(e.loc.x, e.loc.y, e.loc.z, GetEntityCoords(PlayerPedId()), true) < 50 then
-					DrawMarker(25,e.loc.x, e.loc.y, e.loc.z - 0.95, 0, 0, 0, 0, 0, 0, 0.2, 0.2, 0.2, 255, 255, 255, 150, 0, 0, 2, 0, 0, 0, 0)
-					if GetDistanceBetweenCoords(e.loc.x, e.loc.y, e.loc.z, GetEntityCoords(PlayerPedId()), false) < 0.5 then
-						if not exports["fsn_ems"]:isCrouching() then
-							Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Crouch to interact', {255,255,255,50}, 0.2)
-						else
-							if collecting or destroying then
-								Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Blood~w~\nWorking...', {255,255,255,240}, 0.2)
-							else
-								if exports["fsn_police"]:fsn_PDDuty() then
-									Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Blood\n[LALT+E] Collect', {255,255,255,100}, 0.2)
-									if IsControlPressed(0, 19) then
-										if IsControlJustPressed(0, 38) then
-											collecting = true
-											id = k
-											start = GetGameTimer()
-										end
-									end
-								else
-									Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Blood~w~\n[LALT+E] Destroy', {255,255,255,100}, 0.2)
-									if IsControlPressed(0, 19) then
-										if IsControlJustPressed(0, 38) then
-											destroying = true
-											id = k
-											start = GetGameTimer()
-										end
-									end
-								end
-							end
-						end
-					end
-				end
-			end
-			if e.e_type == 'casing' then
-				if GetDistanceBetweenCoords(e.loc.x, e.loc.y, e.loc.z, GetEntityCoords(PlayerPedId()), true) < 50 then
-					DrawMarker(25,e.loc.x, e.loc.y, e.loc.z - 0.95, 0, 0, 0, 0, 0, 0, 0.2, 0.2, 0.2, 255, 255, 255, 150, 0, 0, 2, 0, 0, 0, 0)
-					if GetDistanceBetweenCoords(e.loc.x, e.loc.y, e.loc.z, GetEntityCoords(PlayerPedId()), false) < 0.5 then
-						if not exports["fsn_ems"]:isCrouching() then
-							Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Crouch to interact', {255,255,255,50}, 0.2)
-						else
-							if collecting or destroying then
-								Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~'..e.details.ammoType..' Casing~w~\nWorking...', {255,255,255,240}, 0.2)
-							else
-								if exports["fsn_police"]:fsn_PDDuty() then
-									Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~'..e.details.ammoType..' Casing~w~\n[LALT+E] Collect', {255,255,255,100}, 0.2)
-									if IsControlPressed(0, 19) then
-										if IsControlJustPressed(0, 38) then
-											collecting = true
-											id = k
-											start = GetGameTimer()
-										end
-									end
-								else
-									Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~'..e.details.ammoType..' Casing~w~\n[LALT+E] Destroy', {255,255,255,100}, 0.2)
-									if IsControlPressed(0, 19) then
-										if IsControlJustPressed(0, 38) then
-											destroying = true
-											id = k
-											start = GetGameTimer()
-										end
-									end
-								end
-							end
-						end
-					end
-				end
-			end
-		end
-	end
+
+CreateThread(function()
+    while true do
+        Wait(0)
+        local ped = PlayerPedId()
+        local plyCoords = GetEntityCoords(ped)
+
+        if displaying then
+            if displaying.e_type == 'blood' then
+                Util.DrawText3D(displaying.loc.x, displaying.loc.y, displaying.loc.z,
+                    ('~r~Blood~w~\nDNA MARKUP: %s\n\n[LALT+E] Close'):format(displaying.details.dnastring),
+                    {255,255,255,240}, 0.25)
+            elseif displaying.e_type == 'casing' then
+                Util.DrawText3D(displaying.loc.x, displaying.loc.y, displaying.loc.z,
+                    ('~r~%s Casing~w~\nMarking: %s\n\n[LALT+E] Close'):format(displaying.details.ammoType, displaying.details.serial),
+                    {255,255,255,240}, 0.25)
+            end
+            if IsControlPressed(0, 19) and IsControlJustPressed(0, 38) then
+                displaying = false
+            end
+        end
+
+        for k, e in ipairs(evidence) do
+            local dist = #(vector3(e.loc.x, e.loc.y, e.loc.z) - plyCoords)
+            if e.e_type == 'blood' and dist < 50.0 then
+                DrawMarker(25, e.loc.x, e.loc.y, e.loc.z - 0.95, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2, 0.2, 0.2, 255, 255, 255, 150, false, false, 2, false, 0, 0, false)
+                if dist < 0.5 then
+                    if not exports['fsn_ems']:isCrouching() then
+                        Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Crouch to interact', {255,255,255,50}, 0.2)
+                    else
+                        if collecting or destroying then
+                            Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Blood~w~\nWorking...', {255,255,255,240}, 0.2)
+                        else
+                            if exports['fsn_police']:fsn_PDDuty() then
+                                Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Blood\n[LALT+E] Collect', {255,255,255,100}, 0.2)
+                                if IsControlPressed(0, 19) and IsControlJustPressed(0, 38) then
+                                    collecting = true
+                                    actionId = k
+                                    actionStart = GetGameTimer()
+                                end
+                            else
+                                Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Blood~w~\n[LALT+E] Destroy', {255,255,255,100}, 0.2)
+                                if IsControlPressed(0, 19) and IsControlJustPressed(0, 38) then
+                                    destroying = true
+                                    actionId = k
+                                    actionStart = GetGameTimer()
+                                end
+                            end
+                        end
+                    end
+                end
+            elseif e.e_type == 'casing' and dist < 50.0 then
+                DrawMarker(25, e.loc.x, e.loc.y, e.loc.z - 0.95, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2, 0.2, 0.2, 255, 255, 255, 150, false, false, 2, false, 0, 0, false)
+                if dist < 0.5 then
+                    if not exports['fsn_ems']:isCrouching() then
+                        Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, '~r~Crouch to interact', {255,255,255,50}, 0.2)
+                    else
+                        if collecting or destroying then
+                            Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, ('~r~%s Casing~w~\nWorking...'):format(e.details.ammoType), {255,255,255,240}, 0.2)
+                        else
+                            if exports['fsn_police']:fsn_PDDuty() then
+                                Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, ('~r~%s Casing~w~\n[LALT+E] Collect'):format(e.details.ammoType), {255,255,255,100}, 0.2)
+                                if IsControlPressed(0, 19) and IsControlJustPressed(0, 38) then
+                                    collecting = true
+                                    actionId = k
+                                    actionStart = GetGameTimer()
+                                end
+                            else
+                                Util.DrawText3D(e.loc.x, e.loc.y, e.loc.z, ('~r~%s Casing~w~\n[LALT+E] Destroy'):format(e.details.ammoType), {255,255,255,100}, 0.2)
+                                if IsControlPressed(0, 19) and IsControlJustPressed(0, 38) then
+                                    destroying = true
+                                    actionId = k
+                                    actionStart = GetGameTimer()
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
 end)
 
 TriggerServerEvent('fsn_evidence:request')
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/fxmanifest.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/fxmanifest.lua
@@ -1,28 +1,36 @@
---[[/	:FSN:	\]]--
-fx_version 'adamant'
+--[[/   :FSN:   \]]--
+fx_version 'cerulean'
 game 'gta5'
 
-client_script '@fsn_main/cl_utils.lua'
-server_script '@fsn_main/sv_utils.lua'
-client_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@mysql-async/lib/MySQL.lua'
---[[/	:FSN:	\]]--
+lua54 'yes'
 
-client_script '__descriptions-male.lua'
-client_script '__descriptions-female.lua'
-client_script '__descriptions.lua'
+shared_scripts {
+    '@fsn_main/server_settings/sh_settings.lua'
+}
+
+client_scripts {
+    '@fsn_main/cl_utils.lua',
+    '__descriptions-male.lua',
+    '__descriptions-female.lua',
+    '__descriptions.lua',
+    'cl_evidence.lua',
+    'casings/cl_casings.lua',
+    -- 'bleeding/cl_bleeding.lua',
+    'ped/cl_ped.lua'
+}
+
+server_scripts {
+    '@fsn_main/sv_utils.lua',
+    '@mysql-async/lib/MySQL.lua',
+    'sv_evidence.lua',
+    'ped/sv_ped.lua'
+}
+
 exports({
-	'getSex',
-	'getJacket',
-	'getTop',
-	'getPants',
+        'getSex',
+        'getJacket',
+        'getTop',
+        'getPants'
 })
+--[[/   :FSN:   \]]--
 
-client_script 'cl_evidence.lua'
-server_script 'sv_evidence.lua'
-
-client_script 'casings/cl_casings.lua'
---client_script 'bleeding/cl_bleeding.lua'
-client_script 'ped/cl_ped.lua'
-server_script 'ped/sv_ped.lua'

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/ped/cl_ped.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/ped/cl_ped.lua
@@ -1,36 +1,32 @@
---GetWorldPositionOfEntityBone 
-local inspectSelf = true
-
 local pedState = {}
-function updateState()
-	if pedState[GetPlayerServerId(PlayerId())] and #pedState[GetPlayerServerId(PlayerId())] > 0 then
-		TriggerServerEvent('fsn_evidence:ped:update', pedState[GetPlayerServerId(PlayerId())])
-	end
+
+--[[
+    -- Type: Function
+    -- Name: updateState
+    -- Use: Syncs local ped state with the server
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+local function updateState()
+    local playerId = GetPlayerServerId(PlayerId())
+    if pedState[playerId] and next(pedState[playerId]) then
+        TriggerServerEvent('fsn_evidence:ped:update', pedState[playerId])
+    end
 end
-RegisterNetEvent('fsn_evidence:ped:update')
-AddEventHandler('fsn_evidence:ped:update', function(ply, tbl)
-	for k,v in pairs(tbl) do
-		local ass = tbl[k]['ttl'] * 1000
-		local tyme = GetGameTimer()+ass
-		tbl[k]['expire'] = tyme
-	end
-	pedState[ply] = tbl
+
+RegisterNetEvent('fsn_evidence:ped:update', function(ply, tbl)
+    for k, v in pairs(tbl) do
+        tbl[k].expire = GetGameTimer() + (v.ttl * 1000)
+    end
+    pedState[ply] = tbl
 end)
-RegisterNetEvent('fsn_evidence:ped:addState')
-AddEventHandler('fsn_evidence:ped:addState', function(state, bone, ttl)
-	print('addstate: '..state)
-	if not ttl then
-		ttl = 60
-	end
-	if not pedState[GetPlayerServerId(PlayerId())] then
-		pedState[GetPlayerServerId(PlayerId())] = {}
-	end
-	pedState[GetPlayerServerId(PlayerId())][#pedState[GetPlayerServerId(PlayerId())]+1] = {
-		state = state,
-		bone = bone,
-		ttl = ttl
-	}
-	updateState()
+
+RegisterNetEvent('fsn_evidence:ped:addState', function(state, bone, ttl)
+    ttl = ttl or 60
+    local playerId = GetPlayerServerId(PlayerId())
+    pedState[playerId] = pedState[playerId] or {}
+    table.insert(pedState[playerId], { state = state, bone = bone, ttl = ttl })
+    updateState()
 end)
 
 local BodyParts = {
@@ -50,71 +46,60 @@ local BodyParts = {
     ['RLEG'] = { label = 'Right Leg', causeLimp = true, isDamaged = false, severity = 0, index = 'BONETAG_R_CALF'},
     ['RFOOT'] = { label = 'Right Foot', causeLimp = true, isDamaged = false, severity = 0, index = 'BONETAG_R_FOOT' },
 }
-RegisterNetEvent('fsn_evidence:ped:updateDamage')
-AddEventHandler('fsn_evidence:ped:updateDamage', function(tbl)
-	print'igotupdate'
-	BodyParts = tbl
+
+RegisterNetEvent('fsn_evidence:ped:updateDamage', function(tbl)
+    BodyParts = tbl
 end)
 
-local opacity = 0
-local minus = false 
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
-		if minus then
-			opacity = opacity - 1
-			if opacity <= 0 then
-				minus = false
-			end
-		else
-			opacity = opacity + 1
-			if opacity >=255 then
-				minus = true
-			end
-		end
-		for ply, v in pairs(pedState) do
-			local ply = ply
-			for key, s in pairs(v) do
-				if s.expire then
-					if s.expire <= GetGameTimer() then
-						pedState[ply][key] = nil
-						if #pedState[ply] < 1 then pedState[ply] = nil end
-						if ply == GetPlayerServerId(PlayerId()) then
-							updateState()
-						end
-					else
-						local localPly = GetPlayerFromServerId(ply)
-						local ped = false
-						if localPly == -1 then
-							if ply == GetPlayerServerId(PlayerId()) then
-								ped = PlayerPedId()
-							end
-						else
-							ped = GetPlayerPed(localPly)
-						end
-						if ped and GetDistanceBetweenCoords(GetEntityCoords(ped), GetEntityCoords(PlayerPedId()), true) < 8 then
-							local loc = GetWorldPositionOfEntityBone(ped, GetEntityBoneIndexByName(ped, BodyParts[s.bone]['index']))
-							Util.DrawText3D(loc.x, loc.y, loc.z, s.state, {255,255,255,opacity}, 0.15)
-						end
-					end
-				end
-			end
-		end
-		if not IsPedInAnyVehicle(PlayerPedId()) then
-			for k, b in pairs(BodyParts) do
-				if b.isDamaged and b.index then
-					local loc = GetWorldPositionOfEntityBone(PlayerPedId(), GetEntityBoneIndexByName(PlayerPedId(), b.index))
-					--print(GetEntityBoneIndexByName(PlayerPedId(), b.index))
-					--print(tostring(loc))
-					local col = {255,255,255,255}
-					if b.severity <= 2 then
-						col = {255, 161, 54,opacity}
-					else
-						col = {255,0,0,opacity}
-					end
-					Util.DrawText3D(loc.x, loc.y, loc.z, b.label, col, 0.15)
-				end
-			end
-		end
-	end
+local opacity, decreasing = 0, false
+
+CreateThread(function()
+    while true do
+        Wait(0)
+        opacity = decreasing and opacity - 1 or opacity + 1
+        if opacity <= 0 then
+            decreasing = false
+        elseif opacity >= 255 then
+            decreasing = true
+        end
+
+        local selfId = GetPlayerServerId(PlayerId())
+        local selfPed = PlayerPedId()
+        local selfCoords = GetEntityCoords(selfPed)
+
+        for plyId, states in pairs(pedState) do
+            for key, s in pairs(states) do
+                if s.expire and s.expire <= GetGameTimer() then
+                    pedState[plyId][key] = nil
+                    if not next(pedState[plyId]) then pedState[plyId] = nil end
+                    if plyId == selfId then
+                        updateState()
+                    end
+                else
+                    local targetPlayer = GetPlayerFromServerId(plyId)
+                    local ped = (targetPlayer ~= -1) and GetPlayerPed(targetPlayer) or (plyId == selfId and selfPed)
+                    if ped and #(GetEntityCoords(ped) - selfCoords) < 8.0 then
+                        local loc = GetWorldPositionOfEntityBone(ped, GetEntityBoneIndexByName(ped, BodyParts[s.bone].index))
+                        Util.DrawText3D(loc.x, loc.y, loc.z, s.state, {255,255,255,opacity}, 0.15)
+                    end
+                end
+            end
+        end
+
+        if not IsPedInAnyVehicle(selfPed) then
+            for _, b in pairs(BodyParts) do
+                if b.isDamaged and b.index then
+                    local loc = GetWorldPositionOfEntityBone(selfPed, GetEntityBoneIndexByName(selfPed, b.index))
+                    local col = {255,255,255,255}
+                    if b.severity <= 2 then
+                        col = {255,161,54,opacity}
+                    else
+                        col = {255,0,0,opacity}
+                    end
+                    Util.DrawText3D(loc.x, loc.y, loc.z, b.label, col, 0.15)
+                end
+            end
+        end
+    end
 end)
---TriggerEvent('fsn_evidence:ped:addState', 'SMELLS OF WEED', 'HEAD')
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/ped/sv_ped.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/ped/sv_ped.lua
@@ -1,10 +1,14 @@
 local pedStates = {}
 
-RegisterServerEvent('fsn_evidence:ped:update')
-AddEventHandler('fsn_evidence:ped:update', function(tbl)
-	if not pedStates[source] then
-		pedStates[source] = {}
-	end
-	pedStates[source] = tbl
-	TriggerClientEvent('fsn_evidence:ped:update', -1, source, pedStates[source])
+--[[
+    -- Type: Event Handler
+    -- Name: fsn_evidence:ped:update
+    -- Use: Receives ped state updates from client and broadcasts to others
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_evidence:ped:update', function(tbl)
+    pedStates[source] = tbl or {}
+    TriggerClientEvent('fsn_evidence:ped:update', -1, source, pedStates[source])
 end)
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/sv_evidence.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/sv_evidence.lua
@@ -1,76 +1,88 @@
 local evidence = {}
 
-RegisterServerEvent('fsn_evidence:request')
-AddEventHandler('fsn_evidence:request', function()
-	TriggerClientEvent('fsn_evidence:receive', source, evidence)
+--[[
+    -- Type: Event Handler
+    -- Name: fsn_evidence:request
+    -- Use: Sends current evidence table to requesting client
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_evidence:request', function()
+    TriggerClientEvent('fsn_evidence:receive', source, evidence)
 end)
 
-RegisterServerEvent('fsn_evidence:collect')
-AddEventHandler('fsn_evidence:collect', function(id)
-	local e = evidence[id]
-	if e then
-		TriggerClientEvent('fsn_evidence:display', source, e)
-		evidence[id] = nil
-	else
-		TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'This evidence has already gone.' })
-	end
-	TriggerClientEvent('fsn_evidence:receive', -1, evidence)
+--[[
+    -- Type: Event Handler
+    -- Name: fsn_evidence:collect
+    -- Use: Handles collection of evidence by police
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_evidence:collect', function(id)
+    local e = evidence[id]
+    if e then
+        TriggerClientEvent('fsn_evidence:display', source, e)
+        evidence[id] = nil
+    else
+        TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'This evidence has already gone.' })
+    end
+    TriggerClientEvent('fsn_evidence:receive', -1, evidence)
 end)
 
-RegisterServerEvent('fsn_evidence:destroy')
-AddEventHandler('fsn_evidence:destroy', function(id)
-	local e = evidence[id]
-	if e then
-		evidence[id] = nil
-		TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'success', text = 'You destroyed this evidence!' })
-	else
-		TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'This evidence has already gone.' })
-	end
-	TriggerClientEvent('fsn_evidence:receive', -1, evidence)
+--[[
+    -- Type: Event Handler
+    -- Name: fsn_evidence:destroy
+    -- Use: Handles destruction of evidence by civilians
+    -- Created: 2025-09-10
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_evidence:destroy', function(id)
+    local e = evidence[id]
+    if e then
+        evidence[id] = nil
+        TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'success', text = 'You destroyed this evidence!' })
+    else
+        TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'This evidence has already gone.' })
+    end
+    TriggerClientEvent('fsn_evidence:receive', -1, evidence)
 end)
 
 -- evidence dropping
-RegisterServerEvent('fsn_evidence:drop:casing')
-AddEventHandler('fsn_evidence:drop:casing', function(wep,loc)
-	--print('adding casing('..wep.ammoType..') for weapon '..wep.name..' at '..loc.x..','..loc.y..','..loc.z)
-	evidence[#evidence+1] = {
-		e_type = 'casing',
-		loc = loc,
-		details = {
-			ammoType = wep.ammotype,
-			serial = wep.Serial,
-			owner = wep.Owner
-		},
-		expire = os.time() + 300,
-	}
-	--print(wep.Serial)
-	--TriggerClientEvent('fsn_evidence:receive', -1, evidence)
+RegisterNetEvent('fsn_evidence:drop:casing', function(wep, loc)
+    evidence[#evidence + 1] = {
+        e_type = 'casing',
+        loc = loc,
+        details = {
+            ammoType = wep.ammoType,
+            serial = wep.Serial,
+            owner = wep.Owner
+        },
+        expire = os.time() + 300
+    }
+    TriggerClientEvent('fsn_evidence:receive', -1, evidence)
 end)
 
-RegisterServerEvent('fsn_evidence:drop:blood')
-AddEventHandler('fsn_evidence:drop:blood', function(charid,loc)
-	--print('adding casing('..wep.ammoType..') for weapon '..wep.name..' at '..loc.x..','..loc.y..','..loc.z)
-	evidence[#evidence+1] = {
-		e_type = 'blood',
-		loc = loc,
-		details = {
-			dnastring = charid
-		},
-		expire = os.time() + 300,
-	}
-	--TriggerClientEvent('fsn_evidence:receive', -1, evidence)
+RegisterNetEvent('fsn_evidence:drop:blood', function(charid, loc)
+    evidence[#evidence + 1] = {
+        e_type = 'blood',
+        loc = loc,
+        details = { dnastring = charid },
+        expire = os.time() + 300
+    }
+    TriggerClientEvent('fsn_evidence:receive', -1, evidence)
 end)
 
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(1000)
-		if #evidence > 1 then
-			for k, e in pairs(evidence) do
-				if e.expire <= os.time() then
-					print(k..' has expired')
-					evidence[k] = nil
-				end
-			end
-			TriggerClientEvent('fsn_evidence:receive', -1, evidence)
-		end
-	end
+CreateThread(function()
+    while true do
+        Wait(1000)
+        if next(evidence) then
+            for k, e in pairs(evidence) do
+                if e.expire <= os.time() then
+                    evidence[k] = nil
+                end
+            end
+            TriggerClientEvent('fsn_evidence:receive', -1, evidence)
+        end
+    end
 end)
+


### PR DESCRIPTION
## Summary
- modernize manifest with cerulean fx version and Lua 5.4
- refactor client/server evidence handling and ped state management
- clean up casing tracking and clothing description helpers

## Testing
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `apt-get install -y lua5.4 >/tmp/apt-install.log && tail -n 20 /tmp/apt-install.log`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/__descriptions.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/cl_evidence.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/sv_evidence.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/ped/cl_ped.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/ped/sv_ped.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_evidence/casings/cl_casings.lua`

------
https://chatgpt.com/codex/tasks/task_e_68c203d5bcb0832db752d7c4aff0f781