### PR TITLE
refactor: modernize inventory dropping

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/cl_dropping.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/cl_dropping.lua
@@ -1,43 +1,74 @@
+--[[
+    -- Type: Variable
+    -- Name: droppedItems
+    -- Use: Stores dropped items keyed by identifier
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
 local droppedItems = {}
 
-function PickupAnimation()
-	RequestAnimDict('pickup_object')
-	while not HasAnimDictLoaded('pickup_object') do
-		Citizen.Wait(5)
-		print 'loading anim'
-	end
-	TaskPlayAnim(PlayerPedId(), 'pickup_object', 'pickup_low', 8.0, 1.0, -1, 49, 1.0, 0, 0, 0)
-	Citizen.Wait(1000)
-	ClearPedTasks(PlayerPedId())
+--[[
+    -- Type: Function
+    -- Name: pickupAnimation
+    -- Use: Plays item pickup animation on the player
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+local function pickupAnimation()
+    RequestAnimDict('pickup_object')
+    while not HasAnimDictLoaded('pickup_object') do
+        Wait(5)
+    end
+    TaskPlayAnim(PlayerPedId(), 'pickup_object', 'pickup_low', 8.0, 1.0, -1, 49, 1.0, false, false, false)
+    Wait(1000)
+    ClearPedTasks(PlayerPedId())
 end
 
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
-		for i, d in pairs(droppedItems) do
-			if GetDistanceBetweenCoords(d.loc.x,d.loc.y,d.loc.z,GetEntityCoords(PlayerPedId()),false) < 10 then
-				DrawMarker(25,d.loc.x, d.loc.y, d.loc.z - 0.95, 0, 0, 0, 0, 0, 0, 0.5, 0.5, 0.5, 255, 255, 255, 150, 0, 0, 2, 0, 0, 0, 0)
-				if GetDistanceBetweenCoords(d.loc.x,d.loc.y,d.loc.z,GetEntityCoords(PlayerPedId()),true) < 2 then
-					Util.DrawText3D(d.loc.x,d.loc.y,d.loc.z, '[ALT+E] Pickup~y~\n'..d.item.name, {255,255,255,200}, 0.25)
-					if IsControlPressed(0, 19) then
-						if IsControlJustPressed(0,38) then
-							if exports['fsn_inventory']:fsn_CanCarry(d.item.index, d.item.amt) then
-								TriggerServerEvent('fsn_inventory:drops:collect', i)
-								PickupAnimation()
-							else
-								TriggerEvent('fsn_notify:displayNotification', 'You can not carry this item. (Max Weight Limit: 40)', 'centerLeft', 3000, 'error')
-							end	
-						end
-					end
-				end
-			end
-		end
-	end
+local ALT_KEY, E_KEY = 19, 38
+
+--[[
+    -- Type: Thread
+    -- Name: dropMonitor
+    -- Use: Draws markers and handles item pickup interactions
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+CreateThread(function()
+    while true do
+        Wait(0)
+        local ped = PlayerPedId()
+        local pCoords = GetEntityCoords(ped)
+        for id, drop in pairs(droppedItems) do
+            local dCoords = vector3(drop.loc.x, drop.loc.y, drop.loc.z)
+            local distance = #(pCoords - dCoords)
+            if distance < 10.0 then
+                DrawMarker(25, dCoords.x, dCoords.y, dCoords.z - 0.95, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 255, 255, 255, 150, false, false, 2, false, nil, nil, false)
+                if distance < 2.0 then
+                    Util.DrawText3D(dCoords.x, dCoords.y, dCoords.z, ('[ALT+E] Pickup~y~\n%s'):format(drop.item.name), {255,255,255,200}, 0.25)
+                    if IsControlPressed(0, ALT_KEY) and IsControlJustPressed(0, E_KEY) then
+                        if exports['fsn_inventory']:fsn_CanCarry(drop.item.index, drop.item.amt) then
+                            TriggerServerEvent('fsn_inventory:drops:collect', id)
+                            pickupAnimation()
+                        else
+                            TriggerEvent('fsn_notify:displayNotification', 'You can not carry this item. (Max Weight Limit: 40)', 'centerLeft', 3000, 'error')
+                        end
+                    end
+                end
+            end
+        end
+    end
 end)
 
-RegisterNetEvent('fsn_inventory:drops:send')
-AddEventHandler('fsn_inventory:drops:send', function(tbl)
-	print(':fsn_inventory_dropping: got update of '..#tbl..' items')
-	droppedItems = tbl
+--[[
+    -- Type: Event
+    -- Name: fsn_inventory:drops:send
+    -- Use: Receives updated drop data from server
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_inventory:drops:send', function(tbl)
+    print(('fsn_inventory_dropping: received %s items'):format(#tbl))
+    droppedItems = tbl
 end)
 
 TriggerServerEvent('fsn_inventory:drops:request')

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/fxmanifest.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/fxmanifest.lua
@@ -1,13 +1,18 @@
---[[/	:FSN:	\]]--
-fx_version 'adamant'
+--[[
+    -- Type: Manifest
+    -- Name: fxmanifest
+    -- Use: Registers inventory drop scripts
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+
+fx_version 'cerulean'
 game 'gta5'
+lua54 'yes'
 
 client_script '@fsn_main/cl_utils.lua'
 server_script '@fsn_main/sv_utils.lua'
-client_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@mysql-async/lib/MySQL.lua'
---[[/	:FSN:	\]]--
+shared_script '@fsn_main/server_settings/sh_settings.lua'
 
 client_script 'cl_dropping.lua'
 server_script 'sv_dropping.lua'

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/sv_dropping.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/sv_dropping.lua
@@ -1,55 +1,104 @@
+--[[
+    -- Type: Variable
+    -- Name: lock
+    -- Use: Prevents simultaneous access to the dropped item table
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
 local lock = false
+
+--[[
+    -- Type: Variable
+    -- Name: droppedItems
+    -- Use: Holds all dropped item data
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
 local droppedItems = {}
 
-RegisterNetEvent('fsn_inventory:drops:request')
-AddEventHandler('fsn_inventory:drops:request', function()
-	TriggerClientEvent('fsn_inventory:drops:send', source, droppedItems)
+--[[
+    -- Type: Function
+    -- Name: acquireLock
+    -- Use: Waits for table access with a five minute timeout
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+local function acquireLock()
+    local start = os.time()
+    while lock do
+        Wait(0)
+        if os.time() - start >= 300 then
+            return false
+        end
+    end
+    lock = true
+    return true
+end
+
+--[[
+    -- Type: Function
+    -- Name: releaseLock
+    -- Use: Releases the table access lock
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+local function releaseLock()
+    lock = false
+end
+
+--[[
+    -- Type: Event
+    -- Name: fsn_inventory:drops:request
+    -- Use: Sends all dropped items to the requesting client
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_inventory:drops:request', function()
+    TriggerClientEvent('fsn_inventory:drops:send', source, droppedItems)
 end)
 
-RegisterNetEvent('fsn_inventory:drops:collect')
-AddEventHandler('fsn_inventory:drops:collect', function(id)
-	local start = os.time()
-	while lock do
-		Citizen.Wait(1)
-		if os.time() >= start+300 then
-			TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'Inventory action timed out (5 minutes). Contact a member of staff!' })
-			print'tablelocktimeout'
-			break
-		end
-	end
-	if not lock then
-		lock = true
-		if droppedItems[id] then
-			TriggerClientEvent('fsn_inventory:items:add', source, droppedItems[id].item)
-			
-			droppedItems[id] = nil
-		else
-			TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'This item looks to be missing, did someone else pick it up?' })
-		end
-		TriggerClientEvent('fsn_inventory:drops:send', -1, droppedItems)
-		lock = false
-	else
-		print 'something broke the lock script'
-	end
+--[[
+    -- Type: Event
+    -- Name: fsn_inventory:drops:collect
+    -- Use: Handles a player picking up a dropped item
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_inventory:drops:collect', function(id)
+    local src = source
+    if not acquireLock() then
+        TriggerClientEvent('mythic_notify:client:SendAlert', src, { type = 'error', text = 'Inventory action timed out (5 minutes). Contact a member of staff!' })
+        return
+    end
+
+    local drop = droppedItems[id]
+    if drop then
+        TriggerClientEvent('fsn_inventory:items:add', src, drop.item)
+        droppedItems[id] = nil
+        TriggerClientEvent('fsn_inventory:drops:send', -1, droppedItems)
+    else
+        TriggerClientEvent('mythic_notify:client:SendAlert', src, { type = 'error', text = 'This item looks to be missing, did someone else pick it up?' })
+    end
+
+    releaseLock()
 end)
 
-RegisterNetEvent('fsn_inventory:drops:drop')
-AddEventHandler('fsn_inventory:drops:drop', function(xyz, it)
-	local start = os.time()
-	while lock do
-		Citizen.Wait(1)
-		if os.time() >= start+300 then
-			TriggerClientEvent('mythic_notify:client:SendAlert', source, { type = 'error', text = 'Inventory action timed out (5 minutes). Contact a member of staff!' })
-			print'tablelocktimeout'
-			break
-		end
-	end
-	if not lock then
-		droppedItems[#droppedItems+1] = {
-			loc = xyz,
-			item = it
-		}
-		--Citizen.Wait(500)
-		TriggerClientEvent('fsn_inventory:drops:send', -1, droppedItems)
-	end
+--[[
+    -- Type: Event
+    -- Name: fsn_inventory:drops:drop
+    -- Use: Registers a new item drop and notifies all clients
+    -- Created: 2024-09-17
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_inventory:drops:drop', function(coords, item)
+    local src = source
+    if not acquireLock() then
+        TriggerClientEvent('mythic_notify:client:SendAlert', src, { type = 'error', text = 'Inventory action timed out (5 minutes). Contact a member of staff!' })
+        return
+    end
+
+    droppedItems[#droppedItems + 1] = { loc = coords, item = item }
+    TriggerClientEvent('fsn_inventory:drops:send', -1, droppedItems)
+
+    releaseLock()
 end)


### PR DESCRIPTION
## Summary
- modernize manifest with Lua 5.4 and shared configuration
- refactor client drop handling to use vectors and keyed controls
- add robust server-side locking for dropped item table

## Testing
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/fxmanifest.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/cl_dropping.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_inventory_dropping/sv_dropping.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c203fed9b4832d93dc74f766ad14f2