### PR TITLE
Refactor FSN inventory manifest and event handling

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory/cl_inventory.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory/cl_inventory.lua
@@ -67,8 +67,7 @@ function fsn_CurrentWeight()
 			end
 		end
 	end
-	print('currently carrying '..weight)
-	return weight
+        return weight
 end
 function fsn_HasItem(item)	
 	for k,v in pairs(firstInventory) do
@@ -140,12 +139,13 @@ RegisterNUICallback( "viewData", function(data, cb)
 			end
 		end
 	end
-	SendNUIMessage({
-		action = 'data',
-		index = index,
-		name = name,
-		html = strang
-	})
+        SendNUIMessage({
+                action = 'data',
+                index = index,
+                name = name,
+                html = strang
+        })
+        cb('ok')
 end)
 
 --[[
@@ -173,24 +173,21 @@ function setItemOwner(shoptype , item)
 end
 
 function setItemPolice(armoryid , item)
-	if item.customData ~= nil then
-		print(item.customData.ammotype)
-		print(item.index)
-		if item.index == 'WEAPON_STUNGUN' or item.customData.ammotype ~= 'none' then
-			item.customData.PDIssued = Util.MakeString(6)
-			item.customData.Owner = 'Police: '..name
-		end
-	end
+        if item.customData ~= nil then
+                if item.index == 'WEAPON_STUNGUN' or item.customData.ammotype ~= 'none' then
+                        item.customData.PDIssued = Util.MakeString(6)
+                        item.customData.Owner = 'Police: '..name
+                end
+        end
 end
 
 function fsn_setDevWeapon(item)
-	print(item)
-	if item.customData ~= nil then
-		if item.index == 'weapon_stungun' or item.customData.ammotype ~= 'none' then
-			item.customData.Serial = 'DEV GUN'
-			item.customData.Owner = 'DEV: ' .. name
-		end
-	end
+        if item.customData ~= nil then
+                if item.index == 'weapon_stungun' or item.customData.ammotype ~= 'none' then
+                        item.customData.Serial = 'DEV GUN'
+                        item.customData.Owner = 'DEV: ' .. name
+                end
+        end
 end
 
 --[[

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory/fxmanifest.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory/fxmanifest.lua
@@ -1,101 +1,66 @@
 --[[/ :FSN: \]]--
-fx_version 'adamant'
+fx_version 'cerulean'
 game 'gta5'
+lua54 'yes'
 
+-- Shared configuration
+shared_script '@fsn_main/server_settings/sh_settings.lua'
+
+-- Core scripts
 client_script '@fsn_main/cl_utils.lua'
 server_script '@fsn_main/sv_utils.lua'
-client_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@fsn_main/server_settings/sh_settings.lua'
 server_script '@mysql-async/lib/MySQL.lua'
 --[[/ :FSN: \]]--
 
-exports({
+exports {
   'fsn_HasItem',
   'fsn_GetItemAmount',
   'fsn_GetItemDetails',
   'fsn_CanCarry',
   'EnumerateObjects'
-})
+}
 
-server_exports({
+server_exports {
   'fsn_itemStock'
-})
+}
 
 -- Item scripts
-client_script '_item_misc/binoculars.lua'
-client_script '_item_misc/dm_laundering.lua'
-client_script '_item_misc/burger_store.lua'
-client_script '_item_misc/cl_breather.lua'
-
----------------------------------------------------- new script stuff below
-  client_script 'cl_presets.lua'
-  server_script 'sv_presets.lua'
-	client_script 'cl_uses.lua'
-	client_script 'cl_inventory.lua'
-	client_script 'pd_locker/cl_locker.lua'
-	--client_script 'cl_dropping.lua'
-	client_script 'cl_vehicles.lua'
-	server_script 'sv_inventory.lua'
-	--server_script 'sv_dropping.lua'
-	server_script 'sv_vehicles.lua'
-	server_script 'pd_locker/sv_locker.lua'
--- new gui
-ui_page "html/ui.html"
-files {
-  "html/ui.html",
-  "html/css/ui.css",
-  "html/css/jquery-ui.css",
-  "html/js/inventory.js",
-  "html/js/config.js",
-  -- JS LOCALES
-  "html/locales/cs.js",
-  "html/locales/en.js",
-  "html/locales/fr.js",
-  -- IMAGES
-  "html/img/bullet.png",
-  -- ICONS
-  "html/img/items/*.png",
-  --[["html/img/items/2g_weed.png",
-  "html/img/items/acetone.png",
-  "html/img/items/bandage.png",
-  "html/img/items/beef_jerky.png",
-  "html/img/items/binoculars.png",
-  "html/img/items/burger.png",
-  "html/img/items/burger_bun.png",
-  "html/img/items/coffee.png",
-  "html/img/items/cooked_burger.png",
-  "html/img/items/cooked_meat.png",
-  "html/img/items/cupcake.png",
-  "html/img/items/dirty_money.png",
-  "html/img/items/drill.png",
-  "html/img/items/ecola.png",
-  "html/img/items/empty_canister.png",
-  "html/img/items/evidence.png",
-  "html/img/items/fries.png",
-  "html/img/items/frozen_burger.png",
-  "html/img/items/frozen_fries.png",
-  "html/img/items/gas_canister.png",
-  "html/img/items/joint.png",
-  "html/img/items/keycard.png",
-  "html/img/items/lockpick.png",
-  "html/img/items/meth_rocks.png",
-  "html/img/items/microwave_burrito.png",
-  "html/img/items/minced_meat.png",
-  "html/img/items/modified_drillbit.png",
-  "html/img/items/morphine.png",
-  "html/img/items/packaged_cocaine.png",
-  "html/img/items/painkillers.png",
-  "html/img/items/panini.png",
-  "html/img/items/pepsi.png",
-  "html/img/items/pepsi_max.png",
-  "html/img/items/phone.png",
-  "html/img/items/phosphorus.png",
-  "html/img/items/radio_receiver.png",
-  "html/img/items/repair_kit.png",
-  "html/img/items/uncooked_meat.png",
-  "html/img/items/vpn1.png",
-  "html/img/items/vpn2.png",
-  "html/img/items/water.png",
-  "html/img/items/zipties.png",
-  "html/img/items/tuner_chip.png",]]
+client_scripts {
+  '_item_misc/binoculars.lua',
+  '_item_misc/dm_laundering.lua',
+  '_item_misc/burger_store.lua',
+  '_item_misc/cl_breather.lua',
+  'cl_presets.lua',
+  'cl_uses.lua',
+  'cl_inventory.lua',
+  'pd_locker/cl_locker.lua',
+  --'cl_dropping.lua', -- legacy script disabled
+  'cl_vehicles.lua'
 }
+
+server_scripts {
+  'sv_presets.lua',
+  'sv_inventory.lua',
+  --'sv_dropping.lua', -- legacy script disabled
+  'sv_vehicles.lua',
+  'pd_locker/sv_locker.lua'
+}
+
+-- new gui
+ui_page 'html/ui.html'
+files {
+  'html/ui.html',
+  'html/css/ui.css',
+  'html/css/jquery-ui.css',
+  'html/js/inventory.js',
+  'html/js/config.js',
+  -- JS LOCALES
+  'html/locales/cs.js',
+  'html/locales/en.js',
+  'html/locales/fr.js',
+  -- IMAGES
+  'html/img/bullet.png',
+  -- ICONS
+  'html/img/items/*.png'
+}
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory/sv_inventory.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory/sv_inventory.lua
@@ -1,92 +1,73 @@
 function fsn_SplitString(inputstr, sep)
-    if sep == nil then
-        sep = "%s"
-    end
-    local t={} ; i=1
+    if not sep then sep = "%s" end
+    local t, i = {}, 1
     for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
         t[i] = str
         i = i + 1
     end
     return t
 end
+
 AddEventHandler('chatMessage', function(source, auth, msg)
-	local split = fsn_SplitString(string.lower(msg), ' ')
-	local origSplit = fsn_SplitString(msg, ' ')
-	--if split[1] == '/getinv' then
-	--	TriggerClientEvent('fsn_inventory:ply:request', tonumber(split[2]), source)
-	--end
-	if split[1] == '/inv' then
-		TriggerClientEvent('fsn_inventory:gui:display', source)
-	end
+    local split = fsn_SplitString(string.lower(msg), ' ')
+    if split[1] == '/inv' then
+        TriggerClientEvent('fsn_inventory:gui:display', source)
+    end
 end)
 
-
-RegisterServerEvent('fsn_inventory:sys:request')
-AddEventHandler('fsn_inventory:sys:request', function(to, from)
-	TriggerClientEvent('fsn_inventory:ply:request', to, from)
+RegisterNetEvent('fsn_inventory:sys:request', function(to, from)
+    TriggerClientEvent('fsn_inventory:ply:request', to, from)
 end)
 
-RegisterServerEvent('fsn_inventory:sys:send')
-AddEventHandler('fsn_inventory:sys:send', function(to, tbl)
-	print('got inventory from '..source..' for '..to)
-	TriggerClientEvent('fsn_inventory:ply:recieve', to, source, tbl)
+RegisterNetEvent('fsn_inventory:sys:send', function(to, tbl)
+    print(('got inventory from %s for %s'):format(source, to))
+    TriggerClientEvent('fsn_inventory:ply:recieve', to, source, tbl)
 end)
 
-RegisterServerEvent('fsn_inventory:ply:update')
-AddEventHandler('fsn_inventory:ply:update', function(to, tbl)
-	TriggerClientEvent('fsn_inventory:me:update', to, tbl)
+RegisterNetEvent('fsn_inventory:ply:update', function(to, tbl)
+    TriggerClientEvent('fsn_inventory:me:update', to, tbl)
 end)
 
-RegisterServerEvent('fsn_inventory:ply:finished')
-AddEventHandler('fsn_inventory:ply:finished', function(ply)
-	TriggerClientEvent('fsn_inventory:ply:done', ply)
+RegisterNetEvent('fsn_inventory:ply:finished', function(ply)
+    TriggerClientEvent('fsn_inventory:ply:done', ply)
 end)
 
-RegisterServerEvent('fsn_licenses:id:display')
-AddEventHandler('fsn_licenses:id:display', function(plytbl, name, job, dob, issue, id)
-	for _, ply in pairs(plytbl) do
-		TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6*-----------------------------------------------------------')
-		TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6| ID |^0 '..name..' | '..job..' | '..dob..'/dob | '..issue..'/issue')
-		if id then
-			TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6| ID |^0 CharID: '..id..' | ServerID: '..source)
-		else
-			TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6| ID |^0 ServerID: '..source)
-			TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6| ID |^0 This ID is invalid, get a new one from City Hall!')
-		end
-		TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6*-----------------------------------------------------------')
-	end
+RegisterNetEvent('fsn_licenses:id:display', function(plytbl, name, job, dob, issue, id)
+    for _, ply in pairs(plytbl) do
+        TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6*----------------------------------------------------------')
+        TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6| ID |^0 '..name..' | '..job..' | '..dob..'/dob | '..issue..'/issue')
+        if id then
+            TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6| ID |^0 CharID: '..id..' | ServerID: '..source)
+        else
+            TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6| ID |^0 ServerID: '..source)
+            TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6| ID |^0 This ID is invalid, get a new one from City Hall!')
+        end
+        TriggerClientEvent('chatMessage', ply, '', {0,0,0}, '^6*----------------------------------------------------------')
+    end
 end)
 
 local function fsn_setDevWeapon(user, item)
-	--print(item)
-	local name = ''
-	local charID = exports['fsn_main']:fsn_CharID(user)
-	local character = exports['fsn_main']:fsn_GetCharacterInfo(charID)
-	if item.customData ~= nil then
-		if item.index == 'weapon_stungun' or item.customData.ammotype ~= 'none' then
-			name = character.char_fname .. ' ' ..character.char_lname
-			item.customData.Serial = 'DEV GUN'
-			item.customData.Owner = 'DEV: ' .. name
-		end
-	end
+    local charID = exports['fsn_main']:fsn_CharID(user)
+    local character = exports['fsn_main']:fsn_GetCharacterInfo(charID)
+    if item.customData and (item.index == 'weapon_stungun' or item.customData.ammotype ~= 'none') then
+        local name = character.char_fname .. ' ' .. character.char_lname
+        item.customData.Serial = 'DEV GUN'
+        item.customData.Owner = 'DEV: ' .. name
+    end
 end
 
-RegisterServerEvent('fsn_inventory:item:add')
-AddEventHandler('fsn_inventory:item:add', function(source, item, amt)
-	local player = source
-	--print(player.. ' ' .. item .. ' ' .. amt)
-	if presetItems[item] then
-		local insert = presetItems[item]
-		insert.amt = amt
-		if insert.customData ~= nil then
-			if insert.customData.weapon == 'true' then
-				fsn_setDevWeapon(player, insert)
-				TriggerClientEvent('fsn_inventory:items:add', player, insert)
-			end
-		else
-			TriggerClientEvent('fsn_inventory:items:add', player, insert)
-		end
-	else
-		TriggerClientEvent('mythic_notify:SendAlert', player, { type = 'error', text = 'Item preset '..item..' seems to be missing' })
-	end
+RegisterNetEvent('fsn_inventory:item:add', function(item, amt)
+    local player = source
+    amt = tonumber(amt) or 1
+    if presetItems[item] then
+        local insert = presetItems[item]
+        insert.amt = amt
+        if insert.customData and insert.customData.weapon == 'true' then
+            fsn_setDevWeapon(player, insert)
+        end
+        TriggerClientEvent('fsn_inventory:items:add', player, insert)
+    else
+        TriggerClientEvent('mythic_notify:SendAlert', player, { type = 'error', text = ('Item preset %s seems to be missing'):format(item) })
+    end
 end)
+


### PR DESCRIPTION
## Summary
- Modernize `fxmanifest.lua` with cerulean fx_version, lua54, shared and grouped scripts
- Fix server item add event and clean up server-side inventory helpers
- Remove debug prints and ensure NUI callbacks respond correctly

## Testing
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_inventory/cl_inventory.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_inventory/sv_inventory.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c203ee79c8832dae464f406b36c21b