### PR TITLE
refactor: modernize fsn_licenses

### DIFF
--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/cl_desk.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/cl_desk.lua
@@ -1,29 +1,56 @@
-local id_spot = {x = -551.44750976563, y = -190.33755493164, z = 38.219680786133}
-local dl_spot = {x = -553.81396484375, y = -191.76734924316, z = 38.219673156738}
+local id_spot = vector3(-551.4475, -190.3376, 38.21968)
+local dl_spot = vector3(-553.8140, -191.7673, 38.21967)
 
 local myChar = {}
+
+--[[
+    -- Type: Event
+    -- Name: fsn_main:character
+    -- Use: Stores character data for ID requests
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 AddEventHandler('fsn_main:character', function(tbl)
-	myChar = tbl
-end)
-Citizen.CreateThread(function()
-	while true do Citizen.Wait(0)
-		if GetDistanceBetweenCoords(-548.19848632813, -199.1042175293, 38.219657897949, GetEntityCoords(PlayerPedId()),true) < 50 then
-			DrawMarker(25,id_spot.x, id_spot.y, id_spot.z - 0.95, 0, 0, 0, 0, 0, 0, 1.0, 1.0, 1.0, 255, 255, 255, 150, 0, 0, 2, 0, 0, 0, 0)
-			DrawMarker(25,dl_spot.x, dl_spot.y, dl_spot.z - 0.95, 0, 0, 0, 0, 0, 0, 1.0, 1.0, 1.0, 255, 255, 255, 150, 0, 0, 2, 0, 0, 0, 0)
-			if GetDistanceBetweenCoords(dl_spot.x, dl_spot.y, dl_spot.z, GetEntityCoords(PlayerPedId()),true) < 0.5 then
-				Util.DrawText3D(dl_spot.x, dl_spot.y, dl_spot.z, '[E] Buy ~b~Drivers License~w~ ($500)\n~r~UNAVAILABLE', {255,255,255,200}, 0.25)
-			end
-			if GetDistanceBetweenCoords(id_spot.x, id_spot.y, id_spot.z, GetEntityCoords(PlayerPedId()),true) < 0.5 then
-				Util.DrawText3D(id_spot.x, id_spot.y, id_spot.z, '[E] Collect ~g~Citizen ID', {255,255,255,200}, 0.25)
-				if IsControlJustPressed(0,38) then
-					TriggerServerEvent('fsn_licenses:id:request', myChar)
-				end
-			end
-		end
-	end
+    myChar = tbl
 end)
 
+--[[
+    -- Type: Thread
+    -- Name: ID Desk Thread
+    -- Use: Handles ID collection interaction at the city hall desk
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+Citizen.CreateThread(function()
+    while true do
+        Citizen.Wait(0)
+        if #(GetEntityCoords(PlayerPedId()) - vector3(-548.1985, -199.1042, 38.21966)) < 50 then
+            DrawMarker(25, id_spot.x, id_spot.y, id_spot.z - 0.95, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 255, 255, 255, 150, false, false, 2, false, false, false, false)
+            DrawMarker(25, dl_spot.x, dl_spot.y, dl_spot.z - 0.95, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 255, 255, 255, 150, false, false, 2, false, false, false, false)
+
+            if #(GetEntityCoords(PlayerPedId()) - dl_spot) < 0.5 then
+                Util.DrawText3D(dl_spot.x, dl_spot.y, dl_spot.z, '[E] Buy ~b~Drivers License~w~ ($500)\n~r~UNAVAILABLE', {255,255,255,200}, 0.25)
+            end
+
+            if #(GetEntityCoords(PlayerPedId()) - id_spot) < 0.5 then
+                Util.DrawText3D(id_spot.x, id_spot.y, id_spot.z, '[E] Collect ~g~Citizen ID', {255,255,255,200}, 0.25)
+                if IsControlJustPressed(0, 38) then
+                    TriggerServerEvent('fsn_licenses:id:request', myChar)
+                end
+            end
+        end
+    end
+end)
+
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:giveID
+    -- Use: Requests an ID card from the server
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 RegisterNetEvent('fsn_licenses:giveID')
 AddEventHandler('fsn_licenses:giveID', function()
-	TriggerServerEvent('fsn_licenses:id:request', myChar)
+    TriggerServerEvent('fsn_licenses:id:request', myChar)
 end)
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/client.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/client.lua
@@ -1,205 +1,288 @@
 local licenses = {}
-local name = 'steve the mushroom'
+local name = ''
 local charid = 0
 
-AddEventHandler('fsn_main:character', function(char)
-  if char.char_licenses ~= '' then
-    licenses = json.decode(char.char_licenses)
-  else
-    licenses = {}
-  end
-  name = char.char_fname..' '..char.char_lname
-  charid = char.char_id
-  if licenses["driver"] then
-    TriggerServerEvent('fsn_licenses:check', 'driver', licenses['driver'].infractions, licenses['driver'].date, GetNetworkTime())
-  end
-end)
-
-function fsn_NearestPlayersC(x, y, z, radius)
-	local players = {}
-	for _, id in ipairs(GetActivePlayers()) do
-		local ppos = GetEntityCoords(GetPlayerPed(id))
-		if GetDistanceBetweenCoords(ppos.x, ppos.y, ppos.z, x, y, z) < radius then
-			table.insert(players, #players+1, GetPlayerServerId(id))
-		end
-	end
-  return players
+--[[
+    -- Type: Function
+    -- Name: saveLicenses
+    -- Use: Sends current license table to the server for persistence
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+local function saveLicenses()
+    TriggerServerEvent('fsn_licenses:save', charid, json.encode(licenses))
 end
 
-RegisterNetEvent('fsn_licenses:update')
-AddEventHandler('fsn_licenses:update', function(type, status)
+--[[
+    -- Type: Event
+    -- Name: fsn_main:character
+    -- Use: Initializes license data when a character loads
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+AddEventHandler('fsn_main:character', function(char)
+    if char.char_licenses ~= '' then
+        licenses = json.decode(char.char_licenses)
+    else
+        licenses = {}
+    end
 
-  TriggerEvent('fsn_notify:displayNotification', 'YOUR '..type..' LICENSE HAS BEEN '..status, 'centerLeft', 10000, 'alert')
-  licenses[type].status = status
-  TriggerServerEvent('fsn_licenses:update', charid, json.encode(licenses))
+    name = string.format('%s %s', char.char_fname, char.char_lname)
+    charid = char.char_id
+
+    if licenses["driver"] then
+        TriggerServerEvent('fsn_licenses:check', 'driver', licenses['driver'].infractions, licenses['driver'].date)
+    end
 end)
 
+--[[
+    -- Type: Function
+    -- Name: fsn_NearestPlayersC
+    -- Use: Returns server IDs for players within a radius
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+function fsn_NearestPlayersC(x, y, z, radius)
+    local players = {}
+    for _, id in ipairs(GetActivePlayers()) do
+        local ppos = GetEntityCoords(GetPlayerPed(id))
+        if #(ppos - vector3(x, y, z)) < radius then
+            table.insert(players, GetPlayerServerId(id))
+        end
+    end
+    return players
+end
+
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:updateStatus
+    -- Use: Updates local license status and informs the player
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_licenses:updateStatus')
+AddEventHandler('fsn_licenses:updateStatus', function(type, status)
+    TriggerEvent('fsn_notify:displayNotification', 'YOUR '..type..' LICENSE HAS BEEN '..status, 'centerLeft', 10000, 'alert')
+    if licenses[type] then
+        licenses[type].status = status
+        saveLicenses()
+    end
+end)
+
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:showid
+    -- Use: Displays ID information to nearby players
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 RegisterNetEvent('fsn_licenses:showid')
 AddEventHandler('fsn_licenses:showid', function()
-  local pos = GetEntityCoords(PlayerPedId())
-  TriggerServerEvent('fsn_licenses:chat', name, {
-    type = 'id',
-    charid = charid,
-    job = exports.fsn_jobs:fsn_GetJob(),
-  }, fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5))
+    local pos = GetEntityCoords(PlayerPedId())
+    TriggerServerEvent('fsn_licenses:chat', name, {
+        type = 'id',
+        charid = charid,
+        job = exports.fsn_jobs:fsn_GetJob()
+    }, fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5))
 end)
 
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:infraction
+    -- Use: Adds infraction points to a license
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 RegisterNetEvent('fsn_licenses:infraction')
 AddEventHandler('fsn_licenses:infraction', function(type, amt)
-  licenses[type].infractions = licenses[type].infractions + amt
-  TriggerServerEvent('fsn_licenses:update', charid, json.encode(licenses))
-  TriggerServerEvent('fsn_licenses:check', type, licenses[type].infractions, licenses[type].date, GetNetworkTime())
+    licenses[type].infractions = licenses[type].infractions + amt
+    saveLicenses()
+    TriggerServerEvent('fsn_licenses:check', type, licenses[type].infractions, licenses[type].date)
 end)
 
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:setinfractions
+    -- Use: Sets infraction points and adjusts status accordingly
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 RegisterNetEvent('fsn_licenses:setinfractions')
 AddEventHandler('fsn_licenses:setinfractions', function(type, amt)
-  if amt <= 15 then
-    licenses[type].status = 'ACTIVE'
-  else
-    licenses[type].status = 'SUSPENDED'
-  end
-  licenses[type].infractions = amt
-  TriggerServerEvent('fsn_licenses:update', charid, json.encode(licenses))
+    if amt <= 15 then
+        licenses[type].status = 'ACTIVE'
+    else
+        licenses[type].status = 'SUSPENDED'
+    end
+    licenses[type].infractions = amt
+    saveLicenses()
 end)
 
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:display
+    -- Use: Shares license data with nearby players
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 RegisterNetEvent('fsn_licenses:display')
-AddEventHandler('fsn_licenses:display', function(type)
-  local pos = GetEntityCoords(PlayerPedId())
-  if type == 'all' then
-    for k,v in pairs(licenses) do
-      if licenses["driver"] then
-        TriggerServerEvent('fsn_licenses:chat', name, licenses["driver"], fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5))
-      end
-      if licenses["pilot"] then
-        TriggerServerEvent('fsn_licenses:chat', name, licenses["pilot"], fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5))
-      end
-      if licenses["weapon"] then
-        TriggerServerEvent('fsn_licenses:chat', name, licenses["weapon"], fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5))
-      end
+AddEventHandler('fsn_licenses:display', function(requested)
+    local pos = GetEntityCoords(PlayerPedId())
+    local nearby = fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5)
+
+    if requested == 'all' then
+        for _, lic in pairs(licenses) do
+            TriggerServerEvent('fsn_licenses:chat', name, lic, nearby)
+        end
+        return
     end
-  elseif type == 'driver' then
-    if licenses["driver"] then
-      TriggerServerEvent('fsn_licenses:chat', name, licenses["driver"], fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5))
+
+    local lic = licenses[requested]
+    if lic then
+        TriggerServerEvent('fsn_licenses:chat', name, lic, nearby)
     else
-      TriggerEvent('fsn_notify:displayNotification', 'You do not have a drivers license.', 'centerLeft', 4000, 'error')
+        TriggerEvent('fsn_notify:displayNotification', 'You do not have a '..requested..' license.', 'centerLeft', 4000, 'error')
     end
-  elseif type == 'pilot' then
-    if licenses["pilot"] then
-      TriggerServerEvent('fsn_licenses:chat', name, licenses["pilot"], fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5))
-    else
-      TriggerEvent('fsn_notify:displayNotification', 'You do not have a pilots license.', 'centerLeft', 4000, 'error')
-    end
-  elseif type == 'weapon' then
-    if licenses["weapon"] then
-      TriggerServerEvent('fsn_licenses:chat', name, licenses["weapon"], fsn_NearestPlayersC(pos.x, pos.y, pos.z, 5))
-    else
-      TriggerEvent('fsn_notify:displayNotification', 'You do not have a weapons license.', 'centerLeft', 4000, 'error')
-    end
-  end
 end)
 
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:police:give
+    -- Use: Issues a new license to the player
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 RegisterNetEvent('fsn_licenses:police:give')
 AddEventHandler('fsn_licenses:police:give', function(type)
-  licenses[type] = {}
-  licenses[type].date = GetNetworkTime()
-  licenses[type].type = type
-  licenses[type].infractions = 0
-  licenses[type].status = 'ACTIVE'
-  TriggerServerEvent('fsn_licenses:update', charid, json.encode(licenses))
+    licenses[type] = {
+        date = os.time(),
+        type = type,
+        infractions = 0,
+        status = 'ACTIVE'
+    }
+    saveLicenses()
 end)
 
+--[[
+    -- Type: Function
+    -- Name: fsn_hasLicense
+    -- Use: Exported helper to check license existence
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 function fsn_hasLicense(type)
-  print('checking license type: '..tostring(type))
-  if licenses[type] then
-    return true
-  else
-    return false
-  end
+    return licenses[type] ~= nil
 end
 
+--[[
+    -- Type: Function
+    -- Name: fsn_getLicensePoints
+    -- Use: Exported helper to return infraction points or 100 if missing
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 function fsn_getLicensePoints(type)
-	if licenses[type] then
-    return licenses[type].infractions
-  else
-    return 100
-  end
+    return licenses[type] and licenses[type].infractions or 100
 end
 
----------------------------------------------------------- BUY PLACE
+--[[
+    -- Type: Table
+    -- Name: license_stores
+    -- Use: Holds configuration for license purchase locations
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 local blip = {x = 237.59239196777, y = -406.15228271484, z = 47.924365997314}
 local license_stores = {
-  {
-    loc = {x = 233.22550964355, y = -410.34426879883, z = 48.11198425293},
-    store = 'driver',
-    cost = 500,
-    text = 'Press ~INPUT_PICKUP~ to buy a drivers license (~g~$500~w~)'
-  },
-  {
-    loc = {x = 238.16859436035, y = -412.05615234375, z = 48.11194229126},
-    store = 'pilot',
-    cost = 75000,
-    text = 'Press ~INPUT_PICKUP~ to buy a pilots license (~g~$75,000~w~)'
-  },
+    {
+        loc = {x = 233.22550964355, y = -410.34426879883, z = 48.11198425293},
+        store = 'driver',
+        cost = 500,
+        text = 'Press ~INPUT_PICKUP~ to buy a drivers license (~g~$500~w~)'
+    },
+    {
+        loc = {x = 238.16859436035, y = -412.05615234375, z = 48.11194229126},
+        store = 'pilot',
+        cost = 75000,
+        text = 'Press ~INPUT_PICKUP~ to buy a pilots license (~g~$75,000~w~)'
+    }
 }
+
+--[[
+    -- Type: Function
+    -- Name: buyLicense
+    -- Use: Handles license purchase logic
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 local function buyLicense(index)
-  local store = license_stores[index]
-  if store.store == 'driver' then
-    if tonumber(exports.fsn_main:fsn_GetWallet()) >= store.cost then
-      if licenses['driver'] then
-        if licenses['driver'].status ~= 'EXPIRED' then
-          TriggerEvent('fsn_notify:displayNotification', 'Your current license cannot be replaced', 'centerLeft', 4000, 'error')
+    local store = license_stores[index]
+    if store.store == 'driver' then
+        if tonumber(exports.fsn_main:fsn_GetWallet()) >= store.cost then
+            if licenses['driver'] then
+                if licenses['driver'].status ~= 'EXPIRED' then
+                    TriggerEvent('fsn_notify:displayNotification', 'Your current license cannot be replaced', 'centerLeft', 4000, 'error')
+                else
+                    TriggerEvent('fsn_bank:change:walletMinus', 250)
+                    TriggerEvent('fsn_notify:displayNotification', 'You updated your current license for <span style="color:limegreen">$250', 'centerLeft', 6000, 'success')
+                    licenses['driver'].date = os.time()
+                    licenses['driver'].infractions = 0
+                    licenses['driver'].status = 'ACTIVE'
+                    saveLicenses()
+                end
+            else
+                licenses['driver'] = {
+                    date = os.time(),
+                    type = 'driver',
+                    infractions = 0,
+                    status = 'ACTIVE'
+                }
+                TriggerEvent('fsn_bank:change:walletMinus', 500)
+                TriggerEvent('fsn_notify:displayNotification', 'You bought a new license for <span style="color:limegreen">$500', 'centerLeft', 6000, 'success')
+                saveLicenses()
+            end
         else
-          TriggerEvent('fsn_bank:change:walletMinus', 250)
-          TriggerEvent('fsn_notify:displayNotification', 'You updated your current license for <span style="color:limegreen">$250', 'centerLeft', 6000, 'success')
-
-          licenses['driver'].date = GetNetworkTime()
-          licenses['driver'].infractions = 0
-          licenses['driver'].status = 'ACTIVE'
+            TriggerEvent('fsn_notify:displayNotification', 'You do not have enough cash.', 'centerLeft', 4000, 'error')
         end
-      else
-        licenses['driver'] = {}
-        licenses['driver'].date = GetNetworkTime()
-        licenses['driver'].type = 'driver'
-        licenses['driver'].infractions = 0
-        licenses['driver'].status = 'ACTIVE'
-
-        TriggerEvent('fsn_bank:change:walletMinus', 500)
-        TriggerEvent('fsn_notify:displayNotification', 'You bought a new license for <span style="color:limegreen">$500', 'centerLeft', 6000, 'success')
-
-        TriggerServerEvent('fsn_licenses:update', charid, json.encode(licenses))
-      end
-    else
-      TriggerEvent('fsn_notify:displayNotification', 'You do not have enough cash.', 'centerLeft', 4000, 'error')
+    elseif store.store == 'pilot' then
+        if tonumber(exports.fsn_main:fsn_GetWallet()) >= store.cost then
+            -- Pilot license purchase flow can be implemented here
+        else
+            TriggerEvent('fsn_notify:displayNotification', 'You do not have a enough cash.', 'centerLeft', 4000, 'error')
+        end
     end
-  elseif store.store == 'pilot' then
-    if tonumber(exports.fsn_main:fsn_GetWallet()) >= store.cost then
-
-    else
-      TriggerEvent('fsn_notify:displayNotification', 'You do not have a enough cash.', 'centerLeft', 4000, 'error')
-    end
-  end
 end
+
+--[[
+    -- Type: Thread
+    -- Name: License Center Thread
+    -- Use: Draws markers and handles interaction for license purchases
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
 Citizen.CreateThread(function()
-  local bleep = AddBlipForCoord(blip.x, blip.y, blip.z)
-  SetBlipSprite(bleep, 498)
-  SetBlipAsShortRange(bleep, true)
-  BeginTextCommandSetBlipName("STRING")
-  AddTextComponentString("License Center")
-  EndTextCommandSetBlipName(bleep)
-  while true do
-    Citizen.Wait(0)
-    for k, v in pairs(license_stores) do
-      if GetDistanceBetweenCoords(v.loc.x,v.loc.y,v.loc.z,GetEntityCoords(PlayerPedId()), true) < 10 then
-        DrawMarker(1,v.loc.x,v.loc.y,v.loc.z-1,0,0,0,0,0,0,1.001,1.0001,0.4001,0,155,255,175,0,0,0,0)
-        if GetDistanceBetweenCoords(v.loc.x,v.loc.y,v.loc.z,GetEntityCoords(PlayerPedId()), true) < 1 then
-          SetTextComponentFormat("STRING")
-          AddTextComponentString(v.text)
-          DisplayHelpTextFromStringLabel(0, 0, 1, -1)
-          if IsControlJustPressed(0,38) then
-            buyLicense(k)
-          end
+    local bleep = AddBlipForCoord(blip.x, blip.y, blip.z)
+    SetBlipSprite(bleep, 498)
+    SetBlipAsShortRange(bleep, true)
+    BeginTextCommandSetBlipName("STRING")
+    AddTextComponentString("License Center")
+    EndTextCommandSetBlipName(bleep)
+
+    while true do
+        Citizen.Wait(0)
+        for k, v in pairs(license_stores) do
+            if GetDistanceBetweenCoords(v.loc.x, v.loc.y, v.loc.z, GetEntityCoords(PlayerPedId()), true) < 10 then
+                DrawMarker(1, v.loc.x, v.loc.y, v.loc.z - 1, 0, 0, 0, 0, 0, 0, 1.001, 1.0001, 0.4001, 0, 155, 255, 175, 0, 0, 0, 0)
+                if GetDistanceBetweenCoords(v.loc.x, v.loc.y, v.loc.z, GetEntityCoords(PlayerPedId()), true) < 1 then
+                    SetTextComponentFormat("STRING")
+                    AddTextComponentString(v.text)
+                    DisplayHelpTextFromStringLabel(0, 0, 1, -1)
+                    if IsControlJustPressed(0, 38) then
+                        buyLicense(k)
+                    end
+                end
+            end
         end
-      end
     end
-  end
 end)
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/fxmanifest.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/fxmanifest.lua
@@ -1,21 +1,24 @@
---[[/	:FSN:	\]]--
-fx_version 'adamant'
+--[[/   :FSN:   \]]--
+fx_version 'cerulean'
 game 'gta5'
+lua54 'yes'
 
-client_script '@fsn_main/cl_utils.lua'
-server_script '@fsn_main/sv_utils.lua'
-client_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@fsn_main/server_settings/sh_settings.lua'
-server_script '@mysql-async/lib/MySQL.lua'
---[[/	:FSN:	\]]--
+shared_script '@fsn_main/server_settings/sh_settings.lua'
 
-client_script 'client.lua'
-client_script 'cl_desk.lua'
-server_script 'sv_desk.lua'
+client_scripts {
+  '@fsn_main/cl_utils.lua',
+  'client.lua',
+  'cl_desk.lua'
+}
 
-server_script 'server.lua'
+server_scripts {
+  '@fsn_main/sv_utils.lua',
+  '@mysql-async/lib/MySQL.lua',
+  'sv_desk.lua',
+  'server.lua'
+}
 
-exports({
+exports {
   'fsn_hasLicense',
   'fsn_getLicensePoints'
-})
+}

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/server.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/server.lua
@@ -1,29 +1,65 @@
-RegisterServerEvent('fsn_licenses:chat')
+local LICENSE_VALIDITY = 30 * 24 * 60 * 60 -- seconds
+local SUSPEND_THRESHOLD = 15
+
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:chat
+    -- Use: Broadcast license or ID details to specified players
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_licenses:chat')
 AddEventHandler('fsn_licenses:chat', function(name, license, players)
-  for k, v in pairs(players) do
-    if license.type == 'id' then
-      TriggerClientEvent('chatMessage', v, '', {255,255,255}, '^1ID^0 | '..name..' | '..license.job..' | Ticket# '..source..' | ID# '..license.charid)
-    else
-      TriggerClientEvent('chatMessage', v, '', {255,255,255}, '^1LICENSE^0 | '..name..' | T:'..license.type..' | I:'..license.infractions..' | S:'..license.status)
+    for _, pid in ipairs(players) do
+        local msg
+        if license.type == 'id' then
+            msg = ('^1ID^0 | %s | %s | Ticket# %s | ID# %s'):format(name, license.job, source, license.charid)
+        else
+            msg = ('^1LICENSE^0 | %s | T:%s | I:%s | S:%s'):format(name, license.type, license.infractions, license.status)
+        end
+        TriggerClientEvent('chatMessage', pid, '', {255, 255, 255}, msg)
     end
-  end
 end)
 
-RegisterServerEvent('fsn_licenses:check')
-AddEventHandler('fsn_licenses:check', function(type, infractions, date, time)
-  local date = date + 2592000
-  if date < time then
-    TriggerClientEvent('fsn_licenses:update', source, type, 'ACTIVE')
-  end
-  if infractions > 15 then
-    TriggerClientEvent('fsn_licenses:update', source, type, 'SUSPENDED')
-  end
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:check
+    -- Use: Validate license status based on infractions and expiry
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_licenses:check')
+AddEventHandler('fsn_licenses:check', function(licenseType, infractions, issueDate)
+    local status = 'ACTIVE'
+    local current = os.time()
+    if issueDate > 9999999999 then
+        issueDate = math.floor(issueDate / 1000)
+    end
+    local expiry = issueDate + LICENSE_VALIDITY
+
+    if current > expiry then
+        status = 'EXPIRED'
+    elseif infractions > SUSPEND_THRESHOLD then
+        status = 'SUSPENDED'
+    end
+
+    if status ~= 'ACTIVE' then
+        TriggerClientEvent('fsn_licenses:updateStatus', source, licenseType, status)
+    end
 end)
 
-RegisterServerEvent('fsn_licenses:update')
-AddEventHandler('fsn_licenses:update', function(charid, licenses_json)
-  MySQL.Async.execute('UPDATE `fsn_characters` SET `char_licenses` = @licenses WHERE `char_id` = @charid', {
-    ['@charid'] = charid,
-    ['@licenses'] = licenses_json
-  }, function() end)
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:save
+    -- Use: Persist license data for a character
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_licenses:save')
+AddEventHandler('fsn_licenses:save', function(charid, licenses_json)
+    MySQL.Async.execute('UPDATE `fsn_characters` SET `char_licenses` = @licenses WHERE `char_id` = @charid', {
+        ['@charid'] = charid,
+        ['@licenses'] = licenses_json
+    })
 end)
+

--- a/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/sv_desk.lua
+++ b/Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/sv_desk.lua
@@ -1,22 +1,30 @@
-RegisterServerEvent('fsn_licenses:id:request')
+--[[
+    -- Type: Event
+    -- Name: fsn_licenses:id:request
+    -- Use: Provides a player with an ID card item
+    -- Created: 2024-07-13
+    -- By: VSSVSSN
+--]]
+RegisterNetEvent('fsn_licenses:id:request')
 AddEventHandler('fsn_licenses:id:request', function(tbl)
-	local occu = 'Unemployed'
-	if tbl.char_police > 0 then
-		occu = 'Police'
-	end
-	if tbl.char_ems > 0 then
-		occu = 'EMS'
-	end
-	TriggerClientEvent('fsn_inventory:items:add', source, {
-		index="id",
-		name='ID Card ('..tbl.char_fname..' '..tbl.char_lname..')',
-		amt=1,
-		customData = {
-			Name = tbl.char_fname..' '..tbl.char_lname,
-			Occupation = occu,
-			DOB = tbl.char_dob,
-			Issue = os.date("%x"),
-			CharID = tbl.char_id
-		},
-	})
+    local occu = 'Unemployed'
+    if tbl.char_police > 0 then
+        occu = 'Police'
+    elseif tbl.char_ems > 0 then
+        occu = 'EMS'
+    end
+
+    TriggerClientEvent('fsn_inventory:items:add', source, {
+        index = "id",
+        name = ('ID Card ('..tbl.char_fname..' '..tbl.char_lname..')'),
+        amt = 1,
+        customData = {
+            Name = tbl.char_fname..' '..tbl.char_lname,
+            Occupation = occu,
+            DOB = tbl.char_dob,
+            Issue = os.date('%Y-%m-%d'),
+            CharID = tbl.char_id
+        }
+    })
 end)
+


### PR DESCRIPTION
## Summary
- upgrade FSN license resource to cerulean/lua54 manifest with explicit script sections
- refactor server-side license checks and persistence using epoch timestamps
- streamline client license handling and ID desk interactions with documented functions

## Testing
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/client.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/cl_desk.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/server.lua`
- `luac -p Example_Frameworks/FiveM-FSN-Framework/fsn_licenses/sv_desk.lua`


------
https://chatgpt.com/codex/tasks/task_e_68c2041f4bdc832db140ba8146249d71